### PR TITLE
Generalize calculation of logical qubit operators to the qudit case

### DIFF
--- a/qldpc/codes.py
+++ b/qldpc/codes.py
@@ -699,11 +699,11 @@ class CSSCode(QuditCode):
                 # If any other candidate X-type operators anti-commute with op_z, it's because they
                 # have an op_x component.  Remove that component.  Likewise with Z-type candidates.
                 for xx, other_x in enumerate(candidates_x):
-                    if other_x @ op_z:
-                        candidates_x[xx] = other_x - op_x
+                    if exponent := other_x @ op_z:
+                        candidates_x[xx] = other_x - op_x / exponent
                 for zz, other_z in enumerate(candidates_z):
-                    if other_z @ op_x:
-                        candidates_z[zz] = other_z - op_z
+                    if exponent := other_z @ op_x:
+                        candidates_z[zz] = other_z - op_z / exponent
 
         self._logical_ops = self.field(np.stack([logicals_x, logicals_z]))
         return self._logical_ops

--- a/qldpc/codes.py
+++ b/qldpc/codes.py
@@ -668,6 +668,7 @@ class CSSCode(QuditCode):
         Logical operators are identified using the symplectic Gram-Schmidt orthogonalization
         procedure described in arXiv:0903.5256.
         """
+        # memoize manually because other methods may modify the logical operators computed here
         if self._logical_ops is not None:
             return self._logical_ops
 
@@ -686,7 +687,7 @@ class CSSCode(QuditCode):
 
             # check whether op_x anti-commutes with any of the candidate Z-type operators
             for zz, op_z in enumerate(candidates_z):
-                if op_x @ op_z:
+                if op_x @ op_z == 1:
                     # op_x and op_z anti-commute, so they are conjugate pair of logical operators!
                     found_logical_pair = True
                     logicals_x.append(op_x)
@@ -702,10 +703,10 @@ class CSSCode(QuditCode):
                 # If any other candidate X-type operators anti-commute with op_z, it's because they
                 # have an op_x component.  Remove that component.  Likewise with Z-type candidates.
                 for xx, other_x in enumerate(candidates_x):
-                    if other_x @ op_z:
+                    if other_x @ op_z == 1:
                         candidates_x[xx] = other_x - op_x
                 for zz, other_z in enumerate(candidates_z):
-                    if other_z @ op_x:
+                    if other_z @ op_x == 1:
                         candidates_z[zz] = other_z - op_z
 
         self._logical_ops = np.stack([logicals_x, logicals_z])

--- a/qldpc/codes.py
+++ b/qldpc/codes.py
@@ -651,7 +651,7 @@ class CSSCode(QuditCode):
             self._minimize_weight_of_logical_op(pauli, logical_qubit_index, **decoder_args)
 
         # return the minimum weight of logical X-type or Z-type operators
-        return self.get_logical_ops()[pauli.index].sum(-1).min()
+        return np.count_nonzero(self.get_logical_ops()[pauli.index].view(np.ndarray), axis=-1).min()
 
     def get_logical_ops(self) -> galois.FieldArray:
         """Complete basis of nontrivial X-type and Z-type logical operators for this code.

--- a/qldpc/codes.py
+++ b/qldpc/codes.py
@@ -640,7 +640,7 @@ class CSSCode(QuditCode):
         """Exact X-distance or Z-distance of this code."""
         assert pauli == Pauli.X or pauli == Pauli.Z
         pauli = pauli if not self._codes_equal else Pauli.X
-        if self._field_order != 2:
+        if self.field.degree > 1:
             code_x = self.code_x if pauli == Pauli.X else self.code_z
             code_z = self.code_z if pauli == Pauli.X else self.code_x
             dual_code_x = ~code_x
@@ -741,9 +741,8 @@ class CSSCode(QuditCode):
         assert pauli == Pauli.X or pauli == Pauli.Z
         assert 0 <= logical_qubit_index < self.dimension
         code = self.code_z if pauli == Pauli.X else self.code_x
-        matrix = code.matrix.view(np.ndarray)
         word = self.get_logical_ops()[(~pauli).index, logical_qubit_index].view(np.ndarray)
