### PR TITLE
Puncture and shorten `ClassicalCode`s

### DIFF
--- a/qldpc/codes.py
+++ b/qldpc/codes.py
@@ -409,7 +409,7 @@ class ClassicalCode(AbstractCode):
 
         To shorten a code on a given bit, we:
         - move the bit to the first position,
-        - row-reduce the generator matrix into the form [ identity_matrix, other_stuff ]
+        - row-reduce the generator matrix into the form [ identity_matrix, other_stuff ], and
         - delete the first row and column from the generator matrix.
         """
         if isinstance(bits, int):

--- a/qldpc/codes.py
+++ b/qldpc/codes.py
@@ -392,19 +392,17 @@ class ClassicalCode(AbstractCode):
         matrix, field = named_codes.get_code(standardized_name)
         return ClassicalCode(matrix, field)
 
-    def puncture(self, bits: Collection[int] | int) -> ClassicalCode:
+    def puncture(self, *bits: int) -> ClassicalCode:
         """Delete the specified bits from a code.
 
         To delete bits from the code, we remove the corresponding columns from its generator matrix.
         """
-        if isinstance(bits, int):
-            bits = [bits]
         assert all(0 <= bit < self.num_bits for bit in bits)
         bits_to_keep = [bit for bit in range(self.num_bits) if bit not in bits]
         generator = [word[bits_to_keep] for word in self.generator]
         return ClassicalCode.from_generator(generator, self.field.order)
 
-    def shorten(self, bits: Collection[int] | int) -> ClassicalCode:
+    def shorten(self, *bits: int) -> ClassicalCode:
         """Shorten a code to the words that are zero on the specified bits, and delete those bits.
 
         To shorten a code on a given bit, we:
