### PR TITLE
Additions to the group PSL.

### DIFF
--- a/qldpc/abstract.py
+++ b/qldpc/abstract.py
@@ -901,7 +901,7 @@ class SpecialLinearGroup(Group):
             super()._init_from_group(comb.PermutationGroup(generators), field, lift)
 
         else:
-            # represent group members by how they permute elements of the group
+            # represent group members by how they permute elements of the group itself
             generating_mats = self.get_generating_mats(self.dimension, self.field.order)
             group = self.from_generating_mats(*generating_mats)
             super()._init_from_group(group)
@@ -915,7 +915,7 @@ class SpecialLinearGroup(Group):
     def get_generating_mats(
         cls, dimension: int, field: int | None = None
     ) -> tuple[galois.FieldArray, galois.FieldArray]:
-        """Generator matrices for the Special Linear group, based on arXiv:2201.09155."""
+        """Generating matrices for the Special Linear group, based on arXiv:2201.09155."""
         base_field = galois.GF(field or DEFAULT_FIELD_ORDER)
         gen_w = -base_field(np.diag(np.ones(dimension - 1, dtype=int), k=-1))
         gen_w[0, -1] = 1
@@ -999,7 +999,7 @@ class ProjectiveSpecialLinearGroup(Group):
             super()._init_from_group(comb.PermutationGroup(generators), field, lift)
 
         else:
-            # represent group members by how they permute elements of the group
+            # represent group members by how they permute elements of the group itself
             generating_mats = self.get_generating_mats(self.dimension, self.field.order)
             group = self.from_generating_mats(*generating_mats)
             super()._init_from_group(group)
@@ -1013,9 +1013,11 @@ class ProjectiveSpecialLinearGroup(Group):
     def get_generating_mats(
         cls, dimension: int, field: int | None = None
     ) -> tuple[galois.FieldArray, galois.FieldArray]:
-        """Generator matrices of the adjoint representation of PSL."""
+        """Generating matrices of PSL, constructed out of the generating matrices of SL."""
         base_field = galois.GF(field or DEFAULT_FIELD_ORDER)
         gen_x, gen_w = SpecialLinearGroup.get_generating_mats(dimension, field)
+        if base_field.order == 2:
+            return gen_x, gen_w
         return (
             base_field(np.kron(np.linalg.inv(gen_x), gen_x)),
             base_field(np.kron(np.linalg.inv(gen_w), gen_w)),

--- a/qldpc/abstract.py
+++ b/qldpc/abstract.py
@@ -998,6 +998,7 @@ class ProjectiveSpecialLinearGroup(Group):
             super()._init_from_group(comb.PermutationGroup(generators), field, lift)
 
         else:
+            # represent group members by how they permute elements of the group
             generating_mats = self.get_generating_mats(self.dimension, self.field.order)
             group = self.from_generating_mats(*generating_mats)
             super()._init_from_group(group)

--- a/qldpc/abstract.py
+++ b/qldpc/abstract.py
@@ -969,12 +969,12 @@ class ProjectiveSpecialLinearGroup(Group):
 
             # identify how the generators permute elements of the target space
             generators = []
-            for mat in SpecialLinearGroup.get_generating_mats(self.dimension, self.field.order):
+            for member in SpecialLinearGroup.get_generating_mats(self.dimension, self.field.order):
                 perm = np.empty(len(target_space), dtype=int)
                 for index, vec_bytes in enumerate(target_space):
                     vec = self.field(np.frombuffer(vec_bytes, dtype=np.uint8))
-                    next_orbit = [root * mat @ vec for root in roots]
-                    next_vec = [vec for vec in next_orbit if vec.tobytes() in target_space][0]
+                    next_orbit = [root * member @ vec for root in roots]
+                    next_vec = next((vec for vec in next_orbit if vec.tobytes() in target_space))
                     next_index = target_space.index(next_vec.tobytes())
                     perm[index] = next_index
                 generators.append(GroupMember(perm))

--- a/qldpc/abstract.py
+++ b/qldpc/abstract.py
@@ -959,7 +959,7 @@ class ProjectiveSpecialLinearGroup(Group):
             roots = [primitive_root**kk for kk in range(num_roots)]
 
             # Identify the target space that group members (as matrices) act on:
-            # the space of all nonzero vectors, modded out by roots of unity.
+            # all nonzero vectors, modded out by roots of unity.
             target_orbits = [
                 frozenset([(root * self.field(vec)).tobytes() for root in roots])
                 for vec in itertools.product(range(self.field.order), repeat=self.dimension)

--- a/qldpc/abstract.py
+++ b/qldpc/abstract.py
@@ -914,7 +914,7 @@ class SpecialLinearGroup(Group):
     @classmethod
     def get_generating_mats(
         cls, dimension: int, field: int | None = None
-    ) -> tuple[galois.FieldArray, ...]:
+    ) -> tuple[galois.FieldArray, galois.FieldArray]:
         """Generator matrices for the Special Linear group, based on arXiv:2201.09155."""
         base_field = galois.GF(field or DEFAULT_FIELD_ORDER)
         gen_w = -base_field(np.diag(np.ones(dimension - 1, dtype=int), k=-1))
@@ -1012,11 +1012,14 @@ class ProjectiveSpecialLinearGroup(Group):
     @classmethod
     def get_generating_mats(
         cls, dimension: int, field: int | None = None
-    ) -> tuple[galois.FieldArray, ...]:
+    ) -> tuple[galois.FieldArray, galois.FieldArray]:
         """Generator matrices of the adjoint representation of PSL."""
         base_field = galois.GF(field or DEFAULT_FIELD_ORDER)
