### PR TITLE
Add construction of Tanner codes with undirected subgraphs

### DIFF
--- a/qldpc/codes.py
+++ b/qldpc/codes.py
@@ -374,8 +374,9 @@ class ClassicalCode(AbstractCode):
         matrix, field = named_codes.get_code(standardized_name)
         return ClassicalCode(matrix, field)
 
-    # TODO(?): maybe add modification options
+    # TODO(?): maybe add modification options such as puncturing and shortening
     # https://users.math.msu.edu/users/halljo/classes/codenotes/mod.pdf
+    # https://journals.aps.org/prl/abstract/10.1103/PhysRevLett.122.230501
 
 
 class RepetitionCode(ClassicalCode):
@@ -1480,7 +1481,6 @@ class LPCode(CSSCode):
 # classical and quantum Tanner codes
 
 
-# TODO: add TannerCode construction based on undirected graphs
 class TannerCode(ClassicalCode):
     """Classical Tanner code, as described in DOI:10.1109/TIT.1981.1056404.
 
@@ -1508,8 +1508,11 @@ class TannerCode(ClassicalCode):
     subgraph: nx.DiGraph
     subcode: ClassicalCode
 
-    def __init__(self, subgraph: nx.DiGraph, subcode: ClassicalCode) -> None:
+    def __init__(self, subgraph: nx.Graph, subcode: ClassicalCode) -> None:
         """Construct a classical Tanner code."""
+        if not isinstance(subgraph, nx.DiGraph):
+            subgraph = TannerCode.to_directed(subgraph)
+
         self.subgraph = subgraph
         self.subcode = subcode
         sources = [node for node in subgraph if subgraph.in_degree(node) == 0]
@@ -1531,6 +1534,19 @@ class TannerCode(ClassicalCode):
             self.subgraph.neighbors(node),
             key=lambda neighbor: self.subgraph[node][neighbor].get("sort", neighbor),
         )
+
+    @classmethod
+    def to_directed(self, subgraph: nx.Graph) -> nx.DiGraph:
+        """Convert an undirected graph for a Tanner code into a directed graph for the same code."""
+        directed_subgraph = nx.DiGraph()
+        for node_a, node_b, edge_data in subgraph.edges(data=True):
+            edge = frozenset([node_a, node_b])
+            directed_subgraph.add_edge(node_a, edge)
+            directed_subgraph.add_edge(node_b, edge)
+            if (sort_data := edge_data.pop("sort", None)) is not None:
+                directed_subgraph[node_a][edge]["sort"] = sort_data[node_a]
+                directed_subgraph[node_b][edge]["sort"] = sort_data[node_b]
+        return directed_subgraph
 
 
 # TODO: investigate construction in

--- a/qldpc/codes.py
+++ b/qldpc/codes.py
@@ -1500,6 +1500,9 @@ class TannerCode(ClassicalCode):
     sorts E(v) by the value of the "sort" attribute attached to each edge.  If there is no "sort"
     attribute, its value is treated as corresponding neighbor of v.
 
+    Tanner codes can similarly be defined on regular (undirected) graphs G' = (V',E') by placing
+    checks on V' and bits on E'.
+
     Notes:
     - If the subcode C has m checks, its parity matrix has shape (m,n).
     - The code T(G,C) has |W| bits and |V|m checks.

--- a/qldpc/codes.py
+++ b/qldpc/codes.py
@@ -1511,7 +1511,7 @@ class TannerCode(ClassicalCode):
     def __init__(self, subgraph: nx.Graph, subcode: ClassicalCode) -> None:
         """Construct a classical Tanner code."""
         if not isinstance(subgraph, nx.DiGraph):
-            subgraph = TannerCode.to_directed(subgraph)
+            subgraph = TannerCode.as_directed_subgraph(subgraph)
 
         self.subgraph = subgraph
         self.subcode = subcode
@@ -1536,7 +1536,7 @@ class TannerCode(ClassicalCode):
         )
 
     @classmethod
-    def to_directed(self, subgraph: nx.Graph) -> nx.DiGraph:
+    def as_directed_subgraph(self, subgraph: nx.Graph) -> nx.DiGraph:
         """Convert an undirected graph for a Tanner code into a directed graph for the same code."""
         directed_subgraph = nx.DiGraph()
         for node_a, node_b, edge_data in subgraph.edges(data=True):

--- a/qldpc/codes_test.py
+++ b/qldpc/codes_test.py
@@ -344,26 +344,12 @@ def test_lifted_product_codes() -> None:
 
 
 def test_tanner_code() -> None:
-    """Classical Tanner code construction.
-
-    In order to construct a random Tanner code, we need to construct a random regular directed
-    bipartite graph.  To this end, we first construct a random regular graph G = (V,E), and then
-    build a directed bipartite graph G' with vertex sets (V,E).  The edges in G' have the form
-    (v, {v,w}), where v is in V and {v,w} is in E.
-    """
+    """Classical Tanner codes on random regular graphs."""
     subcode = codes.ClassicalCode.random(10, 5)
-    graph = nx.random_regular_graph(subcode.num_bits, subcode.num_bits * 2 + 2)
-    subgraph = nx.DiGraph()
-    for edge in graph.edges:
-        subgraph.add_edge(edge[0], edge)
-        subgraph.add_edge(edge[1], edge)
-    num_sources = sum(1 for node in subgraph if subgraph.in_degree(node) == 0)
-    num_sinks = subgraph.number_of_nodes() - num_sources
-
-    # build a classical Tanner code and check that it has the right number of checks/bits
+    subgraph = nx.random_regular_graph(subcode.num_bits, subcode.num_bits * 2 + 2)
     code = codes.TannerCode(subgraph, subcode)
-    assert code.num_bits == num_sinks
-    assert code.num_checks == num_sources * code.subcode.num_checks
+    assert code.num_bits == subgraph.number_of_edges()
+    assert code.num_checks == subgraph.number_of_nodes() * code.subcode.num_checks
 
 
 def test_toric_tanner_code(size: int = 4) -> None:

--- a/qldpc/codes_test.py
+++ b/qldpc/codes_test.py
@@ -347,9 +347,15 @@ def test_tanner_code() -> None:
     """Classical Tanner codes on random regular graphs."""
     subcode = codes.ClassicalCode.random(5, 3)
     subgraph = nx.random_regular_graph(subcode.num_bits, subcode.num_bits * 2 + 2)
+
+    tag = "sort_label"
+    for node_a, node_b in subgraph.edges:
+        subgraph[node_a][node_b]["sort"] = {node_a: tag, node_b: tag}
+
     code = codes.TannerCode(subgraph, subcode)
     assert code.num_bits == subgraph.number_of_edges()
     assert code.num_checks == subgraph.number_of_nodes() * code.subcode.num_checks
+    assert all(code.subgraph.get_edge_data(*edge)["sort"] == tag for edge in code.subgraph.edges)
 
 
 def test_toric_tanner_code(size: int = 4) -> None:

--- a/qldpc/codes_test.py
+++ b/qldpc/codes_test.py
@@ -345,7 +345,7 @@ def test_lifted_product_codes() -> None:
 
 def test_tanner_code() -> None:
     """Classical Tanner codes on random regular graphs."""
-    subcode = codes.ClassicalCode.random(10, 5)
+    subcode = codes.ClassicalCode.random(5, 3)
     subgraph = nx.random_regular_graph(subcode.num_bits, subcode.num_bits * 2 + 2)
     code = codes.TannerCode(subgraph, subcode)
     assert code.num_bits == subgraph.number_of_edges()

--- a/qldpc/objects.py
+++ b/qldpc/objects.py
@@ -337,8 +337,8 @@ class CayleyComplex:
         """
         subgraph_0 = nx.DiGraph()
         subgraph_1 = nx.DiGraph()