@@ -412,8 +410,6 @@ class ClassicalCode(AbstractCode):
         - row-reduce the generator matrix into the form [ identity_matrix, other_stuff ], and
         - delete the first row and column from the generator matrix.
         """
-        if isinstance(bits, int):
-            bits = [bits]
         assert all(0 <= bit < self.num_bits for bit in bits)
         generator = self.generator
         for bit in sorted(bits, reverse=True):

--- a/qldpc/codes.py
+++ b/qldpc/codes.py
@@ -406,7 +406,7 @@ class ClassicalCode(AbstractCode):
         assert all(0 <= bit < self.num_bits for bit in bits)
         generator = self.generator
         for bit in sorted(bits, reverse=True):
-            generator = np.roll(generator, -bit, axis=1)  # shift columns to put the target bit at 0
+            generator = np.roll(generator, -bit, axis=1)  # put the target bit in the first column
             generator = generator.row_reduce()[1:, 1:]
             generator = np.roll(generator, bit, axis=1)  # shift columns back
         return ClassicalCode.from_generator(generator)

--- a/qldpc/codes.py
+++ b/qldpc/codes.py
@@ -368,6 +368,13 @@ class ClassicalCode(AbstractCode):
         return ClassicalCode(matrix)
 
     @classmethod
+    def from_generator(
+        self, generator: npt.NDArray[np.int_], field: int | None = None
+    ) -> ClassicalCode:
+        """Construct a ClassicalCode from a generator matrix."""
+        return ~ClassicalCode(generator, field)
+
+    @classmethod
     def from_name(cls, name: str) -> ClassicalCode:
         """Named code in the GAP computer algebra system."""
         standardized_name = name.strip().replace(" ", "")  # remove whitespace

--- a/qldpc/codes.py
+++ b/qldpc/codes.py
@@ -406,7 +406,9 @@ class ClassicalCode(AbstractCode):
         assert all(0 <= bit < self.num_bits for bit in bits)
         generator = self.generator
         for bit in sorted(bits, reverse=True):
-            generator = np.roll(generator, -bit, axis=1).row_reduce()[1:, 1:]
+            generator = np.roll(generator, -bit, axis=1)  # shift columns to put the target bit at 0
+            generator = generator.row_reduce()[1:, 1:]
+            generator = np.roll(generator, bit, axis=1)  # shift columns back
         return ClassicalCode.from_generator(generator)
 
 

--- a/qldpc/codes.py
+++ b/qldpc/codes.py
@@ -162,6 +162,17 @@ class ClassicalCode(AbstractCode):
         """Generator of this code: a matrix whose rows for a basis for code words."""
         return self.matrix.null_space()
 
+    def __eq__(self, other: object) -> bool:
+        """Equality test between two classical codes."""
+        return (
+            isinstance(other, ClassicalCode)
+            and self.field is other.field
+            and (
+                np.array_equal(self.matrix, other.matrix)
+                or np.array_equal(self.generator, other.generator)
+            )
+        )
+
     def words(self) -> galois.FieldArray:
         """Code words of this code."""
         vectors = itertools.product(self.field.elements, repeat=self.generator.shape[0])
@@ -406,9 +417,9 @@ class ClassicalCode(AbstractCode):
         assert all(0 <= bit < self.num_bits for bit in bits)
         generator = self.generator
         for bit in sorted(bits, reverse=True):
-            generator = np.roll(generator, -bit, axis=1)  # put the target bit in the first column
-            generator = generator.row_reduce()[1:, 1:]  # row reduce and delete first row/column
-            generator = np.roll(generator, bit, axis=1)  # shift columns back
+            generator = np.roll(generator, -bit, axis=1)  # type:ignore[assignment]
+            generator = generator.row_reduce()[1:, 1:]
+            generator = np.roll(generator, bit, axis=1)  # type:ignore[assignment]
         return ClassicalCode.from_generator(generator)
 
 

--- a/qldpc/codes.py
+++ b/qldpc/codes.py
@@ -407,7 +407,7 @@ class ClassicalCode(AbstractCode):
         generator = self.generator
         for bit in sorted(bits, reverse=True):
             generator = np.roll(generator, -bit, axis=1)  # put the target bit in the first column
-            generator = generator.row_reduce()[1:, 1:]
+            generator = generator.row_reduce()[1:, 1:]  # row reduce and delete first row/column
             generator = np.roll(generator, bit, axis=1)  # shift columns back
         return ClassicalCode.from_generator(generator)
 

--- a/qldpc/codes_test.py
+++ b/qldpc/codes_test.py
@@ -57,15 +57,10 @@ def test_classical_codes() -> None:
 
     # construct a code from its generator matrix
     code = codes.ClassicalCode.random(5, 3)
-    assert np.array_equal(
-        code.generator, codes.ClassicalCode.from_generator(code.generator).generator
-    )
+    assert code == codes.ClassicalCode.from_generator(code.generator)
 
     # puncture a code
-    assert np.array_equal(
-        codes.ClassicalCode.from_generator(code.generator[:, 1:]).matrix,
-        code.puncture(0).matrix,
-    )
+    assert codes.ClassicalCode.from_generator(code.generator[:, 1:]) == code.puncture(0)
 
     # shortening a repetition code yields a trivial code
     num_bits = 3
@@ -86,9 +81,7 @@ def test_special_codes() -> None:
     order, size = 1, 3
     code = codes.ReedMullerCode(order, size)
     assert code.dimension == codes.ClassicalCode(code.matrix).dimension
-
-    dual_code = codes.ReedMullerCode(size - order - 1, size)
-    assert np.array_equal((~code).matrix, dual_code.matrix)
+    assert ~code == codes.ReedMullerCode(size - order - 1, size)
 
     with pytest.raises(ValueError, match="0 <= r <= m"):
         codes.ReedMullerCode(-1, 0)
@@ -100,8 +93,7 @@ def test_named_codes(order: int = 2) -> None:
     checks = [list(row) for row in code.matrix.view(np.ndarray)]
 
     with unittest.mock.patch("qldpc.named_codes.get_code", return_value=(checks, None)):
-        named_code = codes.ClassicalCode.from_name(f"RepetitionCode({order})")
-        assert np.array_equal(named_code.matrix, code.matrix)
+        assert codes.ClassicalCode.from_name(f"RepetitionCode({order})") == code
 
 
 def test_dual_code(bits: int = 5, checks: int = 3, field: int = 3) -> None:

--- a/qldpc/codes_test.py
+++ b/qldpc/codes_test.py
@@ -31,7 +31,7 @@ def get_random_qudit_code(qudits: int, checks: int, field: int = 2) -> codes.Qud
 
 
 def test_classical_codes() -> None:
-    """Construction of a few classical codes."""
+    """Classical code constructions."""
     assert codes.ClassicalCode.random(5, 3).num_bits == 5
     assert codes.HammingCode(3).get_distance() == 3
 
@@ -60,6 +60,18 @@ def test_classical_codes() -> None:
     assert np.array_equal(
         code.generator, codes.ClassicalCode.from_generator(code.generator).generator
     )
+
+    # puncture a code
+    assert np.array_equal(
+        codes.ClassicalCode.from_generator(code.generator[:, 1:]).matrix,
+        code.puncture(0).matrix,
+    )
+
+    # shortening a repetition code yields a trivial code
+    num_bits = 3
+    code = codes.RepetitionCode(num_bits)
+    words = [[0] * (num_bits - 1)]
+    assert np.array_equal(code.shorten(0).words(), words)
 
 
 def test_special_codes() -> None:

--- a/qldpc/codes_test.py
+++ b/qldpc/codes_test.py
@@ -47,13 +47,19 @@ def test_classical_codes() -> None:
         assert code.get_weight() == 2
         assert code.get_random_word() in code
 
-    # test that rank of repetition and Hamming codes is independent of the field
+    # that rank of repetition and Hamming codes is independent of the field
     assert codes.RepetitionCode(3, 2).rank == codes.RepetitionCode(3, 3).rank
     assert codes.HammingCode(3, 2).rank == codes.HammingCode(3, 3).rank
 
-    # test invalid classical code construction
+    # invalid classical code construction
     with pytest.raises(ValueError, match="inconsistent"):
         codes.ClassicalCode(codes.ClassicalCode.random(2, 2, field=2), field=3)
+
+    # construct a code from its generator matrix
+    code = codes.ClassicalCode.random(5, 3)
+    assert np.array_equal(
+        code.generator, codes.ClassicalCode.from_generator(code.generator).generator
+    )
 
 
 def test_special_codes() -> None:


### PR DESCRIPTION
These methods will be used in code-search experiments.

Also: added equality testing between `ClassicalCode`s, and added the `ClassicalCode.from_generator` constructor.

@mittaltushant no rush, but if you get the chance can you please take a quick look to make sure this looks correct?