### PR TITLE
Add logical operator construction for `QuditCode`s

### DIFF
--- a/qldpc/codes/common.py
+++ b/qldpc/codes/common.py
@@ -574,7 +574,7 @@ class QuditCode(AbstractCode):
 
     @property
     def dimension(self) -> int:
-        """The number of logical bits encoded by this code."""
+        """The number of logical qudits encoded by this code."""
         return self.num_qudits - self.rank
 
     def get_weight(self) -> int:
@@ -675,8 +675,11 @@ class QuditCode(AbstractCode):
 
         Logical operators are represented by a three-dimensional array `logical_ops` with dimensions
         (2, k, n), where k and n are respectively the numbers of logical and physical qudits in this
-        code.  The bitstring `logical_ops[0, 4, :]`, for example, indicates the support (i.e., the
-        physical qudits addressed nontrivially) by the logical Pauli-X operator on logical qudit 4.
+        code.  The first axis is used to keep track of conjugate pairs of logical operators for each
+        logical qubit.  The bitstring `logical_ops[0, 4, :]`, for example, indicates the support
+        (i.e., the physical qudits addressed nontrivially) by a logical operator on logical qudit 4,
+        and the conjugate logical operator is `logical_ops[0, 4, :]`.  In general,
+        `logical_ops[0, aa, :] @ logical_ops[1, bb, :] = int(aa == bb)`.
 
         Logical operators are constructed using the method described in Section 4.1 of Gottesman's
         thesis (arXiv:9705052), slightly modified and generalized for qudits.
@@ -714,13 +717,16 @@ class QuditCode(AbstractCode):
             other = [qq for qq in range(matrix.shape[1]) if qq not in pivots]
             return matrix_RRE, pivots, other
 
-        # identify check matrices for X/Z-type errors, and the current qudit locations
-        checks_x: npt.NDArray[np.int_] = self.matrix_z
-        checks_z: npt.NDArray[np.int_] = self.matrix_x
+        # keep track of current qudit locations
         qudit_locs = np.arange(num_qudits, dtype=int)
 
         # row reduce the check matrix for X-type errors and move its pivots to the back
-        checks_x, pivot_x, other_x = row_reduce(checks_x)
+        checks_x, pivot_x, other_x = row_reduce(self.matrix)
+        print()
+        print(checks_x)
+        print(pivot_x)
+        print(other_x)
+        return
         checks_x = np.hstack([checks_x[:, other_x], checks_x[:, pivot_x]])
         checks_z = np.hstack([checks_z[:, other_x], checks_z[:, pivot_x]])
         qudit_locs = np.hstack([qudit_locs[other_x], qudit_locs[pivot_x]])

--- a/qldpc/codes/common.py
+++ b/qldpc/codes/common.py
@@ -1126,11 +1126,6 @@ class CSSCode(QuditCode):
         checks_z = np.hstack([checks_z[:, other_z], checks_z[:, pivots_z]])
         qudit_locs = np.hstack([qudit_locs[other_z], qudit_locs[pivots_z]])
 
-        # print()
-        # print(checks_x)
-        # print()
-        # print(checks_z)
-
         # run some sanity checks
         assert pivots_z[-1] < num_qudits - len(pivots_x)
         assert dimension + len(pivots_x) + len(pivots_z) == num_qudits

--- a/qldpc/codes/common.py
+++ b/qldpc/codes/common.py
@@ -722,9 +722,6 @@ class QuditCode(AbstractCode):
         checks_x = matrix[: len(pivots_x), :].reshape(len(pivots_x), 2, self.num_qudits)
         checks_z = matrix[len(pivots_x) :, :].reshape(len(pivots_z), 2, self.num_qudits)
 
-        print()
-        print(checks_x.reshape(len(pivots_x), -1))
-
         # run some sanity checks
         assert len(pivots_z) == 0 or pivots_z[-1] < num_qudits - len(pivots_x)
         assert dimension + len(pivots_x) + len(pivots_z) == num_qudits
@@ -753,9 +750,20 @@ class QuditCode(AbstractCode):
         logicals_x = logicals_x[:, :, permutation]
         logicals_z = logicals_z[:, :, permutation]
 