-        nodes_0, _ = nx.bipartite.sets(self.graph)
-        for gg, aa, bb in itertools.product(nodes_0, self.subset_a, self.subset_b):
+        half_group, _ = nx.bipartite.sets(self.graph)
+        for gg, aa, bb in itertools.product(half_group, self.subset_a, self.subset_b):
             aa_gg, gg_bb, aa_gg_bb = aa * gg, gg * bb, aa * gg * bb
             face = frozenset([gg, aa_gg, gg_bb, aa_gg_bb])
             subgraph_0.add_edge(gg, face, sort=(aa, bb))

--- a/qldpc/objects.py
+++ b/qldpc/objects.py
@@ -337,8 +337,8 @@ class CayleyComplex:
         """
         subgraph_0 = nx.DiGraph()
         subgraph_1 = nx.DiGraph()
-        half_group, _ = nx.bipartite.sets(self.graph)
-        for gg, aa, bb in itertools.product(half_group, self.subset_a, self.subset_b):
+        nodes_0, _ = nx.bipartite.sets(self.graph)
+        for gg, aa, bb in itertools.product(nodes_0, self.subset_a, self.subset_b):
             aa_gg, gg_bb, aa_gg_bb = aa * gg, gg * bb, aa * gg * bb
             face = frozenset([gg, aa_gg, gg_bb, aa_gg_bb])
             subgraph_0.add_edge(gg, face, sort=(aa, bb))


### PR DESCRIPTION
Tagging @mittaltushant for visibility, since this is something you have asked about before :slightly_smiling_face:

I'm still defining `CayleyComplex`es with directed graphs though, just because I think these are more "natural" objects to consider :shrug: