### PR TITLE
Faster logical operator construction

### DIFF
--- a/qldpc/codes.py
+++ b/qldpc/codes.py
@@ -681,8 +681,8 @@ class CSSCode(QuditCode):
         procedure described in arXiv:0903.5256, slightly modified and generalized for qudits.
         """
         # memoize manually because other methods may modify the logical operators computed here
-        # if self._logical_ops is not None:
-        #     return self._logical_ops
+        if self._logical_ops is not None:
+            return self._logical_ops
 
         num_qudits = self.num_qudits
         dimension = self.dimension
@@ -769,8 +769,8 @@ class CSSCode(QuditCode):
         procedure described in arXiv:0903.5256, slightly modified and generalized for qudits.
         """
         # memoize manually because other methods may modify the logical operators computed here
-        # if self._logical_ops is not None:
-        #     return self._logical_ops
+        if self._logical_ops is not None:
+            return self._logical_ops
 
         # collect logical operators sequentially
         logicals_x: list[galois.FieldArray] = []

--- a/qldpc/codes.py
+++ b/qldpc/codes.py
@@ -730,7 +730,7 @@ class CSSCode(QuditCode):
         checks_z = np.hstack([checks_z[:, other_z], checks_z[:, pivot_z]])
         qubit_locs = np.hstack([qubit_locs[other_z], qubit_locs[pivot_z]])
 
-        # get the support of the check matrices on non-pivot qubits
+        # get the support of the check matrices on non-pivot qudits
         num_non_pivots = num_qudits - len(pivot_x) - len(pivot_z)
         non_pivot_x = checks_x[:, :num_non_pivots]
         non_pivot_z = checks_z[:, :num_non_pivots]
@@ -745,7 +745,7 @@ class CSSCode(QuditCode):
         logicals_z[:, -non_pivot_z.shape[0] :] = -non_pivot_z.T
         logicals_z[:dimension, :dimension] = identity
 
-        # move qubits back to their original locations
+        # move qudits back to their original locations
         _, permutation = zip(*sorted(zip(qubit_locs, range(num_qudits))))
         logicals_x = logicals_x[:, permutation]
         logicals_z = logicals_z[:, permutation]

--- a/qldpc/codes.py
+++ b/qldpc/codes.py
@@ -677,8 +677,8 @@ class CSSCode(QuditCode):
         by this method are the unit shift and phase operators that generate all logical X-type and
         Z-type qudit operators.
 
-        Logical operators are identified using the symplectic Gram-Schmidt orthogonalization
-        procedure described in arXiv:0903.5256, slightly modified and generalized for qudits.
+        Logical operators are constructed using the method described in Section 4.1 of Gottesman's
+        thesis (arXiv:9705052), slightly modified and generalized for qudits.
         """
         # memoize manually because other methods may modify the logical operators computed here
         if self._logical_ops is not None:

--- a/qldpc/codes_test.py
+++ b/qldpc/codes_test.py
@@ -110,17 +110,12 @@ def test_CSS_code() -> None:
 
 def test_logical_ops() -> None:
     """Logical operator construction."""
-    code = codes.HGPCode(codes.ClassicalCode.random(4, 2, field=2))
+    code = codes.HGPCode(codes.ClassicalCode.random(4, 2, field=3))
     code.get_random_logical_op(codes.Pauli.X, ensure_nontrivial=False)
     code.get_random_logical_op(codes.Pauli.X, ensure_nontrivial=True)
 
+    # test that logical operators are dual to each other and have trivial syndromes
     logicals = code.get_logical_ops()
-    logicals_x, logicals_z = logicals[0], logicals[1]
-    assert np.array_equal(logicals_x @ logicals_z.T, np.eye(code.dimension, dtype=int))
-    assert not np.any(code.code_z.matrix @ logicals_x.T)
-    assert not np.any(code.code_x.matrix @ logicals_z.T)
-
-    logicals = code.new_get_logical_ops()
     logicals_x, logicals_z = logicals[0], logicals[1]
     assert np.array_equal(logicals_x @ logicals_z.T, np.eye(code.dimension, dtype=int))
     assert not np.any(code.code_z.matrix @ logicals_x.T)

--- a/qldpc/codes_test.py
+++ b/qldpc/codes_test.py
@@ -110,13 +110,21 @@ def test_CSS_code() -> None:
 
 def test_logical_ops() -> None:
     """Logical operator construction."""
-    code = codes.HGPCode(codes.ClassicalCode.random(4, 2, field=3))
+    code = codes.HGPCode(codes.ClassicalCode.random(4, 2, field=2))
     code.get_random_logical_op(codes.Pauli.X, ensure_nontrivial=False)
     code.get_random_logical_op(codes.Pauli.X, ensure_nontrivial=True)
-    ops = code.get_logical_ops()
-    for qq in range(code.dimension):
-        for rr in range(qq + 1):
-            assert ops[0, qq, :] @ ops[1, rr, :] == int(qq == rr)
+
+    logicals = code.get_logical_ops()
+    logicals_x, logicals_z = logicals[0], logicals[1]
+    assert np.array_equal(logicals_x @ logicals_z.T, np.eye(code.dimension, dtype=int))
+    assert not np.any(code.code_z.matrix @ logicals_x.T)
+    assert not np.any(code.code_x.matrix @ logicals_z.T)
+
+    logicals = code.new_get_logical_ops()
+    logicals_x, logicals_z = logicals[0], logicals[1]
+    assert np.array_equal(logicals_x @ logicals_z.T, np.eye(code.dimension, dtype=int))
+    assert not np.any(code.code_z.matrix @ logicals_x.T)
+    assert not np.any(code.code_x.matrix @ logicals_z.T)
 
 
 def test_deformations(num_qudits: int = 5, num_checks: int = 3, field: int = 3) -> None:


### PR DESCRIPTION
Based on the construction in Section 4.1 of [Gottesman's thesis](https://arxiv.org/abs/quant-ph/9705052).

Some benchmarking (with memoization turned off):
```python
In [237]: code = codes.HGPCode(codes.ClassicalCode.random(30, 25))

In [238]: %timeit code.old_get_logical_ops()
4.11 s ± 353 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)

In [239]: %timeit code.new_get_logical_ops()
258 ms ± 39.1 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
```