+        # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+        logicals_x = np.roll(logicals_x, 1, axis=1)
+        logicals_z = np.roll(logicals_z, 1, axis=1)
+        print()
+        print(not np.any(self.matrix @ logicals_x.reshape(-1, 2 * self.num_qudits).T))
+        print(not np.any(self.matrix @ logicals_z.reshape(-1, 2 * self.num_qudits).T))
+        logicals_x = np.roll(logicals_x, 1, axis=1)
+        logicals_z = np.roll(logicals_z, 1, axis=1)
+        # !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
         # reshape and return
         logicals_x = logicals_x.reshape(dimension, 2 * num_qudits)
         logicals_z = logicals_z.reshape(dimension, 2 * num_qudits)
+
         self._full_logical_ops = self.field(np.stack([logicals_x, logicals_z]))
         return self._full_logical_ops
 
@@ -1131,9 +1139,6 @@ class CSSCode(QuditCode):
         checks_x = np.hstack([checks_x[:, other_z], checks_x[:, pivots_z]])
         checks_z = np.hstack([checks_z[:, other_z], checks_z[:, pivots_z]])
         qudit_locs = np.hstack([qudit_locs[other_z], qudit_locs[pivots_z]])
-
-        print()
-        print(checks_x)
 
         # run some sanity checks
         assert pivots_z[-1] < num_qudits - len(pivots_x)

--- a/qldpc/codes/common_test.py
+++ b/qldpc/codes/common_test.py
@@ -217,7 +217,7 @@ def test_qudit_ops() -> None:
 # CSS code tests
 
 
-def test_css_code() -> None:
+def test_CSS_code() -> None:
     """Miscellaneous CSS code tests and coverage."""
     code_x = codes.ClassicalCode.random(3, 2)
 
@@ -237,14 +237,16 @@ def test_css_code() -> None:
         codes.CSSCode(code_x, code_z)
 
 
-def test_css_ops() -> None:
+def test_CSS_ops() -> None:
     """Logical operator construction for CSS codes."""
     code: codes.CSSCode
     np.set_printoptions(linewidth=200)
 
-    code = codes.HGPCode(codes.ClassicalCode.random(4, 2, field=3))
-    code.get_random_logical_op(Pauli.X, ensure_nontrivial=False)
-    code.get_random_logical_op(Pauli.X, ensure_nontrivial=True)
+    # code = codes.HGPCode(codes.ClassicalCode.random(4, 2, field=3))
+    # code.get_random_logical_op(Pauli.X, ensure_nontrivial=False)
+    # code.get_random_logical_op(Pauli.X, ensure_nontrivial=True)
+
+    code = codes.SurfaceCode(3, 5, rotated=True)
 
     # test that logical operators are dual to each other and have trivial syndromes
     logicals = code.get_logical_ops()
@@ -261,13 +263,13 @@ def test_css_ops() -> None:
     # assert np.array_equal(full_logicals_z, np.hstack([np.zeros_like(logicals_x), logicals_z]))
 
     print()
-    print(logicals_x)
+    print(logicals_x[0].reshape(3, 5))
     print()
-    print(logicals_z)
+    print(logicals_z[0].reshape(3, 5))
     print()
-    print(full_logicals_x)
+    print(full_logicals_x[0].reshape(6, 5))
     print()
-    print(full_logicals_z)
+    print(full_logicals_z[0].reshape(6, 5))
     # print()
     # print(np.hstack([logicals_x, np.zeros_like(logicals_x)]))
 

--- a/qldpc/codes/common_test.py
+++ b/qldpc/codes/common_test.py
@@ -207,7 +207,7 @@ def test_qudit_ops() -> None:
     assert logical_ops.shape == (2, code.dimension, 2 * code.num_qudits)
     assert np.array_equal(logical_ops[0, 0], [0, 0, 0, 0, 1, 1, 0, 0, 1, 0])
     assert np.array_equal(logical_ops[1, 0], [0, 0, 0, 0, 0, 1, 1, 1, 1, 1])
-    assert code.get_logical_ops() is code._logical_ops
+    assert code.get_logical_ops() is code._full_logical_ops
 
     code = codes.QuditCode.from_stabilizers(*code.get_stabilizers(), "I I I I I")
     assert np.array_equal(logical_ops, code.get_logical_ops())
@@ -240,6 +240,7 @@ def test_css_code() -> None:
 def test_css_ops() -> None:
     """Logical operator construction for CSS codes."""
     code: codes.CSSCode
