### PR TITLE
Require that each file is covered by its own test file

### DIFF
--- a/checks/coverage_.py
+++ b/checks/coverage_.py
@@ -4,4 +4,25 @@ import sys
 import checks_superstaq
 
 if __name__ == "__main__":
-    exit(checks_superstaq.coverage_.run(*sys.argv[1:]))
+    if sys.argv[1:]:
+        # check coverage for the provided arguments
+        exit(checks_superstaq.coverage_.run(*sys.argv[1:]))
+
+    # Check that each file is covered by its own data file.
+    # Start by identifying files that should be covered.
+    tracked_files = checks_superstaq.check_utils.get_tracked_files("*.py")
+    coverage_files = checks_superstaq.check_utils.exclude_files(
+        tracked_files, ["checks/*", "*__init__.py", "*_test.py"]
+    )
+
+    # run checks on individual files
+    checks_passed = {}
+    for file in coverage_files:
+        checks_passed[file] = checks_superstaq.coverage_.run(file)
+
+    # print warnings for files that are not covered
+    for file, passed in checks_passed.items():
+        if not passed:
+            checks_superstaq.check_utils.warning(f"Coverage failed for {file}.")
+
+    exit(0 if all(checks_passed.values()) else 1)

--- a/checks/coverage_.py
+++ b/checks/coverage_.py
@@ -16,13 +16,13 @@ if __name__ == "__main__":
     )
 
     # run checks on individual files
-    checks_passed = {}
+    exit_codes = {}
     for file in coverage_files:
-        checks_passed[file] = checks_superstaq.coverage_.run(file)
+        exit_codes[file] = checks_superstaq.coverage_.run(file)
 
     # print warnings for files that are not covered
-    for file, passed in checks_passed.items():
-        if not passed:
+    for file, exit_code in exit_codes.items():
+        if exit_code:
             checks_superstaq.check_utils.warning(f"Coverage failed for {file}.")
 
-    exit(0 if all(checks_passed.values()) else 1)
+    exit(sum(exit_codes.values()))


### PR DESCRIPTION
This makes coverage more modular.

This requirement may be relaxed in the future, if it becomes a significant obstacle to development.  But I may as well enforce modular coverage while I can.