### PR TITLE
Change conventions for `CSSCode.matrix`

### DIFF
--- a/qldpc/codes/common.py
+++ b/qldpc/codes/common.py
@@ -665,14 +665,14 @@ class QuditCode(AbstractCode):
         Logical operators are represented by a three-dimensional array `logical_ops` with dimensions
         `(2, k, 2 * n)`, where `k` and `n` are respectively the numbers of logical and physical
         qudits in this code.  The first axis is used to keep track of conjugate pairs of logical
-        operators.  The last axis is "doubled" to indicate whether a physical qudit is addressed by
-        a physical X-type or Z-type operator.
+        operators.  The last axis is "doubled" to indicate the support of physical X-type vs. Z-type
+        operators.
 
-        Specifically, `logical_ops[0, :, :]` are "logical X-type" operators that address at least
-        one physical qudit by a physical X-type operator, and may additionally address physical
-        qudits by physical Z-type operators.  `logical_ops[1, :, :]` are logical Z-type operators
-        that -- due to the way that logical operators are constructed here -- only address physical
-        qudits by physical Z-type operators.
+        Specifically, each row of `logical_ops[0, :, :]` is logical X-type operator that -- due to
+        the way that logical operators are constructed here -- only addresses physical qudits by
+        physical X-type operators.  Each row of `logical_ops[1, :, :]` is a logical Z-type operator
+        that addresses at least one physical qudit by a physical Z-type operator, and may
+        additionally address physical qudits by physical X-type operators.
 
         For example, if `logical_ops[p, r, j] == 1` for `j < n` (`j >= n`), then the `p`-type
         logical operator for logical qudit `r` addresses physical qudit `j` with a physical X-type

--- a/qldpc/codes/common.py
+++ b/qldpc/codes/common.py
@@ -570,8 +570,8 @@ class QuditCode(AbstractCode):
 
     def get_weight(self) -> int:
         """Compute the weight of the largest check."""
-        matrix_z = self.matrix[:, : self.num_qudits].view(np.ndarray)
         matrix_x = self.matrix[:, self.num_qudits :].view(np.ndarray)
+        matrix_z = self.matrix[:, : self.num_qudits].view(np.ndarray)
         matrix = matrix_x + matrix_z  # nonzero wherever a check addresses a qudit
         return max(np.count_nonzero(row) for row in matrix)
 