+    np.set_printoptions(linewidth=200)
 
     code = codes.HGPCode(codes.ClassicalCode.random(4, 2, field=3))
     code.get_random_logical_op(Pauli.X, ensure_nontrivial=False)
@@ -253,25 +254,35 @@ def test_css_ops() -> None:
     assert not np.any(code.matrix_x @ logicals_z.T)
     assert code.get_logical_ops() is code._logical_ops
 
-    logicals_full = codes.QuditCode.get_logical_ops(code)
+    # check that the logical operators agree with those computed by the QuditCode method
+    full_logicals = codes.QuditCode.get_logical_ops(code)
+    full_logicals_x, full_logicals_z = full_logicals[0], full_logicals[1]
+    # assert np.array_equal(full_logicals_x, np.hstack([logicals_x, np.zeros_like(logicals_x)]))
+    # assert np.array_equal(full_logicals_z, np.hstack([np.zeros_like(logicals_x), logicals_z]))
 
     print()
     print(logicals_x)
     print()
-    print(logicals_full[0])
+    print(logicals_z)
+    print()
+    print(full_logicals_x)
+    print()
+    print(full_logicals_z)
+    # print()
+    # print(np.hstack([logicals_x, np.zeros_like(logicals_x)]))
 
-    # successfullly construct and reduce logical operators in a code with "over-complete" checks
-    dist = 4
-    code = codes.ToricCode(dist, rotated=True)
-    code.reduce_logical_ops()
-    assert code.get_code_params() == (dist**2, 2, dist)
-    assert not any(np.count_nonzero(op) < dist for op in code.get_logical_ops(Pauli.X))
-    assert not any(np.count_nonzero(op) < dist for op in code.get_logical_ops(Pauli.Z))
+    # # successfullly construct and reduce logical operators in a code with "over-complete" checks
+    # dist = 4
+    # code = codes.ToricCode(dist, rotated=True)
+    # code.reduce_logical_ops()
+    # assert code.get_code_params() == (dist**2, 2, dist)
+    # assert not any(np.count_nonzero(op) < dist for op in code.get_logical_ops(Pauli.X))
+    # assert not any(np.count_nonzero(op) < dist for op in code.get_logical_ops(Pauli.Z))
 
-    # reducing logical operator weight only supported for prime number fields
-    code = codes.HGPCode(codes.ClassicalCode.random(4, 2, field=4))
-    with pytest.raises(ValueError, match="prime number fields"):
-        code.reduce_logical_op(Pauli.X, 0)
+    # # reducing logical operator weight only supported for prime number fields
+    # code = codes.HGPCode(codes.ClassicalCode.random(4, 2, field=4))
+    # with pytest.raises(ValueError, match="prime number fields"):
+    #     code.reduce_logical_op(Pauli.X, 0)
 
 
 def test_distance_quantum() -> None:

--- a/qldpc/codes/common_test.py
+++ b/qldpc/codes/common_test.py
@@ -198,6 +198,19 @@ def test_deformations(num_qudits: int = 5, num_checks: int = 3, field: int = 3) 
         assert tuple(transformed_matrix[node_check.index, :, node_qubit.index]) == vals
 
 
+def test_qudit_ops() -> None:
+    """Logical operator construction for Galois qudit codes."""
+    code = codes.FiveQubitCode()
+    print()
+    print(code.dimension)
+
+    logical_ops = code.get_logical_ops()
+
+
+####################################################################################################
+# CSS code tests
+
+
 def test_CSS_code() -> None:
     """Miscellaneous CSS code tests and coverage."""
     code_x = codes.ClassicalCode.random(3, 2)
@@ -218,8 +231,8 @@ def test_CSS_code() -> None:
         codes.CSSCode(code_x, code_z)
 
 
-def test_logical_ops() -> None:
-    """Logical operator construction."""
+def test_CSS_ops() -> None:
+    """Logical operator construction for CSS codes."""
     code: codes.QuditCode
 
     code = codes.HGPCode(codes.ClassicalCode.random(4, 2, field=3))

--- a/qldpc/codes/common_test.py
+++ b/qldpc/codes/common_test.py
@@ -217,7 +217,7 @@ def test_qudit_ops() -> None:
 # CSS code tests
 
 
