### PR TITLE
ignore errors from flake8-modern-annotations

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,6 +59,7 @@ statistics = true
 count = true
 enable-extensions = ["TC", "TC1"]
 extend-ignore = [
+  "MDA",  # REPO-SPECIFIC CONFIG
   "E203",
   "I100",
   "I101",


### PR DESCRIPTION
will be necessary after https://github.com/Infleqtion/client-superstaq/pull/858 (at least until annotations in this repo are updated as well)