### PR TITLE
Add distance calculation for classical codes with non-binary fields

### DIFF
--- a/qldpc/codes.py
+++ b/qldpc/codes.py
@@ -142,7 +142,7 @@ class ClassicalCode(AbstractCode):
         """
         return self.matrix.null_space()
 
-    def words(self) -> list[galois.FieldArray]:
+    def words(self) -> galois.FieldArray:
         """Code words of this code."""
         vectors = itertools.product(self.field.elements, repeat=self.generator.shape[0])
         return self.field(list(vectors)) @ self.generator
@@ -209,9 +209,7 @@ class ClassicalCode(AbstractCode):
     @functools.cache
     def get_distance(self) -> int:
         """The distance of this code."""
-        if self._field_order == 2:
-            return ldpc.code_util.compute_code_distance(self._matrix)
-        return np.min(self.words().astype(bool).sum(axis=1))
+        return np.min(np.count_nonzero(np.array(self.words())[1:, :], axis=1))
 
     def get_code_params(self) -> tuple[int, int, int]:
         """Compute the parameters of this code: [n,k,d].

--- a/qldpc/codes.py
+++ b/qldpc/codes.py
@@ -206,13 +206,12 @@ class ClassicalCode(AbstractCode):
         """The number of logical bits encoded by this code."""
         return self.num_bits - self.rank
 
-    # TODO: compute distance for fields > 2
     @functools.cache
     def get_distance(self) -> int:
         """The distance of this code."""
         if self._field_order == 2:
             return ldpc.code_util.compute_code_distance(self._matrix)
-        raise ValueError("Code distance not implemented for field orders greater than 2")
+        return np.min(self.words().astype(bool).sum(axis=1))
 
     def get_code_params(self) -> tuple[int, int, int]:
         """Compute the parameters of this code: [n,k,d].

--- a/qldpc/codes.py
+++ b/qldpc/codes.py
@@ -210,7 +210,7 @@ class ClassicalCode(AbstractCode):
 
     @functools.cache
     def get_distance(self) -> int:
-        """The distance of this code."""
+        """The distance of this code, or equivalently the minimal weight of a nonzero code word."""
         words = self.words().view(np.ndarray)
         return np.min(np.count_nonzero(words[1:], axis=1))
 

--- a/qldpc/codes.py
+++ b/qldpc/codes.py
@@ -24,7 +24,6 @@ from typing import Literal
 
 import cachetools
 import galois
-import ldpc.code_util
 import ldpc.codes
 import ldpc.mod2
 import networkx as nx

--- a/qldpc/codes.py
+++ b/qldpc/codes.py
@@ -211,7 +211,8 @@ class ClassicalCode(AbstractCode):
     @functools.cache
     def get_distance(self) -> int:
         """The distance of this code."""
-        return np.min(np.count_nonzero(np.array(self.words())[1:, :], axis=1))
+        words = self.words().view(np.ndarray)
+        return np.min(np.count_nonzero(words[1:], axis=1))
 
     def get_code_params(self) -> tuple[int, int, int]:
         """Compute the parameters of this code: [n,k,d].

--- a/qldpc/codes_test.py
+++ b/qldpc/codes_test.py
@@ -58,8 +58,7 @@ def test_tensor_product(
     code_a = codes.ClassicalCode.random(*bits_checks_a)
     code_b = codes.ClassicalCode.random(*bits_checks_b)
     code_ab = codes.ClassicalCode.tensor_product(code_a, code_b)
-    basis = code_ab.generator
-    basis.shape = (-1, code_a.num_bits, code_b.num_bits)
+    basis = np.reshape(code_ab.generator, (-1, code_a.num_bits, code_b.num_bits))
     assert all(not (code_a.matrix @ word @ code_b.matrix.T).any() for word in basis)
 
     n_a, k_a, d_a = code_a.get_code_params()

--- a/qldpc/codes_test.py
+++ b/qldpc/codes_test.py
@@ -27,7 +27,10 @@ def test_bit_codes() -> None:
     assert codes.ClassicalCode.hamming(3).get_distance() == 3
 
     num_bits = 5
-    for code in [codes.ClassicalCode.repetition(num_bits), codes.ClassicalCode.ring(num_bits)]:
+    for code in [
+        codes.ClassicalCode.repetition(num_bits, field=3),
+        codes.ClassicalCode.ring(num_bits, field=4),
+    ]:
         assert code.num_bits == num_bits
         assert code.dimension == 1
         assert code.get_distance() == num_bits
@@ -37,9 +40,6 @@ def test_bit_codes() -> None:
 
     with pytest.raises(ValueError, match="inconsistent"):
         codes.ClassicalCode(codes.ClassicalCode.random(2, 2, field=2), field=3)
-
-    with pytest.raises(ValueError, match="not implemented"):
-        codes.ClassicalCode.random(2, 2, 3).get_distance()
 
 
 def test_dual_code(bits: int = 5, checks: int = 3, field: int = 3) -> None:


### PR DESCRIPTION
This calculation is brute-force:
- generate all words in the code
- return the minimum weight (number of nonzero entries) of all nontrivial words