### PR TITLE
Retrieve `SmallGroup` structure descriptions

### DIFF
--- a/qldpc/abstract.py
+++ b/qldpc/abstract.py
@@ -825,6 +825,11 @@ class SmallGroup(Group):
         super()._init_from_group(Group.from_name(name))
         self.index = index
 
+    @functools.cached_property
+    def description(self) -> str:
+        """Return a description of this group."""
+        return external.groups.get_small_group_description(self.order, self.index)
+
     @classmethod
     def number(cls, order: int) -> int:
         """The number of groups of a given order."""

--- a/qldpc/abstract.py
+++ b/qldpc/abstract.py
@@ -828,7 +828,7 @@ class SmallGroup(Group):
     @functools.cached_property
     def structure(self) -> str:
         """A description of the structure of this group."""
-        return external.groups.get_small_group_structure(self.order, self.index)
+        return self.get_structure(self.order, self.index)
 
     @classmethod
     def number(cls, order: int) -> int:
@@ -840,6 +840,11 @@ class SmallGroup(Group):
         """Iterator over all groups of a given order."""
         for ii in range(SmallGroup.number(order)):
             yield SmallGroup(order, ii + 1)
+
+    @classmethod
+    def get_structure(cls, order: int, index: int) -> str:
+        """Retrieve a description of the structure of a group."""
+        return external.groups.get_small_group_structure(order, index)
 
 
 ################################################################################

--- a/qldpc/abstract.py
+++ b/qldpc/abstract.py
@@ -826,9 +826,9 @@ class SmallGroup(Group):
         self.index = index
 
     @functools.cached_property
-    def description(self) -> str:
-        """Return a description of this group."""
-        return external.groups.get_small_group_description(self.order, self.index)
+    def structure(self) -> str:
+        """A description of the structure of this group."""
+        return external.groups.get_small_group_structure(self.order, self.index)
 
     @classmethod
     def number(cls, order: int) -> int:

--- a/qldpc/abstract_test.py
+++ b/qldpc/abstract_test.py
@@ -211,9 +211,9 @@ def test_small_group() -> None:
         assert group.generators == desired_group.generators
         assert list(abstract.SmallGroup.generator(order)) == [desired_group]
 
-        # retrieve group description
-        description = "test"
+        # retrieve group structure
+        structure = "test"
         with unittest.mock.patch(
-            "qldpc.external.groups.get_small_group_description", return_value=description
+            "qldpc.external.groups.get_small_group_structure", return_value=structure
         ):
-            assert group.description == description
+            assert group.structure == structure

--- a/qldpc/abstract_test.py
+++ b/qldpc/abstract_test.py
@@ -207,5 +207,13 @@ def test_small_group() -> None:
         unittest.mock.patch("qldpc.abstract.SmallGroup.number", return_value=index),
         unittest.mock.patch("qldpc.external.groups.get_generators", return_value=generators),
     ):
-        assert abstract.SmallGroup(order, index).generators == desired_group.generators
+        group = abstract.SmallGroup(order, index)
+        assert group.generators == desired_group.generators
         assert list(abstract.SmallGroup.generator(order)) == [desired_group]
+
+        # retrieve group description
+        description = "test"
+        with unittest.mock.patch(
+            "qldpc.external.groups.get_small_group_description", return_value=description
+        ):
+            assert group.description == description

--- a/qldpc/external/codes.py
+++ b/qldpc/external/codes.py
@@ -21,8 +21,10 @@ import re
 import qldpc.cache
 from qldpc.external.groups import gap_is_installed, get_gap_result
 
+CACHE_NAME = "qldpc_codes"
 
-@qldpc.cache.use_disk_cache("qldpc_codes")
+
+@qldpc.cache.use_disk_cache(CACHE_NAME)
 def get_code(code: str) -> tuple[list[list[int]], int | None]:
     """Retrieve a group from GAP."""
 

