### PR TITLE
Protograph bugfixes

### DIFF
--- a/qldpc/abstract.py
+++ b/qldpc/abstract.py
@@ -580,15 +580,16 @@ class Protograph(npt.NDArray[np.object_]):
         for value in protograph.ravel():
             if not isinstance(value, Element):
                 raise ValueError(
-                    "Requirement failed: all entries of a protograph must be Element-valued"
+                    "Requirement failed: all entries of a protograph must be Element-valued\n"
+                    "Try building a protograph with Protograph.build(...)"
                 )
             else:
                 if not (group is None or group == value.group):
-                    raise ValueError("Inconsistent base groups provided for protograph")
+                    raise ValueError("Inconsistent base groups provided for a protograph")
                 group = value.group
 
         if group is None:
-            raise ValueError("Cannot determine underlying group for a protograh")
+            raise ValueError("Cannot determine the underlying group for a protograh")
         protograph._group = group
 
         return protograph
@@ -601,7 +602,7 @@ class Protograph(npt.NDArray[np.object_]):
     @property
     def field(self) -> type[galois.FieldArray]:
         """Base field of this protograph."""
-        return self.group.field
+        return self._group.field
 
     def lift(self) -> galois.FieldArray:
         """Block matrix obtained by lifting each entry of the protograph."""
@@ -645,6 +646,13 @@ class Protograph(npt.NDArray[np.object_]):
 
         vals = [elevate(value) for value in array.ravel()]
         return Protograph(np.array(vals).reshape(array.shape), group)
+
+    def __matmul__(self, other: object) -> Protograph:
+        if isinstance(other, Protograph) and not self._group == other._group:
+            raise ValueError("Cannot multiply protographs with different base groups")
+        protograph = super().__matmul__(other)
+        protograph._group = self._group
+        return protograph
 
 
 ################################################################################

--- a/qldpc/abstract_test.py
+++ b/qldpc/abstract_test.py
@@ -126,6 +126,7 @@ def test_protograph() -> None:
     assert protograph.group == abstract.TrivialGroup()
     assert protograph.field == abstract.TrivialGroup().field
     assert np.array_equal(protograph.lift(), matrix)
+    assert np.array_equal((protograph @ protograph).lift(), matrix @ matrix % 2)
 
     # fail to construct a valid protograph
     with pytest.raises(ValueError, match="must be Element-valued"):
@@ -133,8 +134,11 @@ def test_protograph() -> None:
     with pytest.raises(ValueError, match="Inconsistent base groups"):
         groups = [abstract.TrivialGroup(), abstract.CyclicGroup(1)]
         abstract.Protograph([[abstract.Element(group) for group in groups]])
-    with pytest.raises(ValueError, match="Cannot determine underlying group"):
+    with pytest.raises(ValueError, match="Cannot determine the underlying group"):
         abstract.Protograph([])
+    with pytest.raises(ValueError, match="different base groups"):
+        new_protograph = abstract.Protograph.build(abstract.CyclicGroup(1), [[1]])
+        protograph @ new_protograph
 
 
 def test_transpose() -> None:


### PR DESCRIPTION
Override `Protograph.__matmul__` to keep track of the base group of protographs.