### PR TITLE
Add early stopping to `*Code.get_distance_bound` methods

### DIFF
--- a/qldpc/codes/common.py
+++ b/qldpc/codes/common.py
@@ -371,8 +371,8 @@ class ClassicalCode(AbstractCode):
     ) -> int | float:
         """Compute an upper bound on code distance by minimizing many individual upper bounds.
 
+        If passed a cutoff, don't bother trying to find distances less than the cutoff.
         If passed a vector, compute the minimum Hamming distance between the vector and a code word.
-
         Additional arguments, if applicable, are passed to a decoder in `get_one_distance_bound`.
         """
         if (known_distance := self._get_distance_if_known(vector)) is not None:
@@ -789,6 +789,7 @@ class QuditCode(AbstractCode):
     ) -> int | float:
         """Compute an upper bound on code distance by minimizing many individual upper bounds.
 
+        If passed a cutoff, don't bother trying to find distances less than the cutoff.
         Additional arguments, if applicable, are passed to a decoder in `get_one_distance_bound`.
         """
         if (known_distance := self._get_distance_if_known()) is not None:
@@ -1131,7 +1132,7 @@ class CSSCode(QuditCode):
         """Compute an upper bound on code distance by minimizing many individual upper bounds.
 
         If `pauli is not None`, consider only `pauli`-type logical operators.
-
+        If passed a cutoff, don't bother trying to find distances less than the cutoff.
         Additional arguments, if applicable, are passed to a decoder in `get_one_distance_bound`.
         """
         if (known_distance := self._get_distance_if_known(pauli)) is not None:

--- a/qldpc/codes/common.py
+++ b/qldpc/codes/common.py
@@ -382,10 +382,10 @@ class ClassicalCode(AbstractCode):
 
         min_bound = len(self)
         for _ in range(num_trials):
-            new_bound = self.get_one_distance_bound(vector=vector, **decoder_args)
-            min_bound = int(min(min_bound, new_bound))
             if cutoff and min_bound <= cutoff:
                 break
+            new_bound = self.get_one_distance_bound(vector=vector, **decoder_args)
+            min_bound = int(min(min_bound, new_bound))
         return min_bound
 
     def get_one_distance_bound(
@@ -800,10 +800,10 @@ class QuditCode(AbstractCode):
 
         min_bound = len(self)
         for _ in range(num_trials):
-            new_bound = self.get_one_distance_bound(**decoder_args)
-            min_bound = int(min(min_bound, new_bound))
             if cutoff and min_bound <= cutoff:
                 break
+            new_bound = self.get_one_distance_bound(**decoder_args)
+            min_bound = int(min(min_bound, new_bound))
         return min_bound
 
     def get_one_distance_bound(self, **decoder_args: Any) -> int:
@@ -1145,10 +1145,10 @@ class CSSCode(QuditCode):
 
         min_bound = len(self)
         for _ in range(num_trials):
-            new_bound = self.get_one_distance_bound(pauli, **decoder_args)
-            min_bound = int(min(min_bound, new_bound))
             if cutoff and min_bound <= cutoff:
                 break
+            new_bound = self.get_one_distance_bound(pauli, **decoder_args)
+            min_bound = int(min(min_bound, new_bound))
         return min_bound
 
     def get_one_distance_bound(

--- a/qldpc/codes/common.py
+++ b/qldpc/codes/common.py
@@ -372,7 +372,9 @@ class ClassicalCode(AbstractCode):
         """Compute an upper bound on code distance by minimizing many individual upper bounds.
 
         If passed a cutoff, don't bother trying to find distances less than the cutoff.
+
         If passed a vector, compute the minimum Hamming distance between the vector and a code word.
+
         Additional arguments, if applicable, are passed to a decoder in `get_one_distance_bound`.
         """
         if (known_distance := self._get_distance_if_known(vector)) is not None:
@@ -790,6 +792,7 @@ class QuditCode(AbstractCode):
         """Compute an upper bound on code distance by minimizing many individual upper bounds.
 
         If passed a cutoff, don't bother trying to find distances less than the cutoff.
+
         Additional arguments, if applicable, are passed to a decoder in `get_one_distance_bound`.
         """
         if (known_distance := self._get_distance_if_known()) is not None:
@@ -1132,7 +1135,9 @@ class CSSCode(QuditCode):
         """Compute an upper bound on code distance by minimizing many individual upper bounds.
 
         If `pauli is not None`, consider only `pauli`-type logical operators.
+
         If passed a cutoff, don't bother trying to find distances less than the cutoff.
+
         Additional arguments, if applicable, are passed to a decoder in `get_one_distance_bound`.
         """
         if (known_distance := self._get_distance_if_known(pauli)) is not None:

--- a/qldpc/codes/common_test.py
+++ b/qldpc/codes/common_test.py
@@ -231,12 +231,14 @@ def test_qudit_code() -> None:
 
     # "forget" the code distance and recompute
     code._exact_distance = None
-    assert code.get_distance_bound(cutoff=len(code)) == len(code)
+    assert code.get_distance_bound(cutoff=5) == 5
     assert code.get_distance_exact() == 3
 
     code._exact_distance = None
     with pytest.raises(NotImplementedError, match="not implemented"):
         code.get_distance(bound=True)
+    with unittest.mock.patch("qldpc.codes.QuditCode.get_one_distance_bound", return_value=3):
+        code.get_distance(bound=True) == 3
 
     # stacking two codes
     two_codes = codes.QuditCode.stack(code, code)
@@ -366,7 +368,7 @@ def test_distance_css() -> None:
     """Distance calculations for CSS codes."""
     code = codes.HGPCode(codes.RepetitionCode(2, field=3))
     assert code.get_distance_bound(cutoff=len(code)) == len(code)
-    assert code.get_distance(bound=True) == 2
+    assert code.get_distance(bound=True) <= len(code)
     assert code.get_distance(bound=False) == 2
 
     # an empty quantum code has distance infinity

--- a/qldpc/codes/common_test.py
+++ b/qldpc/codes/common_test.py
@@ -122,6 +122,7 @@ def test_distance_classical(bits: int = 3) -> None:
     # "forget" the exact code distance
     rep_code._exact_distance = None
 
+    assert rep_code.get_distance_bound(cutoff=bits) == bits
     assert rep_code.get_distance(bound=True) == bits
     assert rep_code.get_distance() == bits
     for vector in itertools.product(rep_code.field.elements, repeat=bits):
@@ -230,6 +231,7 @@ def test_qudit_code() -> None:
 
     # "forget" the code distance and recompute
     code._exact_distance = None
+    assert code.get_distance_bound(cutoff=len(code)) == len(code)
     assert code.get_distance_exact() == 3
 
     code._exact_distance = None
@@ -363,6 +365,7 @@ def test_css_ops() -> None:
 def test_distance_css() -> None:
     """Distance calculations for CSS codes."""
     code = codes.HGPCode(codes.RepetitionCode(2, field=3))
+    assert code.get_distance_bound(cutoff=len(code)) == len(code)
     assert code.get_distance(bound=True) == 2
     assert code.get_distance(bound=False) == 2
 


### PR DESCRIPTION
The distance bounding methods will stop trying to find a tighter bound on code distance if it finds a distance <= a provided cutoff.