--- a/qldpc/external/groups.py
+++ b/qldpc/external/groups.py
@@ -220,26 +220,26 @@ def get_small_group_number(order: int) -> int:
     return max(int(match) for match in matches)
 
 
-def get_small_group_description(order: int, index: int) -> str:
-    """Get the description of a SmallGroup from GAP."""
-    # if we have the description cached, retrieve it
+def get_small_group_structure(order: int, index: int) -> str:
+    """Get a description of the structure of a SmallGroup from GAP."""
+    # if we have the structure cached, retrieve it
     key = (order, index)
     cache = qldpc.cache.get_disk_cache(CACHE_NAME)
-    if description := cache.get(key, None):
-        return description
+    if structure := cache.get(key, None):
+        return structure
 
-    # try to retrieve the description from GAP
+    # try to retrieve the structure from GAP
     name = f"SmallGroup({order},{index})"
     if gap_is_installed():
         command = f"Print(StructureDescription({name}));"
         result = get_gap_result(command)
-        description = result.stdout.strip()
+        structure = result.stdout.strip()
 
-        if not description:
+        if not structure:
             raise ValueError(f"Group not recognized by GAP: {name}")
 
-        cache[key] = description
-        return description
+        cache[key] = structure
+        return structure
 
     # return the name of the group
     return name

--- a/qldpc/external/groups_test.py
+++ b/qldpc/external/groups_test.py
@@ -223,17 +223,17 @@ def test_get_small_group_number() -> None:
         assert external.groups.get_small_group_number(order) == number
 
 
-def test_get_small_group_description() -> None:
-    """Retrieve a description of a group."""
+def test_get_small_group_structure() -> None:
+    """Retrieve a description of the structure of a group."""
     order, index = 12, 3
-    description = "C3 : C4"
+    structure = "C3 : C4"
 
-    # retrieve a description from cache
-    cache = {(order, index): description}
+    # retrieve a structure from cache
+    cache = {(order, index): structure}
     with unittest.mock.patch("qldpc.cache.get_disk_cache", return_value=cache):
-        assert external.groups.get_small_group_description(order, index) == description
+        assert external.groups.get_small_group_structure(order, index) == structure
 
-    # fail to retrieve description from GAP
+    # fail to retrieve structure from GAP
     process = get_mock_process("")
     with (
         unittest.mock.patch("qldpc.cache.get_disk_cache", return_value={}),
@@ -241,21 +241,21 @@ def test_get_small_group_description() -> None:
         unittest.mock.patch("qldpc.external.groups.get_gap_result", return_value=process),
         pytest.raises(ValueError, match="Group not recognized"),
     ):
-        external.groups.get_small_group_description(order, index)
+        external.groups.get_small_group_structure(order, index)
 
-    # retrieve description from GAP
-    process = get_mock_process(description)
+    # retrieve structure from GAP
+    process = get_mock_process(structure)
     with (
         unittest.mock.patch("qldpc.cache.get_disk_cache", return_value={}),
         unittest.mock.patch("qldpc.external.groups.gap_is_installed", return_value=True),
         unittest.mock.patch("qldpc.external.groups.get_gap_result", return_value=process),
     ):
-        assert external.groups.get_small_group_description(order, index) == description
+        assert external.groups.get_small_group_structure(order, index) == structure
 
     # GAP is not installed
     with (
         unittest.mock.patch("qldpc.cache.get_disk_cache", return_value={}),
         unittest.mock.patch("qldpc.external.groups.gap_is_installed", return_value=False),
     ):
-        description = f"SmallGroup({order},{index})"
-        assert external.groups.get_small_group_description(order, index) == description
+        structure = f"SmallGroup({order},{index})"
+        assert external.groups.get_small_group_structure(order, index) == structure


### PR DESCRIPTION
For example, `qldpc.abstract.SmallGroup(12, 1).structure == "C3 : C4"`