### PR TITLE
Identify "toric" layouts of quasi-cyclic codes (`QCCode`s)

### DIFF
--- a/qldpc/codes.py
+++ b/qldpc/codes.py
@@ -1285,15 +1285,15 @@ class QCCode(GBCode):
         self.symbol_gens = dict(zip(self.symbols, self.gens))
 
         # hadamard-transform qubits in the "R" sector
-        num_qubits = self.group.order * 2
-        qubits_to_conjugate: slice | Sequence[int] = (
-            slice(num_qubits // 2, num_qubits + 1) if conjugate else ()
+        num_qudits = self.group.order * 2
+        qudits_to_conjugate: slice | Sequence[int] = (
+            slice(num_qudits // 2, num_qudits + 1) if conjugate else ()
         )
 
         # build defining matrices of a generalized bicycle code
         matrix_a = self.eval(self.poly_a).lift().view(np.ndarray)
         matrix_b = self.eval(self.poly_b).lift().view(np.ndarray)
-        GBCode.__init__(self, matrix_a, matrix_b, field, conjugate=qubits_to_conjugate)
+        GBCode.__init__(self, matrix_a, matrix_b, field, conjugate=qudits_to_conjugate)
 
     def eval(
         self,
@@ -1363,6 +1363,7 @@ class QCCode(GBCode):
         a few far-away qubits.
         """
         if not nx.is_weakly_connected(self.graph):
+            # a connected tanner graph is a baseline requirement for a toric mapping to exist
             return []
 
         # identify individual terms in the polynomials
@@ -1951,7 +1952,7 @@ class SurfaceCode(CSSCode):
         self._exact_distance_z = rows
 
         # which qubits should be Hadamard-transformed?
-        qubits_to_conjugate: slice | Sequence[int] | None
+        qudits_to_conjugate: slice | Sequence[int] | None
 
         if rotated:
             # rotated surface code
@@ -1959,12 +1960,12 @@ class SurfaceCode(CSSCode):
 
             if conjugate:
                 # Hadamard-transform qubits in a checkerboard pattern
-                qubits_to_conjugate = [
+                qudits_to_conjugate = [
                     idx for idx, (row, col) in enumerate(np.ndindex(rows, cols)) if (row + col) % 2
                 ]
 
             else:
-                qubits_to_conjugate = None
+                qudits_to_conjugate = None
 
         else:
             # "original" surface code
@@ -1973,14 +1974,14 @@ class SurfaceCode(CSSCode):
             code_ab = HGPCode(code_a, code_b, field, conjugate=conjugate)
             matrix_x = code_ab.matrix_x
             matrix_z = code_ab.matrix_z
-            qubits_to_conjugate = code_ab.conjugated_qubits
+            qudits_to_conjugate = code_ab.conjugated_qubits
 
         CSSCode.__init__(
             self,
             matrix_x,
             matrix_z,
             field=field,
-            conjugate=qubits_to_conjugate,
+            conjugate=qudits_to_conjugate,
             skip_validation=True,
         )
 
@@ -2069,7 +2070,7 @@ class ToricCode(CSSCode):
         self._exact_distance_x = self._exact_distance_z = min(rows, cols)
 
         # which qubits should be Hadamard-transformed?
-        qubits_to_conjugate: slice | Sequence[int] | None
+        qudits_to_conjugate: slice | Sequence[int] | None
 
         if rotated:
             # rotated toric code
@@ -2082,12 +2083,12 @@ class ToricCode(CSSCode):
 
             if conjugate:
                 # Hadamard-transform qubits in a checkerboard pattern
-                qubits_to_conjugate = [
+                qudits_to_conjugate = [
                     idx for idx, (row, col) in enumerate(np.ndindex(rows, cols)) if (row + col) % 2
                 ]
 
             else:
-                qubits_to_conjugate = None
+                qudits_to_conjugate = None
 
         else:
             # "original" toric code
@@ -2096,14 +2097,14 @@ class ToricCode(CSSCode):
             code_ab = HGPCode(code_a, code_b, field, conjugate=conjugate)
             matrix_x = code_ab.matrix_x
             matrix_z = code_ab.matrix_z
-            qubits_to_conjugate = code_ab.conjugated_qubits
+            qudits_to_conjugate = code_ab.conjugated_qubits
 
         CSSCode.__init__(
             self,
             matrix_x,
             matrix_z,
             field=field,
-            conjugate=qubits_to_conjugate,
+            conjugate=qudits_to_conjugate,
             skip_validation=True,
         )
 

--- a/qldpc/codes.py
+++ b/qldpc/codes.py
@@ -1229,7 +1229,6 @@ CyclicIndexMap = Callable[
     [int, int, int | Literal[Pauli.X, Pauli.Z], tuple[int, int]],
     tuple[int, int],
 ]
-LayoutData = tuple[tuple[int, int], CyclicIndexMap]
 
 
 # TODO:
@@ -1354,7 +1353,7 @@ class QCCode(GBCode):
         return exponents.get(self.symbols[0], 0), exponents.get(self.symbols[1], 0)
 
     @functools.cache
-    def get_toric_layout_data(self) -> Sequence[LayoutData]:
+    def get_toric_layout_data(self) -> Sequence[tuple[tuple[int, int], CyclicIndexMap]]:
         """Get toric layout data, if any, as discussed in arXiv:2308.07915."""
         if not nx.is_weakly_connected(self.graph):
             return []

--- a/qldpc/codes.py
+++ b/qldpc/codes.py
@@ -1225,9 +1225,7 @@ QCCIndexMap = Callable[[int, int, int | PauliXZ], tuple[int, int]]
 # - allow initializing from matrices of coefficients
 # - maybe generalize to higher dimensions
 class QCCode(GBCode):
-    """Quasi-cyclic (QC) code.
-
-    Inspired by arXiv:2308.07915.
+    """Quasi-cyclic (QC) codes from arXiv:2308.07915.
 
     A quasi-cyclic code is a CSS code with subcode parity check matrices
     - matrix_x = [A, B], and

--- a/qldpc/codes.py
+++ b/qldpc/codes.py
@@ -1390,18 +1390,18 @@ class QCCode(GBCode):
             build a grid_map (dictionary) that maps (i, j) --> (a, b), where
                 x^i y^j = g^a h^b.
             Equivalently, we want
-                i = a p + b r  mod order(x),
-                j = b q + b s  mod order(y).
+                i = a p + b u  mod order(x),
+                j = b q + b v  mod order(y).
             """
             gen_g = self.to_group_member(shift_a)
             gen_h = self.to_group_member(shift_b)
             pp, qq = self.get_exponents(shift_a)
-            rr, ss = self.get_exponents(shift_b)
+            uu, vv = self.get_exponents(shift_b)
             torus_shape: tuple[int, int] = (gen_g.order(), gen_h.order())
             grid_map = {
                 (
-                    (aa * pp + bb * rr) % self.orders[0],
-                    (aa * qq + bb * ss) % self.orders[1],
+                    (aa * pp + bb * uu) % self.orders[0],
+                    (aa * qq + bb * vv) % self.orders[1],
                 ): (aa, bb)
                 for aa, bb in np.ndindex(torus_shape)
             }

--- a/qldpc/codes.py
+++ b/qldpc/codes.py
@@ -1352,7 +1352,7 @@ class QCCode(GBCode):
         return exponents.get(self.symbols[0], 0), exponents.get(self.symbols[1], 0)
 
     @functools.cache
-    def get_toric_mapping(self) -> Sequence[tuple[QuasiCyclicPlaquetteMap, tuple[int, int]]]:
+    def get_toric_mappings(self) -> Sequence[tuple[QuasiCyclicPlaquetteMap, tuple[int, int]]]:
         """Get plaquette mappings that arrange qubits in a toric layout.
 
         Each plaquette looks like:

--- a/qldpc/codes.py
+++ b/qldpc/codes.py
@@ -1317,7 +1317,7 @@ class QCCode(GBCode):
 
     def get_exponents(
         self, expr: sympy.Integer | sympy.Symbol | sympy.Pow | sympy.Mul
-    ) -> tuple[int, ...]:
+    ) -> tuple[int, int]:
         """Get the exponents of a term, for example converting x**2 y**4 into the (2, 4)."""
         exponents = {}
         if isinstance(expr, sympy.Symbol):
@@ -1329,7 +1329,7 @@ class QCCode(GBCode):
             for factor in expr.args:
                 base, exp = factor.as_base_exp()
                 exponents[base] = exp
-        return tuple(exponents.get(symbol, 0) for symbol in self.symbols)
+        return exponents.get(self.symbols[0], 0), exponents.get(self.symbols[1], 0)
 
     def get_toric_params(self) -> tuple[int, ...] | None:
         """Get toric layout parameters, if any, as discussed in arXiv:2308.07915."""

--- a/qldpc/codes_test.py
+++ b/qldpc/codes_test.py
@@ -340,8 +340,6 @@ def test_cyclic_codes(field: int = 3) -> None:
     assert code.dimension == 10
     assert code.get_weight() == 8
 
-    assert code.to_group_member(x * y) == code.to_group_member(x) * code.to_group_member(y)
-
     # [[144, 12, 12]] code in Table 3 and Figure 2 of arXiv:2308.07915
     dims = (12, 6)
     poly_a = x**3 + y + y**2
@@ -358,7 +356,7 @@ def test_cyclic_codes(field: int = 3) -> None:
         assert unit_shifts.issubset(shifts_x)
         assert unit_shifts.issubset(shifts_z)
 
-    # assert that there are no toric mappings
+    # check a case with no toric mappings
     dims = (6, 6)
     poly_a = 1 + y + y**2
     poly_b = y**3 + x**2 + x**4

--- a/qldpc/codes_test.py
+++ b/qldpc/codes_test.py
@@ -319,27 +319,55 @@ def test_twisted_XZZX(width: int = 3) -> None:
 
 
 def test_cyclic_codes(field: int = 3) -> None:
-    """Quasi-cyclic codes from arXiv:2308.07915."""
+    """Quasi-cyclic codes from arXiv:2308.07915 and arXiv:2311.16980."""
     from sympy.abc import x, y
 
+    # first code in Table 3 of arXiv:2308.07915
     dims = (6, 6)
-    terms_a = x**3 + y + y**2
-    terms_b = y**3 + x + x**2
-    code = codes.QCCode(dims, terms_a, terms_b, field=2)
+    poly_a = x**3 + y + y**2
+    poly_b = y**3 + x + x**2
+    code = codes.QCCode(dims, poly_a, poly_b, field=2)
     assert code.num_qudits == 72
     assert code.dimension == 12
     assert code.get_weight() == 6
 
-    dims_dict = {x: 15, y: 3}
-    terms_a = x**9 + y + y**2
-    terms_b = 1 + x**2 + x**7
-    code = codes.QCCode(dims_dict, terms_a, terms_b, field=3)
-    assert code.num_qudits == 90
-    assert code.dimension == 8
+    # last code in Table II of arXiv:2311.16980
+    dims_dict = {x: 12, y: 4}
+    poly_a = 1 + y + x * y + x**9
+    poly_b = 1 + x**2 + x**7 + x**9 * y**2
+    code = codes.QCCode(dims_dict, poly_a, poly_b, field=2)
+    assert code.num_qudits == 96
+    assert code.dimension == 10
+    assert code.get_weight() == 8
+
+    assert code.to_group_member(x * y) == code.to_group_member(x) * code.to_group_member(y)
+
+    # [[144, 12, 12]] code in Table 3 and Figure 2 of arXiv:2308.07915
+    dims = (12, 6)
+    poly_a = x**3 + y + y**2
+    poly_b = y**3 + x + x**2
+    code = codes.QCCode(dims, poly_a, poly_b, field=2)
+    assert code.num_qudits == 144
+    assert code.dimension == 12
     assert code.get_weight() == 6
 
+    # check that every check qubit addresses its neighboring data qubits
+    unit_shifts = {(0, 1), (1, 0), (0, -1), (-1, 0)}
+    for plaquette_map, torus_shape in code.get_toric_mappings():
+        shifts_x, shifts_z = code.get_check_shifts(plaquette_map, torus_shape)
+        assert unit_shifts.issubset(shifts_x)
+        assert unit_shifts.issubset(shifts_z)
+
+    # assert that there are no toric mappings
+    dims = (6, 6)
+    poly_a = 1 + y + y**2
+    poly_b = y**3 + x**2 + x**4
+    code = codes.QCCode(dims, poly_a, poly_b, field=2)
+    assert not code.get_toric_mappings()
+
+    # fail to match cyclic group orders to free variables
     with pytest.raises(ValueError, match="Could not match"):
-        codes.QCCode({}, terms_a, terms_b, field=2)
+        codes.QCCode({}, poly_a, poly_b, field=2)
 
 
 def test_GB_code_error() -> None:

--- a/qldpc/objects.py
+++ b/qldpc/objects.py
@@ -21,6 +21,7 @@ import dataclasses
 import enum
 import itertools
 from collections.abc import Collection, Iterator
+from typing import Literal
 
 import galois
 import networkx as nx
@@ -84,6 +85,9 @@ class Pauli(enum.Enum):
         if self == Pauli.Z:
             return 1
         raise AttributeError(f"No index for {self}.")
+
+
+PauliXZ = Literal[Pauli.X, Pauli.Z]
 
 
 class QuditOperator:

--- a/qldpc/objects.py
+++ b/qldpc/objects.py
@@ -88,6 +88,7 @@ class Pauli(enum.Enum):
 
 
 PauliXZ = Literal[Pauli.X, Pauli.Z]
+PAULIS_XZ: list[PauliXZ] = [Pauli.X, Pauli.Z]
 
 
 class QuditOperator:


### PR DESCRIPTION
Methods taken from [arXiv:2308.07915](https://arxiv.org/abs/2308.07915) (page 12)