### PR TITLE
Clean up interactions between cache and pytest

### DIFF
--- a/qldpc/abstract.py
+++ b/qldpc/abstract.py
@@ -407,14 +407,13 @@ class Group:
                 return singles | doubles
 
     @classmethod
-    def from_name(cls, name: str) -> Group:
+    def from_name(cls, name: str, field: int | None = None) -> Group:
         """Named group in the GAP computer algebra system."""
         standardized_name = name.strip().replace(" ", "")
         if standardized_name == "SmallGroup(1,1)":
             return TrivialGroup()
         generators = [GroupMember(gen) for gen in external.groups.get_generators(standardized_name)]
-        group = Group(*generators, name=standardized_name)
-        return group
+        return Group(*generators, name=standardized_name, field=field)
 
 
 ################################################################################

--- a/qldpc/cache.py
+++ b/qldpc/cache.py
@@ -19,11 +19,17 @@ from __future__ import annotations
 
 import functools
 import os
+import sys
 from collections.abc import Callable, Hashable
 from typing import Any
 
 import diskcache
 import platformdirs
+
+
+def running_with_pytest() -> bool:
+    """Are we currently running  with pytest?"""
+    return "pytest" in sys.modules
 
 
 def get_disk_cache(cache_name: str, *, cache_dir: str | None = None) -> diskcache.Cache:
@@ -39,6 +45,9 @@ def use_disk_cache(
     """Decorator to cache results to disk."""
 
     def decorator(function: Callable[..., Any]) -> Callable[..., Any]:
+        if running_with_pytest():
+            return function
+
         @functools.wraps(function)
         def function_with_cache(*args: Hashable, **kwargs: Hashable) -> Any:
             # retrieve results from cache, if available

--- a/qldpc/cache_test.py
+++ b/qldpc/cache_test.py
@@ -22,16 +22,29 @@ import unittest.mock
 import qldpc.cache
 
 
+def test_pytest() -> None:
+    """We are running with pytest."""
+    assert qldpc.cache.running_with_pytest()
+
+    def test_func() -> None: ...
+
+    assert test_func is qldpc.cache.use_disk_cache("test")(test_func)
+
+
 def test_use_disk_cache() -> None:
     """Cache function outputs."""
 
-    @qldpc.cache.use_disk_cache("test")
-    def get_five(_: str) -> int:
-        return 5
-
-    # use cache to save/retrieve results
     cache: dict[tuple[str], int] = {}
-    with unittest.mock.patch("diskcache.Cache", return_value=cache):
+    with (
+        unittest.mock.patch("qldpc.cache.running_with_pytest", return_value=False),
+        unittest.mock.patch("diskcache.Cache", return_value=cache),
+    ):
+
+        @qldpc.cache.use_disk_cache("test")
+        def get_five(_: str) -> int:
+            return 5
+
+        # use cache to save/retrieve results
         get_five("test")  # save results to cache
         assert cache == {("test",): 5}  # check cache
         assert cache[("test",)] == get_five("test")  # retrieve results

--- a/qldpc/codes/common.py
+++ b/qldpc/codes/common.py
@@ -487,11 +487,7 @@ class ClassicalCode(AbstractCode):
         matrix = "[" + ",".join(checks) + "]"
         code = f"CheckMatCode({matrix}, GF({self.field.order}))"
         group_cmd = "AutomorphismGroup" if self.field.order == 2 else "PermutationAutomorphismGroup"
-        perms = external.groups.get_generators_with_gap(f"{group_cmd}({code})", load_guava=True)
-        if perms is None:
-            raise ValueError("Cannot retrieve group from GAP.  Is GAP installed?")
-        generators = [abstract.GroupMember(perm) for perm in perms]
-        return abstract.Group(*generators, field=self.field.order)
+        return abstract.Group.from_name(f"{group_cmd}({code})", field=self.field.order)
 
     def puncture(self, *bits: int) -> ClassicalCode:
         """Delete the specified bits from a code.

--- a/qldpc/codes/common_test.py
+++ b/qldpc/codes/common_test.py
@@ -142,7 +142,7 @@ def test_automorphism() -> None:
     # raise an error when GAP is not installed
     with (
         unittest.mock.patch("qldpc.external.gap.is_installed", return_value=False),
-        pytest.raises(ValueError, match="Is GAP installed?"),
+        pytest.raises(ValueError, match="Cannot build GAP group"),
     ):
         code.get_automorphism_group()
 

--- a/qldpc/external/codes_test.py
+++ b/qldpc/external/codes_test.py
@@ -24,10 +24,6 @@ import pytest
 
 from qldpc import external
 
-# strip cache wrapper
-assert hasattr(external.codes.get_code, "__wrapped__")
-external.codes.get_code = external.codes.get_code.__wrapped__
-
 
 def get_mock_process(stdout: str) -> subprocess.CompletedProcess[str]:
     """Fake process with the given stdout."""

--- a/qldpc/external/groups.py
+++ b/qldpc/external/groups.py
@@ -112,7 +112,7 @@ def get_generators_from_groupnames(group: str) -> GENERATORS_LIST | None:
     return generators
 
 
-def get_generators_with_gap(group: str, load_guava: bool = False) -> GENERATORS_LIST | None:
+def get_generators_with_gap(group: str) -> GENERATORS_LIST | None:
     """Retrieve GAP group generators from GAP directly."""
 
     if not qldpc.external.gap.is_installed():
@@ -120,7 +120,7 @@ def get_generators_with_gap(group: str, load_guava: bool = False) -> GENERATORS_
 
     # run GAP commands
     commands = [
-        *['LoadPackage("guava");' if load_guava else ""],
+        'LoadPackage("guava");',
         f"G := {group};",
         "iso := IsomorphismPermGroup(G);",
         "permG := Image(iso, G);",

--- a/qldpc/external/groups_test.py
+++ b/qldpc/external/groups_test.py
@@ -25,12 +25,6 @@ import pytest
 
 from qldpc import external
 
-# strip cache wrappers
-assert hasattr(external.groups.get_generators, "__wrapped__")
-assert hasattr(external.groups.get_small_group_number, "__wrapped__")
-external.groups.get_generators = external.groups.get_generators.__wrapped__
-external.groups.get_small_group_number = external.groups.get_small_group_number.__wrapped__
-
 # define global testing variables
 ORDER, INDEX = 2, 1
 GENERATORS = [[(0, 1)]]


### PR DESCRIPTION
I previously stripped functions of their cache wrapper in `*_test.py` files.  This PR instead makes the `qldpc.cache.use_disk_cache` decorator recognize whether it's being run with pytest and behave accordingly.