--- a/qldpc/codes/common.py
+++ b/qldpc/codes/common.py
@@ -504,7 +504,7 @@ class QuditCode(AbstractCode):
     """Quantum stabilizer code for Galois qudits, with dimension q = p^m for prime p and integer m.
 
     The parity check matrix of a QuditCode has dimensions (num_checks, 2 * num_qudits), and can be
-    written as a block matrix in the form H = [H_x|H_z].  Each block has num_qudits columns.
+    written as a block matrix in the form H = [H_z|H_x].  Each block has num_qudits columns.
 
     The entries H_x[c, d] = r_x and H_z[c, d] = r_z iff check c addresses qudit d with the operator
     X(r_x) * Z(r_z), where r_x, r_z range over the base field, and X(r), Z(r) are generalized Pauli

--- a/qldpc/codes/common.py
+++ b/qldpc/codes/common.py
@@ -619,8 +619,8 @@ class QuditCode(AbstractCode):
         for check in range(self.num_checks):
             ops = []
             for qudit in range(self.num_qudits):
-                val_x = matrix[check, 1, qudit]
-                val_z = matrix[check, 0, qudit]
+                val_x = matrix[check, ~Pauli.X, qudit]
+                val_z = matrix[check, ~Pauli.Z, qudit]
                 vals_xz = (val_x, val_z)
                 if self.field.order == 2:
                     ops.append(str(Pauli(vals_xz)))

--- a/qldpc/codes/common_test.py
+++ b/qldpc/codes/common_test.py
@@ -195,7 +195,7 @@ def test_deformations(num_qudits: int = 5, num_checks: int = 3, field: int = 3) 
     transformed_matrix = transformed_matrix.reshape(num_checks, 2, num_qudits)
     for node_check, node_qubit, data in code.graph.edges(data=True):
         vals = data[QuditOperator].value
-        assert tuple(transformed_matrix[node_check.index, :, node_qubit.index]) == vals
+        assert tuple(transformed_matrix[node_check.index, :, node_qubit.index]) == vals[::-1]
 
 
 def test_qudit_ops() -> None:
@@ -205,8 +205,8 @@ def test_qudit_ops() -> None:
     code = codes.FiveQubitCode()
     logical_ops = code.get_logical_ops()
     assert logical_ops.shape == (2, code.dimension, 2 * code.num_qudits)
-    assert np.array_equal(logical_ops[0, 0], [1, 1, 1, 1, 1, 0, 0, 0, 0, 0])
-    assert np.array_equal(logical_ops[1, 0], [1, 0, 0, 1, 0, 0, 0, 0, 0, 1])
+    assert np.array_equal(logical_ops[0], [[1, 1, 1, 1, 1, 0, 0, 0, 0, 0]])
+    assert np.array_equal(logical_ops[1], [[0, 1, 1, 0, 0, 0, 0, 0, 0, 1]])
     assert code.get_logical_ops() is code._full_logical_ops
 
     code = codes.QuditCode.from_stabilizers(*code.get_stabilizers(), "I I I I I")

--- a/qldpc/codes/common_test.py
+++ b/qldpc/codes/common_test.py
@@ -205,8 +205,8 @@ def test_qudit_ops() -> None:
     code = codes.FiveQubitCode()
     logical_ops = code.get_logical_ops()
     assert logical_ops.shape == (2, code.dimension, 2 * code.num_qudits)
-    assert np.array_equal(logical_ops[0, 0], [0, 0, 0, 0, 1, 1, 0, 0, 1, 0])
-    assert np.array_equal(logical_ops[1, 0], [0, 0, 0, 0, 0, 1, 1, 1, 1, 1])
+    assert np.array_equal(logical_ops[0, 0], [1, 1, 1, 1, 1, 0, 0, 0, 0, 0])
+    assert np.array_equal(logical_ops[1, 0], [1, 0, 0, 1, 0, 0, 0, 0, 0, 1])
     assert code.get_logical_ops() is code._full_logical_ops
 
     code = codes.QuditCode.from_stabilizers(*code.get_stabilizers(), "I I I I I")
@@ -257,6 +257,8 @@ def test_CSS_ops() -> None:
     full_logicals_x, full_logicals_z = full_logicals[0], full_logicals[1]
     assert np.array_equal(full_logicals_x, np.hstack([logicals_x, np.zeros_like(logicals_x)]))
     assert np.array_equal(full_logicals_z, np.hstack([np.zeros_like(logicals_x), logicals_z]))
+    assert not np.any(code.matrix @ full_logicals_x.T)
+    assert not np.any(code.matrix @ full_logicals_z.T)
 
     # successfullly construct and reduce logical operators in a code with "over-complete" checks
     dist = 4

--- a/qldpc/codes/quantum.py
+++ b/qldpc/codes/quantum.py
@@ -678,20 +678,34 @@ class HGPCode(CSSCode):
 
     @classmethod
     def get_product_node_map(
-        cls, nodes_a: Collection[Node], nodes_b: Collection[Node]
+        cls, nodes_a: Sequence[Node], nodes_b: Sequence[Node]
     ) -> dict[tuple[Node, Node], Node]:
         """Map (dictionary) that re-labels nodes in the hypergraph product of two codes."""
-        index_qudit = 0
-        index_check = 0
+        num_qudits_a = sum(node.is_data for node in nodes_a)
+        num_qudits_b = sum(node.is_data for node in nodes_b)
+        num_checks_a = len(nodes_a) - num_qudits_a
+        num_checks_b = len(nodes_b) - num_qudits_b
+        sector_shapes = [
+            [(num_qudits_a, num_qudits_b), (num_qudits_a, num_checks_b)],
+            [(num_checks_a, num_qudits_b), (num_checks_a, num_checks_b)],
+        ]
+
         node_map = {}
         for node_a, node_b in itertools.product(sorted(nodes_a), sorted(nodes_b)):
-            if cls.get_sector(node_a, node_b) in [(0, 0), (1, 1)]:
-                node = Node(index=index_qudit, is_data=True)
-                index_qudit += 1
-            else:
-                node = Node(index=index_check, is_data=False)
-                index_check += 1
-            node_map[node_a, node_b] = node
+            # identify sector and whether this is a data vs. check qudit
+            sector = cls.get_sector(node_a, node_b)
+            is_data = sector in [(0, 0), (1, 1)]
+
+            # identify node index
+            sector_shape = sector_shapes[sector[0]][sector[1]]
+            index = int(np.ravel_multi_index((node_a.index, node_b.index), sector_shape))
+            if sector == (1, 1):
+                index += num_qudits_a * num_qudits_b
+            if sector == (0, 1):
+                index += num_checks_a * num_qudits_b
+
+            node_map[node_a, node_b] = Node(index=index, is_data=is_data)
+
         return node_map
 
 

--- a/qldpc/codes/quantum_test.py
+++ b/qldpc/codes/quantum_test.py
@@ -196,8 +196,8 @@ def test_twisted_XZZX(width: int = 3) -> None:
     zero_4 = np.zeros((mat_2.shape[0],) * 2, dtype=int)
     matrix = np.block(
         [
-            [zero_1, mat_1.T, -mat_2, zero_4],
-            [mat_1, zero_2, zero_3, mat_2.T],
+            [zero_3, mat_2.T, mat_1, zero_2],
+            [-mat_2, zero_4, zero_1, mat_1.T],
         ]
     )
 


### PR DESCRIPTION
(... yet again)

The motivation here is be consistent in having `n`-qubit operators represented by `2n`-bit strings in which the first (last) `n` bits indicate the support of X-type (Z-type) operators.  In order to extract, say, `syndrome = parity_check_matrix @ error` for a `n`-qubit error operator, we therefore need the rows of the parity check matrix to look like `[z_support|x_support]`.