### PR TITLE
Change equality check between ClassicalCode instances

### DIFF
--- a/qldpc/codes.py
+++ b/qldpc/codes.py
@@ -129,7 +129,7 @@ class ClassicalCode(AbstractCode):
     def __contains__(
         self, words: npt.NDArray[np.int_] | Sequence[int] | Sequence[Sequence[int]] | ClassicalCode
     ) -> bool:
-        """Does this code contain this given word(s)?
+        """Does this code contain the given word(s)?
 
         If passed a code, interpret "words" to be "all words in the given code", which are spanned
         by the code's generator matrix.

--- a/qldpc/codes.py
+++ b/qldpc/codes.py
@@ -131,8 +131,8 @@ class ClassicalCode(AbstractCode):
     ) -> bool:
         """Does this code contain the given word(s)?
 
-        If passed a code, interpret "words" to be "all words in the given code", which are spanned
-        by the code's generator matrix.
+        If passed a ClassicalCode for "words", interpret it to mean "all words in the given code",
+        which are spanned by the code's generator matrix.
         """
         if isinstance(words, ClassicalCode):
             words = words.generator

--- a/qldpc/codes.py
+++ b/qldpc/codes.py
@@ -183,8 +183,8 @@ class ClassicalCode(AbstractCode):
     def equiv(cls, code_a: ClassicalCode, code_b: ClassicalCode) -> bool:
         """Test equivalence between two classical codes.
 
-        Two classical codes are equivalent if they have the same code words.  The code words of
-        classical codes C_A and C_B are spanned by their generator matrices, G_A and G_B.
+        Two classical codes are equivalent if they have the same code words.  Equivalently, codes
+        C_a and C_b are equivalent if they contain each other, C_a ⊆ C_b and C_b ⊆ C_a.
         """
         return code_a.field is code_b.field and code_a in code_b and code_b in code_a
 

--- a/qldpc/codes.py
+++ b/qldpc/codes.py
@@ -126,8 +126,17 @@ class ClassicalCode(AbstractCode):
     _matrix: galois.FieldArray
     _exact_distance: int | None = None
 
-    def __contains__(self, word: npt.NDArray[np.int_] | Sequence[int]) -> bool:
-        return not np.any(self.matrix @ self.field(word))
+    def __contains__(
+        self, words: npt.NDArray[np.int_] | Sequence[int] | Sequence[Sequence[int]] | ClassicalCode
+    ) -> bool:
+        """Does this code contain this given word(s)?
+
+        If passed a code, interpret "words" to be "all words in the given code", which are spanned
+        by the code's generator matrix.
+        """
+        if isinstance(words, ClassicalCode):
+            words = words.generator
+        return not np.any(self.matrix @ self.field(words).T)
 
     @classmethod
     def matrix_to_graph(cls, matrix: npt.NDArray[np.int_] | Sequence[Sequence[int]]) -> nx.DiGraph:
@@ -163,15 +172,21 @@ class ClassicalCode(AbstractCode):
         return self.matrix.null_space()
 
     def __eq__(self, other: object) -> bool:
-        """Equality test between two classical codes."""
+        """Equality test between two classical code instances."""
         return (
             isinstance(other, ClassicalCode)
             and self.field is other.field
-            and (
-                np.array_equal(self.matrix, other.matrix)
-                or np.array_equal(self.generator, other.generator)
-            )
+            and np.array_equal(self.matrix, other.matrix)
         )
+
+    @classmethod
+    def equiv(cls, code_a: ClassicalCode, code_b: ClassicalCode) -> bool:
+        """Test equivalence between two classical codes.
+
+        Two classical codes are equivalent if they have the same code words.  The code words of
+        classical codes C_A and C_B are spanned by their generator matrices, G_A and G_B.
+        """
+        return code_a.field is code_b.field and code_a in code_b and code_b in code_a
 
     def words(self) -> galois.FieldArray:
         """Code words of this code."""

--- a/qldpc/codes_test.py
+++ b/qldpc/codes_test.py
@@ -57,7 +57,7 @@ def test_classical_codes() -> None:
 
     # construct a code from its generator matrix
     code = codes.ClassicalCode.random(5, 3)
-    assert code == codes.ClassicalCode.from_generator(code.generator)
+    assert codes.ClassicalCode.equiv(code, codes.ClassicalCode.from_generator(code.generator))
 
     # puncture a code
     assert codes.ClassicalCode.from_generator(code.generator[:, 1:]) == code.puncture(0)


### PR DESCRIPTION
Per [this comment](https://github.com/Infleqtion/qLDPC/pull/41#issuecomment-2020470622), `ClassicalCodes.__eq__` now checks exact equality between code **_instances_**, while `ClassicalCode.equiv` checks whether they are "equivalent", meaning that the two codes contain each other (or: have the same set of code words).