-def test_CSS_code() -> None:
+def test_css_code() -> None:
     """Miscellaneous CSS code tests and coverage."""
     code_x = codes.ClassicalCode.random(3, 2)
 
@@ -237,9 +237,9 @@ def test_CSS_code() -> None:
         codes.CSSCode(code_x, code_z)
 
 
-def test_CSS_ops() -> None:
+def test_css_ops() -> None:
     """Logical operator construction for CSS codes."""
-    code: codes.QuditCode
+    code: codes.CSSCode
 
     code = codes.HGPCode(codes.ClassicalCode.random(4, 2, field=3))
     code.get_random_logical_op(Pauli.X, ensure_nontrivial=False)
@@ -253,10 +253,12 @@ def test_CSS_ops() -> None:
     assert not np.any(code.matrix_x @ logicals_z.T)
     assert code.get_logical_ops() is code._logical_ops
 
-    # reducing logical operator weight only supported for prime number fields
-    code = codes.HGPCode(codes.ClassicalCode.random(4, 2, field=4))
-    with pytest.raises(ValueError, match="prime number fields"):
-        code.reduce_logical_op(Pauli.X, 0)
+    logicals_full = codes.QuditCode.get_logical_ops(code)
+
+    print()
+    print(logicals_x)
+    print()
+    print(logicals_full[0])
 
     # successfullly construct and reduce logical operators in a code with "over-complete" checks
     dist = 4
@@ -265,6 +267,11 @@ def test_CSS_ops() -> None:
     assert code.get_code_params() == (dist**2, 2, dist)
     assert not any(np.count_nonzero(op) < dist for op in code.get_logical_ops(Pauli.X))
     assert not any(np.count_nonzero(op) < dist for op in code.get_logical_ops(Pauli.Z))
+
+    # reducing logical operator weight only supported for prime number fields
+    code = codes.HGPCode(codes.ClassicalCode.random(4, 2, field=4))
+    with pytest.raises(ValueError, match="prime number fields"):
+        code.reduce_logical_op(Pauli.X, 0)
 
 
 def test_distance_quantum() -> None:

--- a/qldpc/codes/common_test.py
+++ b/qldpc/codes/common_test.py
@@ -240,13 +240,10 @@ def test_CSS_code() -> None:
 def test_CSS_ops() -> None:
     """Logical operator construction for CSS codes."""
     code: codes.CSSCode
-    np.set_printoptions(linewidth=200)
 
-    # code = codes.HGPCode(codes.ClassicalCode.random(4, 2, field=3))
-    # code.get_random_logical_op(Pauli.X, ensure_nontrivial=False)
-    # code.get_random_logical_op(Pauli.X, ensure_nontrivial=True)
-
-    code = codes.SurfaceCode(3, 5, rotated=True)
+    code = codes.HGPCode(codes.ClassicalCode.random(4, 2, field=3))
+    code.get_random_logical_op(Pauli.X, ensure_nontrivial=False)
+    code.get_random_logical_op(Pauli.X, ensure_nontrivial=True)
 
     # test that logical operators are dual to each other and have trivial syndromes
     logicals = code.get_logical_ops()
@@ -259,32 +256,21 @@ def test_CSS_ops() -> None:
     # check that the logical operators agree with those computed by the QuditCode method
     full_logicals = codes.QuditCode.get_logical_ops(code)
     full_logicals_x, full_logicals_z = full_logicals[0], full_logicals[1]
-    # assert np.array_equal(full_logicals_x, np.hstack([logicals_x, np.zeros_like(logicals_x)]))
-    # assert np.array_equal(full_logicals_z, np.hstack([np.zeros_like(logicals_x), logicals_z]))
+    assert np.array_equal(full_logicals_x, np.hstack([logicals_x, np.zeros_like(logicals_x)]))
+    assert np.array_equal(full_logicals_z, np.hstack([np.zeros_like(logicals_x), logicals_z]))
 
-    print()
-    print(logicals_x[0].reshape(3, 5))
-    print()
-    print(logicals_z[0].reshape(3, 5))
-    print()
-    print(full_logicals_x[0].reshape(6, 5))
-    print()
-    print(full_logicals_z[0].reshape(6, 5))
-    # print()
-    # print(np.hstack([logicals_x, np.zeros_like(logicals_x)]))
+    # successfullly construct and reduce logical operators in a code with "over-complete" checks
+    dist = 4
+    code = codes.ToricCode(dist, rotated=True)
+    code.reduce_logical_ops()
+    assert code.get_code_params() == (dist**2, 2, dist)
+    assert not any(np.count_nonzero(op) < dist for op in code.get_logical_ops(Pauli.X))
+    assert not any(np.count_nonzero(op) < dist for op in code.get_logical_ops(Pauli.Z))
 
