### PR TITLE
Identify the dimension of qudit codes

### DIFF
--- a/qldpc/codes/common.py
+++ b/qldpc/codes/common.py
@@ -25,7 +25,6 @@ from collections.abc import Callable, Sequence
 from typing import Literal
 
 import galois
-import ldpc.mod2
 import networkx as nx
 import numpy as np
 import numpy.typing as npt
@@ -119,6 +118,16 @@ class AbstractCode(abc.ABC):
     def matrix(self) -> galois.FieldArray:
         """Parity check matrix of this code."""
         return self._matrix
+
+    @functools.cached_property
+    def rank(self) -> int:
+        """Rank of this code's parity check matrix.
+
+        Equivalently, the number of linearly independent parity checks in this code.
+        """
+        matrix_RREF = self.matrix.row_reduce()
+        nonzero_rows = np.any(matrix_RREF, axis=1)
+        return np.count_nonzero(nonzero_rows)
 
     @functools.cached_property
     def graph(self) -> nx.DiGraph:
@@ -279,16 +288,6 @@ class ClassicalCode(AbstractCode):
     def num_bits(self) -> int:
         """Number of data bits in this code."""
         return self._matrix.shape[1]
-
-    @functools.cached_property
-    def rank(self) -> int:
-        """Rank of this code's parity check matrix.
-
-        Equivalently, the number of linearly independent parity checks in this code.
-        """
-        if self.field.order == 2:
-            return ldpc.mod2.rank(self._matrix)
-        return np.linalg.matrix_rank(self._matrix)
 
     @property
     def dimension(self) -> int:
@@ -571,6 +570,11 @@ class QuditCode(AbstractCode):
     def _assert_qubit_code(self) -> None:
         if self.field.order != 2:
             raise ValueError("Attempted to call a qubit-only method with a non-qubit code")
+
+    @property
+    def dimension(self) -> int:
+        """The number of logical bits encoded by this code."""
+        return self.num_qudits - self.rank
 
     def get_weight(self) -> int:
         """Compute the weight of the largest check."""
@@ -1025,16 +1029,16 @@ class CSSCode(QuditCode):
             """Perform Gaussian elimination on the matrix.
 
             Returns:
-                matrix_RRE: the reduced row echelon form of the matrix.
+                matrix_RREF: the reduced row echelon form of the matrix.
                 pivot: the "pivot" columns of the reduced matrix.
                 other: the remaining columns of the reduced matrix.
 
             In reduced row echelon form, the first nonzero entry of each row is a 1, and these 1s
-            occur at a unique columns for each row; these columns are the "pivots" of matrix_RRE.
+            occur at a unique columns for each row; these columns are the "pivots" of matrix_RREF.
             """
             # row-reduce the matrix and identify its pivots
-            matrix_RRE = self.field(matrix).row_reduce()
-            pivots = (matrix_RRE != 0).argmax(axis=1)
+            matrix_RREF = self.field(matrix).row_reduce()
+            pivots = (matrix_RREF != 0).argmax(axis=1)
 
             # remove trailing zero pivots, which correspond to trivial (all-zero) rows
             if pivots.size > 1 and pivots[-1] == 0:
@@ -1042,7 +1046,7 @@ class CSSCode(QuditCode):
 
             # identify remaining columns and return
             other = [qq for qq in range(matrix.shape[1]) if qq not in pivots]
-            return matrix_RRE, pivots, other
+            return matrix_RREF, pivots, other
 
         # identify check matrices for X/Z-type errors, and the current qudit locations
         checks_x: npt.NDArray[np.int_] = self.matrix_z

--- a/qldpc/codes/common_test.py
+++ b/qldpc/codes/common_test.py
@@ -160,6 +160,11 @@ def test_qubit_code(num_qubits: int = 5, num_checks: int = 3) -> None:
         assert get_random_qudit_code(num_qubits, num_checks, field=3).num_qubits
 
 
+def test_qudit_code() -> None:
+    """Miscellaneous qudit code tests and coverage."""
+    assert codes.FiveQubitCode().dimension == 1
+
+
 @pytest.mark.parametrize("field", [2, 3])
 def test_conversions_quantum(field: int, bits: int = 5, checks: int = 3) -> None:
     """Conversions between matrix and graph representations of a code."""


### PR DESCRIPTION
This also speeds up the calculation of dimension for codes with a base field > 2, because it now uses Gaussian elimination rather than an SVD decomposition.