-        generators_SL = SpecialLinearGroup.get_generating_mats(dimension, field)
-        return tuple(base_field(np.kron(np.linalg.inv(gen), gen)) for gen in generators_SL)
+        gen_x, gen_w = SpecialLinearGroup.get_generating_mats(dimension, field)
+        return (
+            base_field(np.kron(np.linalg.inv(gen_x), gen_x)),
+            base_field(np.kron(np.linalg.inv(gen_w), gen_w)),
+        )
 
     @classmethod
     def iter_mats(cls, dimension: int, field: int | None = None) -> Iterator[galois.FieldArray]:

--- a/qldpc/abstract.py
+++ b/qldpc/abstract.py
@@ -871,7 +871,7 @@ class SpecialLinearGroup(Group):
                 self.field(vec).tobytes()
                 for vec in itertools.product(range(self.field.order), repeat=self.dimension)
             ]
-            del target_space[0]  # remove the all-0 element
+            del target_space[0]  # remove the zero vector
 
             # identify how the generators permute elements of the target space
             generators = []
@@ -955,8 +955,8 @@ class ProjectiveSpecialLinearGroup(Group):
 
             # identify multiplicative roots of unity
             num_roots = math.gcd(self.dimension, self.field.order - 1)
-            base_root = self.field.primitive_element ** ((self.field.order - 1) // num_roots)
-            roots = [base_root**kk for kk in range(num_roots)]
+            primitive_root = self.field.primitive_element ** ((self.field.order - 1) // num_roots)
+            roots = [primitive_root**kk for kk in range(num_roots)]
 
             # Identify the target space that group members (as matrices) act on.
             # The target space is same as for SL, but modded out by roots of unity.
@@ -973,7 +973,7 @@ class ProjectiveSpecialLinearGroup(Group):
                 for index, vec_bytes in enumerate(target_space):
                     vec = self.field(np.frombuffer(vec_bytes, dtype=np.uint8))
                     next_orbit = [root * mat @ vec for root in roots]
-                    next_vec = [v for v in next_orbit if v.tobytes() in target_space][0]
+                    next_vec = [vec for vec in next_orbit if vec.tobytes() in target_space][0]
                     next_index = target_space.index(next_vec.tobytes())
                     perm[index] = next_index
                 generators.append(GroupMember(perm))

--- a/qldpc/abstract.py
+++ b/qldpc/abstract.py
@@ -866,7 +866,7 @@ class SpecialLinearGroup(Group):
             # Construct a linear representation of this group, in which group elements permute
             # elements of the vector space that the generating matrices act on.
 
-            # identify the target space that group members (as matrices) act on
+            # identify the target space that group members (as matrices) act on: all nonzero vectors
             target_space = [
                 self.field(vec).tobytes()
                 for vec in itertools.product(range(self.field.order), repeat=self.dimension)
@@ -958,8 +958,8 @@ class ProjectiveSpecialLinearGroup(Group):
             primitive_root = self.field.primitive_element ** ((self.field.order - 1) // num_roots)
             roots = [primitive_root**kk for kk in range(num_roots)]
 
-            # Identify the target space that group members (as matrices) act on.
-            # The target space is same as for SL, but modded out by roots of unity.
+            # Identify the target space that group members (as matrices) act on:
+            # the space of all nonzero vectors, modded out by roots of unity.
             target_orbits = [
                 frozenset([(root * self.field(vec)).tobytes() for root in roots])
                 for vec in itertools.product(range(self.field.order), repeat=self.dimension)
@@ -967,6 +967,7 @@ class ProjectiveSpecialLinearGroup(Group):
             del target_orbits[0]  # remove the orbit of the zero vector
             target_space = [next(iter(orbit)) for orbit in set(target_orbits)]
 
+            # identify how the generators permute elements of the target space
             generators = []
             for mat in SpecialLinearGroup.get_generating_mats(self.dimension, self.field.order):
                 perm = np.empty(len(target_space), dtype=int)

--- a/qldpc/abstract.py
+++ b/qldpc/abstract.py
@@ -979,6 +979,7 @@ class ProjectiveSpecialLinearGroup(Group):
                     perm[index] = next_index
                 generators.append(GroupMember(perm))
 
+            # construct a lift identical to that for the linear representation of SL
             def lift(member: GroupMember) -> npt.NDArray[np.int_]:
                 """Lift a group member to a square matrix.
 

--- a/qldpc/abstract.py
+++ b/qldpc/abstract.py
@@ -1017,7 +1017,7 @@ class ProjectiveSpecialLinearGroup(Group):
     def _get_generating_mats(
         cls, dimension: int, field: int | None = None
     ) -> tuple[galois.FieldArray, ...]:
-        """Generators of the adjoint representation of PSL."""
+        """Generator matrices of the adjoint representation of PSL."""
         base_field = galois.GF(field or DEFAULT_FIELD_ORDER)
         generators_SL = SpecialLinearGroup._get_generating_mats(dimension, field)
         return tuple(base_field(np.kron(np.linalg.inv(gen), gen)) for gen in generators_SL)

--- a/qldpc/abstract.py
+++ b/qldpc/abstract.py
@@ -940,7 +940,15 @@ class SpecialLinearGroup(Group):
 
 
 class ProjectiveSpecialLinearGroup(Group):
-    """Projective special linear group (PSL = SL/center)."""
+    """Projective special linear group (PSL = SL/center).
+
+    Here "center" is the subgroup of SL that commutes with all elements of SL.  Specifically, every
+    element in the center of SL is a scalar multiple of the identity matrix I.  In the case of
+    SL(d,q) (d×d matrices over F_q with determinant 1), the determinant of scalar*I is scalar**d,
+    which is only contained in SL(d,q) if scalar**d == 1.
+
+    Altogether, we construct PSL(d,q) by SL(d,q) mod [d-th roots of unity over F_q].
+    """
 
     _dimension: int
 

--- a/qldpc/abstract_test.py
+++ b/qldpc/abstract_test.py
@@ -170,7 +170,7 @@ def test_SL(field: int = 3) -> None:
         assert np.array_equal(group.lift(gens[0]), mats[0])
         assert np.array_equal(group.lift(gens[1]), mats[1].view(np.ndarray))
 
-    assert abstract.SL(2,field).order == field*(field**2-1)
+    assert abstract.SL(2, field).order == field * (field**2 - 1)
     assert len(list(abstract.SL.iter_mats(2, 2))) == abstract.SL(2, 2).order
 
     # cover representation with different generators
@@ -184,13 +184,14 @@ def test_PSL(field: int = 3) -> None:
         PSL22 = abstract.PSL(2, 2, linear_rep=linear_rep)
         SL2q = abstract.SL(2, field=field, linear_rep=linear_rep)
         PSL2q = abstract.PSL(2, field=field, linear_rep=linear_rep)
-        assert abstract.Group(SL22.generators).to_sympy().equals(abstract.Group(PSL22.generators).to_sympy())
+        assert (
+            abstract.Group(SL22.generators)
+            .to_sympy()
+            .equals(abstract.Group(PSL22.generators).to_sympy())
+        )
         assert PSL22.dimension == 2
         assert len(list(abstract.PSL.iter_mats(2, 2))) == PSL22.order
-        assert PSL2q.order == SL2q.order // galois.gcd(2,field-1)
-
-    #with pytest.raises(ValueError, match="not yet supported"):
-    #    abstract.PSL(3, 3)
+        assert PSL2q.order == SL2q.order // galois.gcd(2, field - 1)
 
 
 def test_small_group() -> None:

--- a/qldpc/abstract_test.py
+++ b/qldpc/abstract_test.py
@@ -162,7 +162,7 @@ def test_random_symmetric_subset() -> None:
         group.random_symmetric_subset(size=0)
 
 
-@pytest.mark.parametrize("dimension,field", [(2, 2), (2, 3), (3, 2)])
+@pytest.mark.parametrize("dimension,field", [(2, 2), (2, 4), (3, 2)])
 @pytest.mark.parametrize("linear_rep", [False, True])
 def test_SL(dimension: int, field: int, linear_rep: bool) -> None:
     """Special linear group."""
@@ -175,9 +175,6 @@ def test_SL(dimension: int, field: int, linear_rep: bool) -> None:
     gen_mats = group.get_generating_mats(dimension, field)
     assert np.array_equal(group.lift(gens[0]), gen_mats[0])
     assert np.array_equal(group.lift(gens[1]), gen_mats[1])
-
-    # # cover representation with different generators
-    # assert len(abstract.SL(2, 5).generators) == 2
 
 
 @pytest.mark.parametrize("dimension,field", [(2, 2), (2, 3), (3, 2)])

--- a/qldpc/abstract_test.py
+++ b/qldpc/abstract_test.py
@@ -182,7 +182,7 @@ def test_SL(dimension: int, field: int, linear_rep: bool) -> None:
 def test_PSL(dimension: int, field: int, linear_rep: bool) -> None:
     """Projective special linear group."""
     order_SL = np.prod([field**dimension - field**jj for jj in range(dimension)]) // (field - 1)
-    order = order_SL // math.gcd(2, field - 1)
+    order = order_SL // math.gcd(dimension, field - 1)
     group = abstract.PSL(dimension, field, linear_rep=linear_rep)
     mats = tuple(abstract.PSL.iter_mats(dimension, field))
     assert group.order == len(mats) == order

--- a/qldpc/abstract_test.py
+++ b/qldpc/abstract_test.py
@@ -15,6 +15,7 @@
    limitations under the License.
 """
 
+import math
 import unittest.mock
 
 import galois
@@ -166,12 +167,12 @@ def test_SL(field: int = 3) -> None:
     for linear_rep in [False, True]:
         group = abstract.SL(2, field=field, linear_rep=linear_rep)
         gens = group.generators
-        mats = group.get_generator_mats()
+        mats = group.get_generating_mats()
         assert np.array_equal(group.lift(gens[0]), mats[0])
         assert np.array_equal(group.lift(gens[1]), mats[1].view(np.ndarray))
 
     assert abstract.SL(2, field).order == field * (field**2 - 1)
-    assert len(list(abstract.SL.iter_mats(2, 2))) == abstract.SL(2, 2).order
+    assert len(list(abstract.SL._iter_mats(2, 2))) == abstract.SL(2, 2).order
 
     # cover representation with different generators
     assert len(abstract.SL(2, 5).generators) == 2
@@ -185,13 +186,13 @@ def test_PSL(field: int = 3) -> None:
         SL2q = abstract.SL(2, field=field, linear_rep=linear_rep)
         PSL2q = abstract.PSL(2, field=field, linear_rep=linear_rep)
         assert (
-            abstract.Group(SL22.generators)
+            abstract.Group(*SL22.generators)
             .to_sympy()
-            .equals(abstract.Group(PSL22.generators).to_sympy())
+            .equals(abstract.Group(*PSL22.generators).to_sympy())
         )
         assert PSL22.dimension == 2
-        assert len(list(abstract.PSL.iter_mats(2, 2))) == PSL22.order
-        assert PSL2q.order == SL2q.order // galois.gcd(2, field - 1)
+        assert len(list(abstract.PSL._iter_mats(2, 2))) == PSL22.order
+        assert PSL2q.order == SL2q.order // math.gcd(2, field - 1)
 
 
 def test_small_group() -> None:

--- a/qldpc/abstract_test.py
+++ b/qldpc/abstract_test.py
@@ -187,6 +187,12 @@ def test_PSL(dimension: int, field: int, linear_rep: bool) -> None:
     mats = tuple(abstract.PSL.iter_mats(dimension, field))
     assert group.order == len(mats) == order
 
+    if field == 2:
+        gens = group.generators
+        gen_mats = group.get_generating_mats(dimension, field)
+        assert np.array_equal(group.lift(gens[0]), gen_mats[0])
+        assert np.array_equal(group.lift(gens[1]), gen_mats[1])
+
 
 def test_small_group() -> None:
     """Groups indexed by the GAP computer algebra system."""

--- a/qldpc/abstract_test.py
+++ b/qldpc/abstract_test.py
@@ -190,10 +190,6 @@ def test_PSL(dimension: int, field: int, linear_rep: bool) -> None:
     mats = tuple(abstract.PSL.iter_mats(dimension, field))
     assert group.order == len(mats) == order
 
-    if dimension == field == 2:
-        group_SL = abstract.SL(dimension, field, linear_rep=linear_rep)
-        assert group.to_sympy().equals(group_SL.to_sympy())
-
 
 def test_small_group() -> None:
     """Groups indexed by the GAP computer algebra system."""

--- a/qldpc/abstract_test.py
+++ b/qldpc/abstract_test.py
@@ -181,9 +181,9 @@ def test_SL(dimension: int, field: int, linear_rep: bool) -> None:
 @pytest.mark.parametrize("linear_rep", [False, True])
 def test_PSL(dimension: int, field: int, linear_rep: bool) -> None:
     """Projective special linear group."""
+    group = abstract.PSL(dimension, field, linear_rep=linear_rep)
     order_SL = np.prod([field**dimension - field**jj for jj in range(dimension)]) // (field - 1)
     order = order_SL // math.gcd(dimension, field - 1)
-    group = abstract.PSL(dimension, field, linear_rep=linear_rep)
     mats = tuple(abstract.PSL.iter_mats(dimension, field))
     assert group.order == len(mats) == order
 

--- a/qldpc/abstract_test.py
+++ b/qldpc/abstract_test.py
@@ -162,17 +162,17 @@ def test_random_symmetric_subset() -> None:
         group.random_symmetric_subset(size=0)
 
 
-def test_SL(field: int = 3) -> None:
+def test_SL(dimension: int = 2, field: int = 3) -> None:
     """Special linear group."""
     for linear_rep in [False, True]:
-        group = abstract.SL(2, field=field, linear_rep=linear_rep)
+        group = abstract.SL(dimension, field=field, linear_rep=linear_rep)
         gens = group.generators
-        mats = group.get_generating_mats()
+        mats = group.get_generating_mats(dimension, field)
         assert np.array_equal(group.lift(gens[0]), mats[0])
         assert np.array_equal(group.lift(gens[1]), mats[1].view(np.ndarray))
 
     assert abstract.SL(2, field).order == field * (field**2 - 1)
-    assert len(list(abstract.SL._iter_mats(2, 2))) == abstract.SL(2, 2).order
+    assert len(list(abstract.SL.iter_mats(2, 2))) == abstract.SL(2, 2).order
 
     # cover representation with different generators
     assert len(abstract.SL(2, 5).generators) == 2
@@ -191,7 +191,7 @@ def test_PSL(field: int = 3) -> None:
             .equals(abstract.Group(*PSL22.generators).to_sympy())
         )
         assert PSL22.dimension == 2
-        assert len(list(abstract.PSL._iter_mats(2, 2))) == PSL22.order
+        assert len(list(abstract.PSL.iter_mats(2, 2))) == PSL22.order
         assert PSL2q.order == SL2q.order // math.gcd(2, field - 1)
 
 


### PR DESCRIPTION
The `ProjectiveSpecialLinearGroup` class works in any dimension `2, 3, 4, ...`:

- If `linear_rep == True `, the constructor uses a permutation representation acting on cosets of the standard representation of the `SpecialLinearGroup`.

- If `linear_rep == False`, the constructor uses the adjoint representation.