-    # # successfullly construct and reduce logical operators in a code with "over-complete" checks
-    # dist = 4
-    # code = codes.ToricCode(dist, rotated=True)
-    # code.reduce_logical_ops()
-    # assert code.get_code_params() == (dist**2, 2, dist)
-    # assert not any(np.count_nonzero(op) < dist for op in code.get_logical_ops(Pauli.X))
-    # assert not any(np.count_nonzero(op) < dist for op in code.get_logical_ops(Pauli.Z))
-
-    # # reducing logical operator weight only supported for prime number fields
-    # code = codes.HGPCode(codes.ClassicalCode.random(4, 2, field=4))
-    # with pytest.raises(ValueError, match="prime number fields"):
-    #     code.reduce_logical_op(Pauli.X, 0)
+    # reducing logical operator weight only supported for prime number fields
+    code = codes.HGPCode(codes.ClassicalCode.random(4, 2, field=4))
+    with pytest.raises(ValueError, match="prime number fields"):
+        code.reduce_logical_op(Pauli.X, 0)
 
 
 def test_distance_quantum() -> None:

--- a/qldpc/codes/common_test.py
+++ b/qldpc/codes/common_test.py
@@ -201,10 +201,13 @@ def test_deformations(num_qudits: int = 5, num_checks: int = 3, field: int = 3) 
 def test_qudit_ops() -> None:
     """Logical operator construction for Galois qudit codes."""
     code = codes.FiveQubitCode()
-    print()
-    print(code.dimension)
+    # code = codes.SteaneCode()
 
-    logical_ops = code.get_logical_ops()
+    logical_ops = codes.QuditCode.get_logical_ops(code)
+
+    print()
+    for op in logical_ops:
+        print(op)
 
 
 ####################################################################################################

--- a/qldpc/codes/common_test.py
+++ b/qldpc/codes/common_test.py
@@ -200,14 +200,17 @@ def test_deformations(num_qudits: int = 5, num_checks: int = 3, field: int = 3) 
 
 def test_qudit_ops() -> None:
     """Logical operator construction for Galois qudit codes."""
+    code: codes.QuditCode
+
     code = codes.FiveQubitCode()
-    # code = codes.SteaneCode()
+    logical_ops = code.get_logical_ops()
+    assert logical_ops.shape == (2, code.dimension, 2 * code.num_qudits)
+    assert np.array_equal(logical_ops[0, 0], [0, 0, 0, 0, 1, 1, 0, 0, 1, 0])
+    assert np.array_equal(logical_ops[1, 0], [0, 0, 0, 0, 0, 1, 1, 1, 1, 1])
+    assert code.get_logical_ops() is code._logical_ops
 
-    logical_ops = codes.QuditCode.get_logical_ops(code)
-
-    print()
-    for op in logical_ops:
-        print(op)
+    code = codes.QuditCode.from_stabilizers(*code.get_stabilizers(), "I I I I I")
+    assert np.array_equal(logical_ops, code.get_logical_ops())
 
 
 ####################################################################################################

--- a/qldpc/codes/quantum_test.py
+++ b/qldpc/codes/quantum_test.py
@@ -196,8 +196,8 @@ def test_twisted_XZZX(width: int = 3) -> None:
     zero_4 = np.zeros((mat_2.shape[0],) * 2, dtype=int)
     matrix = np.block(
         [
-            [zero_1, mat_1.T, -mat_2, zero_4],
             [mat_1, zero_2, zero_3, mat_2.T],
+            [zero_1, mat_1.T, -mat_2, zero_4],
         ]
     )
 


### PR DESCRIPTION
Also ensure consistency between `QuditCode.get_logical_ops` and `CSSCode.get_logical_ops` for CSS codes, which required changing CSS parity check matrix conventions, to put H_x "on top".  This convention is consistent with
- https://arxiv.org/abs/1202.0928
- http://quantum-journal.org/papers/q-2021-11-22-585/