### PR TITLE
Change logical operator format

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ filterwarnings = [
 
 [tool.ruff]
 line-length = 100
+lint.extend-select = ["I"]
 
 [tool.black]
 color = true

--- a/qldpc/codes/common.py
+++ b/qldpc/codes/common.py
@@ -1118,8 +1118,7 @@ class CSSCode(QuditCode):
 
         # if requested, retrieve logical operators of one type only
         if pauli is not None:
-            shape = (self.dimension, 2, self.num_qudits)
-            return self.get_logical_ops()
+            return self.get_logical_ops()[pauli]
 
         # memoize manually because other methods may modify the logical operators computed here
         if self._logical_ops is not None:
@@ -1218,8 +1217,13 @@ class CSSCode(QuditCode):
         assert 0 <= logical_index < self.dimension
 
         # effective check matrix = syndromes and other logical operators
-        code = self.code_z if pauli == Pauli.X else self.code_x
-        all_dual_ops = self.get_logical_ops(~pauli)  # type:ignore[arg-type]
+        if pauli == Pauli.X:
+            code = self.code_z
+            nonzero_dual_section = slice(self.num_qudits, 2 * self.num_qudits)
+        else:
+            code = self.code_x
+            nonzero_dual_section = slice(self.num_qudits)
+        all_dual_ops = self.get_logical_ops()[~pauli, :, nonzero_dual_section]
         effective_check_matrix = np.vstack([code.matrix, all_dual_ops]).view(np.ndarray)
         dual_op_index = code.num_checks + logical_index
 

--- a/qldpc/codes/common.py
+++ b/qldpc/codes/common.py
@@ -678,6 +678,9 @@ class QuditCode(AbstractCode):
         logical operator for logical qudit `r` addresses physical qudit `j` with a physical X-type
         (Z-type) operator.
 
+        If passed a pauli operator (Pauli.X or Pauli.Z), return the two-dimensional array of logical
+        operators of that type.
+
         Logical operators are constructed using the method described in Section 4.1 of Gottesman's
         thesis (arXiv:9705052), slightly modified for qudits.
         """
@@ -1107,9 +1110,8 @@ class CSSCode(QuditCode):
         (Z-type) operator.  The fact that logical operators come in conjugate pairs means that
         `logical_ops(Pauli.X)[r, :] @ logical_ops(Pauli.Z)[s, :] == int(r == s)`.
 
-        If passed a pauli operator (Pauli.X or Pauli.Z), return the two-dimensional array with
-        dimensions `(k, n)`, in which `logical_ops[r, :]` indicates the support of the purely-X-type
-        or purely-Z-type logical operator on qudit `r`.
+        If passed a pauli operator (Pauli.X or Pauli.Z), return the two-dimensional array of logical
+        operators of that type.
 
         Logical operators are constructed using the method described in Section 4.1 of Gottesman's
         thesis (arXiv:9705052), slightly modified for qudits.

--- a/qldpc/codes/common_test.py
+++ b/qldpc/codes/common_test.py
@@ -209,7 +209,7 @@ def test_qudit_ops() -> None:
     assert logical_ops.shape == (2, code.dimension, 2 * code.num_qudits)
     assert np.array_equal(logical_ops[0], [[1, 1, 1, 1, 1, 0, 0, 0, 0, 0]])
     assert np.array_equal(logical_ops[1], [[0, 1, 1, 0, 0, 0, 0, 0, 0, 1]])
-    assert code.get_logical_ops() is code._full_logical_ops
+    assert code.get_logical_ops() is code._logical_ops
 
     code = codes.QuditCode.from_stabilizers(*code.get_stabilizers(), "I I I I I")
     assert np.array_equal(logical_ops, code.get_logical_ops())

--- a/qldpc/codes/common_test.py
+++ b/qldpc/codes/common_test.py
@@ -164,7 +164,9 @@ def test_qubit_code(num_qubits: int = 5, num_checks: int = 3) -> None:
 
 def test_qudit_code() -> None:
     """Miscellaneous qudit code tests and coverage."""
-    assert codes.FiveQubitCode().dimension == 1
+    code = codes.FiveQubitCode()
+    assert code.dimension == 1
+    assert code.get_logical_ops(Pauli.X).shape == code.get_logical_ops(Pauli.Z).shape
 
 
 @pytest.mark.parametrize("field", [2, 3])

--- a/qldpc/codes/common_test.py
+++ b/qldpc/codes/common_test.py
@@ -247,20 +247,19 @@ def test_CSS_ops() -> None:
     code.get_random_logical_op(Pauli.X, ensure_nontrivial=False)
     code.get_random_logical_op(Pauli.X, ensure_nontrivial=True)
 
-    # test that logical operators are dual to each other and have trivial syndromes
-    logicals_x, logicals_z = code.get_logical_ops(Pauli.X), code.get_logical_ops(Pauli.Z)
-    assert np.array_equal(logicals_x @ logicals_z.T, np.eye(code.dimension, dtype=int))
-    assert not np.any(code.matrix_z @ logicals_x.T)
-    assert not np.any(code.matrix_x @ logicals_z.T)
+    # test that logical operators have trivial syndromes
+    logicals_x = code.get_logical_ops(Pauli.X)
+    logicals_z = code.get_logical_ops(Pauli.Z)
+    assert not np.any(logicals_x[:, code.num_qudits :])
+    assert not np.any(logicals_z[:, : code.num_qudits])
+    assert not np.any(code.matrix @ logicals_x.T)
+    assert not np.any(code.matrix @ logicals_z.T)
     assert code.get_logical_ops() is code._logical_ops
 
-    # verify consistency with QuditCode.get_logical_ops
-    full_logicals = codes.QuditCode.get_logical_ops(code)
-    full_logicals_x, full_logicals_z = full_logicals[0], full_logicals[1]
-    assert np.array_equal(full_logicals_x, np.hstack([logicals_x, np.zeros_like(logicals_x)]))
-    assert np.array_equal(full_logicals_z, np.hstack([np.zeros_like(logicals_x), logicals_z]))
-    assert not np.any(code.matrix @ full_logicals_x.T)
-    assert not np.any(code.matrix @ full_logicals_z.T)
+    # test that logical operators are dual to each other
+    logicals_x = logicals_x[:, : code.num_qudits]
+    logicals_z = logicals_z[:, code.num_qudits :]
+    assert np.array_equal(logicals_x @ logicals_z.T, np.eye(code.dimension, dtype=int))
 
     # successfullly construct and reduce logical operators in a code with "over-complete" checks
     dist = 4


### PR DESCRIPTION
Logical operators, even for `CSSCode`s, are now always organized into `[x_support | z_support]`.