-        effective_check_matrix = np.vstack([matrix, word])
+        effective_check_matrix = np.vstack([code.matrix, word]).view(np.ndarray)
         effective_syndrome = np.zeros((code.num_checks + 1), dtype=int)
         effective_syndrome[-1] = 1
         logical_op = qldpc.decoder.decode(

--- a/qldpc/codes.py
+++ b/qldpc/codes.py
@@ -610,7 +610,6 @@ class CSSCode(QuditCode):
 
         # define code_z and pauli_z as if we are computing X-distance
         code_z = self.code_z if pauli == Pauli.X else self.code_x
-        matrix_z = code_z.matrix.view(np.ndarray)
         pauli_z: Literal[Pauli.Z, Pauli.X] = Pauli.Z if pauli == Pauli.X else Pauli.X
 
         # construct the effective syndrome
@@ -620,10 +619,10 @@ class CSSCode(QuditCode):
         logical_op_found = False
         while not logical_op_found:
             # support of pauli string with a trivial syndrome
-            word = self.get_random_logical_op(pauli_z).view(np.ndarray)
+            word = self.get_random_logical_op(pauli_z)
 
             # support of a candidate pauli-type logical operator
-            effective_check_matrix = np.vstack([matrix_z, word])
+            effective_check_matrix = np.vstack([code_z.matrix, word]).view(np.ndarray)
             candidate_logical_op = qldpc.decoder.decode(
                 effective_check_matrix, effective_syndrome, exact=False, **decoder_args
             )
@@ -743,7 +742,7 @@ class CSSCode(QuditCode):
         assert pauli == Pauli.X or pauli == Pauli.Z
         assert 0 <= logical_qubit_index < self.dimension
         code = self.code_z if pauli == Pauli.X else self.code_x
-        word = self.get_logical_ops()[(~pauli).index, logical_qubit_index].view(np.ndarray)
+        word = self.get_logical_ops()[(~pauli).index, logical_qubit_index]
         effective_check_matrix = np.vstack([code.matrix, word]).view(np.ndarray)
         effective_syndrome = np.zeros((code.num_checks + 1), dtype=int)
         effective_syndrome[-1] = 1

--- a/qldpc/codes.py
+++ b/qldpc/codes.py
@@ -427,7 +427,7 @@ class CSSCode(QuditCode):
     _field_order: int  # The order of the field over which the CSS code is defined
 
     _codes_equal: bool
-    _logical_ops: npt.NDArray[np.int_] | None = None
+    _logical_ops: galois.FieldArray | None = None
 
     def __init__(
         self,
@@ -653,7 +653,7 @@ class CSSCode(QuditCode):
         # return the minimum weight of logical X-type or Z-type operators
         return self.get_logical_ops()[pauli.index].sum(-1).min()
 
-    def get_logical_ops(self) -> npt.NDArray[np.int_]:
+    def get_logical_ops(self) -> galois.FieldArray:
         """Complete basis of nontrivial X-type and Z-type logical operators for this code.
 
         Logical operators are represented by a three-dimensional array `logical_ops` with dimensions
@@ -709,12 +709,12 @@ class CSSCode(QuditCode):
                     if other_z @ op_x == 1:
                         candidates_z[zz] = other_z - op_z
 
-        self._logical_ops = np.stack([logicals_x, logicals_z])
+        self._logical_ops = self.field(np.stack([logicals_x, logicals_z]))
         return self._logical_ops
 
     def get_random_logical_op(
         self, pauli: Literal[Pauli.X, Pauli.Z], ensure_nontrivial: bool = False
-    ) -> npt.NDArray[np.int_]:
+    ) -> galois.FieldArray:
         """Return a random logical operator of a given type.
 
         A random logical operator may be trivial, which is to say that it may be equal to the

--- a/qldpc/codes.py
+++ b/qldpc/codes.py
@@ -299,6 +299,9 @@ class QuditCode(AbstractCode):
     operators.  Specifically:
     - X(r) = sum_{j=0}^{d-1} |j+r><j| is a shift operator, and
     - Z(r) = sum_{j=0}^{d-1} w^{j r} |j><j| is a phase operator, with w = exp(2 pi i / d).
+
+    Warning: here j, r, s, etc. not integers, but elements of the Galois field GF(d), which may have
+    different rules for addition and multiplication.
     """
 
     @property

--- a/qldpc/codes.py
+++ b/qldpc/codes.py
@@ -701,10 +701,10 @@ class CSSCode(QuditCode):
                 # have an op_x component.  Remove that component.  Likewise with Z-type candidates.
                 for xx, other_x in enumerate(candidates_x):
                     if exponent := other_x @ op_z:
-                        candidates_x[xx] = other_x - op_x * exponent
+                        candidates_x[xx] = other_x - exponent * op_x
                 for zz, other_z in enumerate(candidates_z):
                     if exponent := other_z @ op_x:
-                        candidates_z[zz] = other_z - op_z * exponent
+                        candidates_z[zz] = other_z - exponent * op_z
 
         self._logical_ops = self.field(np.stack([logicals_x, logicals_z]))
         return self._logical_ops

--- a/qldpc/codes.py
+++ b/qldpc/codes.py
@@ -701,10 +701,10 @@ class CSSCode(QuditCode):
                 # have an op_x component.  Remove that component.  Likewise with Z-type candidates.
                 for xx, other_x in enumerate(candidates_x):
                     if exponent := other_x @ op_z:
-                        candidates_x[xx] = other_x / exponent - op_x
+                        candidates_x[xx] = other_x - op_x * exponent
                 for zz, other_z in enumerate(candidates_z):
                     if exponent := other_z @ op_x:
-                        candidates_z[zz] = other_z / exponent - op_z
+                        candidates_z[zz] = other_z - op_z * exponent
 
         self._logical_ops = self.field(np.stack([logicals_x, logicals_z]))
         return self._logical_ops

--- a/qldpc/codes.py
+++ b/qldpc/codes.py
@@ -638,8 +638,9 @@ class CSSCode(QuditCode):
         assert pauli == Pauli.X or pauli == Pauli.Z
         pauli = pauli if not self._codes_equal else Pauli.X
         if self.field.degree > 1:
-            # The base field is not prime, so we can't use the integer linear program method.
-            # Compute code distance with a brute-force search over all code words.
+            # The base field is not prime, so we can't use the integer linear program method due to
+            # different rules for addition and multiplication.  We therefore compute distance with a
+            # brute-force search over all code words.
             code_x = self.code_x if pauli == Pauli.X else self.code_z
             code_z = self.code_z if pauli == Pauli.X else self.code_x
             dual_code_x = ~code_x

--- a/qldpc/codes.py
+++ b/qldpc/codes.py
@@ -684,10 +684,11 @@ class CSSCode(QuditCode):
             # check whether op_x anti-commutes with any of the candidate Z-type operators
             for zz, op_z in enumerate(candidates_z):
                 if exponent := op_x @ op_z:
+                    op_z /= exponent
                     # op_x and op_z anti-commute, so they are conjugate pair of logical operators!
                     found_logical_pair = True
                     logicals_x.append(op_x)
-                    logicals_z.append(op_z / exponent)
+                    logicals_z.append(op_z)
                     del candidates_z[zz]
                     break
 
@@ -700,10 +701,10 @@ class CSSCode(QuditCode):
                 # have an op_x component.  Remove that component.  Likewise with Z-type candidates.
                 for xx, other_x in enumerate(candidates_x):
                     if exponent := other_x @ op_z:
-                        candidates_x[xx] = other_x - op_x / exponent
+                        candidates_x[xx] = other_x / exponent - op_x
                 for zz, other_z in enumerate(candidates_z):
                     if exponent := other_z @ op_x:
-                        candidates_z[zz] = other_z - op_z / exponent
+                        candidates_z[zz] = other_z / exponent - op_z
 
         self._logical_ops = self.field(np.stack([logicals_x, logicals_z]))
         return self._logical_ops

--- a/qldpc/codes.py
+++ b/qldpc/codes.py
@@ -289,7 +289,7 @@ class ClassicalCode(AbstractCode):
 #   - also compute and store sub-codes, if CSS
 #   - also add QuditCode.to_CSS() -> CSSCode
 class QuditCode(AbstractCode):
-    """Quantum stabilizer code for Galois qudits.
+    """Quantum stabilizer code for Galois qudits, with dimension q = p^m for prime p and integer m.
 
     The parity check matrix of a QuditCode has dimensions (num_checks, 2 * num_qudits), and can be
     written as a block matrix in the form H = [H_x|H_z].  Each block has num_qudits columns.
@@ -297,11 +297,13 @@ class QuditCode(AbstractCode):
     The entries H_x[c, d] = r_x and H_z[c, d] = r_z iff check c addresses qudit d with the operator
     X(r_x) * Z(r_z), where r_x, r_z range over the base field, and X(r), Z(r) are generalized Pauli
     operators.  Specifically:
-    - X(r) = sum_{j=0}^{d-1} |j+r><j| is a shift operator, and
-    - Z(r) = sum_{j=0}^{d-1} w^{j r} |j><j| is a phase operator, with w = exp(2 pi i / d).
+    - X(r) = sum_{j=0}^{q-1} |j+r><j| is a shift operator, and
+    - Z(r) = sum_{j=0}^{q-1} w^{j r} |j><j| is a phase operator, with w = exp(2 pi i / q).
 
-    Warning: here j, r, s, etc. not integers, but elements of the Galois field GF(d), which may have
-    different rules for addition and multiplication.
+    Warning: here j, r, s, etc. not integers, but elements of the Galois field GF(q), which has
+    different rules for addition and multiplication when q is not a prime number.
+
+    Helpful lecture by Gottesman: https://www.youtube.com/watch?v=JWg4zrNAF-g
     """
 
     @property

--- a/qldpc/codes.py
+++ b/qldpc/codes.py
@@ -697,11 +697,11 @@ class CSSCode(QuditCode):
                     del candidates_z[zz]
                     break
 
-            if len(logicals_x) == self.dimension:
-                # we have found all logical operators
-                break
-
             if found_logical_pair:
+                if len(logicals_x) == self.dimension:
+                    # we have found all logical operators
+                    break
+
                 # If any other candidate X-type operators anti-commute with op_z, it's because they
                 # have an op_x component.  Remove that component.  Likewise with Z-type candidates.
                 for xx, other_x in enumerate(candidates_x):

--- a/qldpc/codes.py
+++ b/qldpc/codes.py
@@ -687,7 +687,7 @@ class CSSCode(QuditCode):
             # check whether op_x anti-commutes with any of the candidate Z-type operators
             for zz, op_z in enumerate(candidates_z):
                 if exponent := op_x @ op_z:
-                    op_z /= exponent
+                    op_z /= exponent  # to ensure that op_x @ op_z == 1
                     # op_x and op_z anti-commute, so they are conjugate pair of logical operators!
                     found_logical_pair = True
                     logicals_x.append(op_x)

--- a/qldpc/codes.py
+++ b/qldpc/codes.py
@@ -748,7 +748,11 @@ class CSSCode(QuditCode):
         effective_syndrome = np.zeros((code.num_checks + 1), dtype=int)
         effective_syndrome[-1] = 1
         logical_op = qldpc.decoder.decode(
-            effective_check_matrix, effective_syndrome, exact=True, **decoder_args
+            effective_check_matrix,
+            effective_syndrome,
+            exact=True,
+            modulus=self.field.order,
+            **decoder_args,
         )
         assert self._logical_ops is not None
         self._logical_ops[pauli.index, logical_qubit_index] = logical_op

--- a/qldpc/codes.py
+++ b/qldpc/codes.py
@@ -683,11 +683,11 @@ class CSSCode(QuditCode):
 
             # check whether op_x anti-commutes with any of the candidate Z-type operators
             for zz, op_z in enumerate(candidates_z):
-                if op_x @ op_z == 1:
+                if exponent := op_x @ op_z:
                     # op_x and op_z anti-commute, so they are conjugate pair of logical operators!
                     found_logical_pair = True
                     logicals_x.append(op_x)
-                    logicals_z.append(op_z)
+                    logicals_z.append(op_z / exponent)
                     del candidates_z[zz]
                     break
 
@@ -699,10 +699,10 @@ class CSSCode(QuditCode):
                 # If any other candidate X-type operators anti-commute with op_z, it's because they
                 # have an op_x component.  Remove that component.  Likewise with Z-type candidates.
                 for xx, other_x in enumerate(candidates_x):
-                    if other_x @ op_z == 1:
+                    if other_x @ op_z:
                         candidates_x[xx] = other_x - op_x
                 for zz, other_z in enumerate(candidates_z):
-                    if other_z @ op_x == 1:
+                    if other_z @ op_x:
                         candidates_z[zz] = other_z - op_z
 
         self._logical_ops = self.field(np.stack([logicals_x, logicals_z]))

--- a/qldpc/codes.py
+++ b/qldpc/codes.py
@@ -641,6 +641,8 @@ class CSSCode(QuditCode):
         assert pauli == Pauli.X or pauli == Pauli.Z
         pauli = pauli if not self._codes_equal else Pauli.X
         if self.field.degree > 1:
+            # The base field is not prime, so we can't use the integer linear program method.
+            # Compute code distance with a brute-force search over all code words.
             code_x = self.code_x if pauli == Pauli.X else self.code_z
             code_z = self.code_z if pauli == Pauli.X else self.code_x
             dual_code_x = ~code_x

--- a/qldpc/codes.py
+++ b/qldpc/codes.py
@@ -655,7 +655,7 @@ class CSSCode(QuditCode):
         # return the minimum weight of logical X-type or Z-type operators
         return np.count_nonzero(self.get_logical_ops()[pauli.index].view(np.ndarray), axis=-1).min()
 
-    def get_logical_ops(self) -> galois.FieldArray:
+    def get_logical_ops(self) -> galois.FieldArray:  # noqa:C901 -- ignore flake8 complexity check
         """Complete basis of nontrivial X-type and Z-type logical operators for this code.
 
         Logical operators are represented by a three-dimensional array `logical_ops` with dimensions

--- a/qldpc/codes_test.py
+++ b/qldpc/codes_test.py
@@ -338,7 +338,7 @@ def test_qudit_distance() -> None:
     trit_code = codes.ClassicalCode.repetition(2, field=3)
     code = codes.HGPCode(trit_code)
 
-    assert code.get_distance(exact=True) == 2
+    assert code.get_distance() == 2
     with pytest.raises(ValueError, match="not implemented"):
         code.get_distance(upper=1)
     with pytest.raises(ValueError, match="Must choose"):

--- a/qldpc/codes_test.py
+++ b/qldpc/codes_test.py
@@ -102,9 +102,17 @@ def test_CSS_code() -> None:
         code_z = codes.ClassicalCode.random(3, 2, 3)
         codes.CSSCode(code_x, code_z)
 
-    code = codes.HGPCode(code_x)
-    code.get_random_logical_op(codes.Pauli.X, ensure_nontrivial=True)
+
+def test_logical_ops() -> None:
+    """Test logical operator construction."""
+    code = codes.HGPCode(codes.ClassicalCode.random(3, 2, field=3))
     code.get_random_logical_op(codes.Pauli.X, ensure_nontrivial=False)
+    code.get_random_logical_op(codes.Pauli.X, ensure_nontrivial=True)
+    ops = code.get_logical_ops()
+    for qudit in range(code.dimension):
+        op_x = ops[0, qudit, :]
+        op_z = ops[1, qudit, :]
+        assert op_x @ op_z == 1
 
 
 def test_deformations(num_qudits: int = 5, num_checks: int = 3) -> None:

--- a/qldpc/codes_test.py
+++ b/qldpc/codes_test.py
@@ -333,11 +333,10 @@ def test_toric_tanner_code() -> None:
         code = codes.QTCode(subset_a, subset_b, subcode_a, subcode_b)
 
 
-def test_qudit_distance() -> None:
+@pytest.mark.parametrize("field", [3, 4])
+def test_qudit_distance(field: int) -> None:
     """Distance calculations for qudits."""
-    trit_code = codes.ClassicalCode.repetition(2, field=3)
-    code = codes.HGPCode(trit_code)
-
+    code = codes.HGPCode(codes.ClassicalCode.repetition(2, field=field))
     assert code.get_distance() == 2
     with pytest.raises(ValueError, match="not implemented"):
         code.get_distance(upper=1)

--- a/qldpc/codes_test.py
+++ b/qldpc/codes_test.py
@@ -104,7 +104,7 @@ def test_CSS_code() -> None:
 
 
 def test_logical_ops() -> None:
-    """Test logical operator construction."""
+    """Logical operator construction."""
     code = codes.HGPCode(codes.ClassicalCode.random(3, 2, field=3))
     code.get_random_logical_op(codes.Pauli.X, ensure_nontrivial=False)
     code.get_random_logical_op(codes.Pauli.X, ensure_nontrivial=True)

--- a/qldpc/decoder.py
+++ b/qldpc/decoder.py
@@ -64,7 +64,7 @@ def decode_with_ILP(
         opt_variables = cvxpy.Variable(matrix.shape[1], integer=True)
     objective = cvxpy.Minimize(sum(iter(opt_variables)))
 
-    # collect constraints, using slack variables to relax each constraint of the form
+    # collect constraints, using boolean slack variables to relax each constraint of the form
     # `expression = val mod q` to `expression = val + sum_j q^j s_j`
     constraints = []
     matrix = matrix % modulus

--- a/qldpc/decoder.py
+++ b/qldpc/decoder.py
@@ -96,7 +96,7 @@ def decode_with_ILP(
         message = "Optimal solution to integer linear program could not be found!"
         raise ValueError(message + f"\nSolver output: {result}")
     solution = problem.variables()[0].value
-    return np.array(solution).astype(int)
+    return np.array(solution).astype(int) % modulus
 
 
 def decode(


### PR DESCRIPTION
More or less the same algorithm as before works, but now rather than looking for anti-commutation between X-type and Z-type logical operators, we look for the condition that `X(1)*Z(1) = w*Z(1)*X(1)`, where `w = exp(2 pi i / q)` for a `q`-dimensional qudit.

If we consider the generalized `n`-qudit Pauli strings `X(a)` and `Z(b)`, where now `a` and `b` are vectors in `F_q^n` and (say) `X(a) = \bigotimes_j X^{a_j}`, then the requirement `X(a)*Z(b) = w*Z(b)*X(a)` implies `a @ b = 1`.

Once we can construct logical operators, we can also compute exact code distance with an integer linear program (in the case of prime number fields).