### PR TITLE
Rename generalized bicycle code (GBCode) to two-block code (TBCode)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Notable features include:
   - `CSSCode.get_logical_ops`: method to construct a complete basis of nontrivial logical operators for a `CSSCode`.
   - `CSSCode.get_distance`: method to compute the code distance (i.e., the minimum weight of a nontrivial logical operator) of a `CSSCode`.  Includes options for computing the exact code distance by brute force, as well as an estimate (or upper bound) with the method of [arXiv:2308.07915](https://arxiv.org/abs/2308.07915).
   - Includes options for applying local Hadamard transformations, which is useful for tailoring a `CSSCode` to biased noise (see [arXiv:2202.01702](https://arxiv.org/abs/2202.01702)).  Options to apply more general Clifford code deformations are pending.
-- `GBCode`: class for constructing [generalized bicycle codes](https://errorcorrectionzoo.org/c/generalized_bicycle), as described in [arXiv:1904.02703](https://arxiv.org/abs/1904.02703).
+- `TBCode`: class for constructing [two-block quantum codes](https://errorcorrectionzoo.org/c/two_block_quantum).
 - `BBCode`: class for constructing the [bivariate bicycle codes](https://errorcorrectionzoo.org/c/quantum_quasi_cyclic) in [arXiv:2308.07915](https://arxiv.org/abs/2308.07915) and [arXiv:2311.16980](https://arxiv.org/abs/2311.16980).
   - Includes methods to identify "toric layouts" of a `BBCode`, in which the code looks like a toric code augmented by some long-distance checks, as in discussed in [arXiv:2308.07915](https://arxiv.org/abs/2308.07915).
 - `HGPCode`: class for constructing [hypergraph product codes](https://errorcorrectionzoo.org/c/hypergraph_product) out of two `ClassicalCode`s.

--- a/qldpc/codes/__init__.py
+++ b/qldpc/codes/__init__.py
@@ -11,18 +11,17 @@ from .common import ClassicalCode, CSSCode, QuditCode
 from .quantum import (
     BBCode,
     FiveQubitCode,
-    GBCode,
     GeneralizedSurfaceCode,
     HGPCode,
     LPCode,
     QTCode,
     SteaneCode,
     SurfaceCode,
+    TBCode,
     ToricCode,
 )
 
 __all__ = [
-    "BBCode",
     "BCHCode",
     "HammingCode",
     "ReedMullerCode",
@@ -33,13 +32,14 @@ __all__ = [
     "ClassicalCode",
     "CSSCode",
     "QuditCode",
+    "BBCode",
     "FiveQubitCode",
-    "GBCode",
     "GeneralizedSurfaceCode",
     "HGPCode",
     "LPCode",
     "QTCode",
     "SteaneCode",
     "SurfaceCode",
+    "TBCode",
     "ToricCode",
 ]

--- a/qldpc/codes/quantum.py
+++ b/qldpc/codes/quantum.py
@@ -709,7 +709,7 @@ class LPCode(CSSCode):
         two-block group-algebra code).  If the base group of the protographs is a cyclic group, the
         resulting lifted product code is a generalized bicycle code.
     - A lifted product code with protographs whose entries get lifted to 1×1 matrices is a
-        hypergraph product code of the lifted protographs.
+        hypergraph product code built from the lifted protographs.
     - One way to get an LPCode: take a classical code with parity check matrix H and multiply it by
         a diagonal matrix D = diag(a_1, a_2, ... a_n), where all {a_j} are elements of a group
         algebra.  The protograph P = H @ D can then be used for one of the protographs of an LPCode.

--- a/qldpc/codes/quantum.py
+++ b/qldpc/codes/quantum.py
@@ -64,17 +64,16 @@ class SteaneCode(CSSCode):
 # bicycle codes
 
 
-class GBCode(CSSCode):
-    """Generalized bicycle (GB) code.
+class TBCode(CSSCode):
+    """Two-block (TB) code.
 
-    A GBCode code is built out of two matrices A and B, which are combined as
+    A TBCode code is built out of two matrices A and B, which are combined as
     - matrix_x = [A, B], and
     - matrix_z = [B.T, -A.T],
     to form the parity check matrices of a CSSCode.  If A and B commute, the parity check matrices
     matrix_x and matrix_z satisfy the requirements of a CSSCode.
 
-    References:
-    - https://arxiv.org/abs/2012.04068
+    Two-block codes constructed out of circulant matrices are known as generalized bicycle codes.
     """
 
     def __init__(
@@ -87,11 +86,11 @@ class GBCode(CSSCode):
         promise_balanced_codes: bool = False,
         skip_validation: bool = False,
     ) -> None:
-        """Construct a generalized bicycle code."""
+        """Construct a two-block quantum code."""
         matrix_a = ClassicalCode(matrix_a, field).matrix
         matrix_b = ClassicalCode(matrix_b, field).matrix
         if not skip_validation and not np.array_equal(matrix_a @ matrix_b, matrix_b @ matrix_a):
-            raise ValueError("The matrices provided for this GBCode are incompatible")
+            raise ValueError("The matrices provided for this TBCode are incompatible")
 
         matrix_x = np.block([matrix_a, matrix_b])
         matrix_z = np.block([matrix_b.T, -matrix_a.T])
@@ -111,7 +110,7 @@ BBCodePlaquetteMap = Callable[[int | PauliXZ], npt.NDArray[np.int_]]
 
 
 # TODO: example notebook featuring this code
-class BBCode(GBCode):
+class BBCode(TBCode):
     """Bivariate bicycle codes from arXiv:2308.07915.
 
     A bivariate bicycle code is a CSS code with subcode parity check matrices
@@ -186,7 +185,7 @@ class BBCode(GBCode):
         # build defining matrices of a generalized bicycle code
         matrix_a = self.eval(self.poly_a).lift()
         matrix_b = self.eval(self.poly_b).lift()
-        GBCode.__init__(
+        TBCode.__init__(
             self,
             matrix_a,
             matrix_b,
@@ -706,7 +705,8 @@ class LPCode(CSSCode):
     this is called "lifting" the protograph.
 
     Notes:
-    - A lifted product code with protographs of size 1×1 is a generalized bicycle code.
+    - A lifted product code with protographs of size 1×1 is a two-block code (more specifically, a
+        two-block group-algebra code).
     - A lifted product code with protographs whose entries get lifted to 1×1 matrices is a
         hypergraph product code of the lifted protographs.
     - One way to get an LPCode: take a classical code with parity check matrix H and multiply it by
@@ -717,6 +717,7 @@ class LPCode(CSSCode):
     - https://errorcorrectionzoo.org/c/lifted_product
     - https://arxiv.org/abs/2202.01702
     - https://arxiv.org/abs/2012.04068
+    - https://arxiv.org/abs/2306.16400
     """
 
     def __init__(

--- a/qldpc/codes/quantum.py
+++ b/qldpc/codes/quantum.py
@@ -706,7 +706,8 @@ class LPCode(CSSCode):
 
     Notes:
     - A lifted product code with protographs of size 1×1 is a two-block code (more specifically, a
-        two-block group-algebra code).
+        two-block group-algebra code).  If the base group of the protographs is a cyclic group, the
+        resulting lifted product code is a generalized bicycle code.
     - A lifted product code with protographs whose entries get lifted to 1×1 matrices is a
         hypergraph product code of the lifted protographs.
     - One way to get an LPCode: take a classical code with parity check matrix H and multiply it by

--- a/qldpc/codes/quantum_test.py
+++ b/qldpc/codes/quantum_test.py
@@ -37,11 +37,11 @@ def test_small_codes() -> None:
 
 
 def test_GB_code_error() -> None:
-    """Raise error when trying to construct incompatible generalized bicycle codes."""
+    """Raise error when trying to construct incompatible two-block codes."""
     matrix_a = [[1, 0], [0, 2]]
     matrix_b = [[0, 1], [1, 0]]
     with pytest.raises(ValueError, match="incompatible"):
-        codes.GBCode(matrix_a, matrix_b, field=3)
+        codes.TBCode(matrix_a, matrix_b, field=3)
 
 
 def test_cyclic_codes() -> None:


### PR DESCRIPTION
`GBCode`s are a special case of `TBCode`s.  The construction implemented in this library was in fact that of a `TBCode`.