### PR TITLE
Using a bipartite matching algorithm

### DIFF
--- a/examples/find_optimal_communication_distance.py
+++ b/examples/find_optimal_communication_distance.py
@@ -60,7 +60,7 @@ def get_qubit_assignment(
     graph = build_placement_graph(code, folded_layout, max_comm_dist)
     if graph is None:
         return None
-    matching = nx.max_weight_matching(graph, maxcardinality=True)
+    matching = nx.bipartite.maximum_matching(graph)
     return matching if nx.is_perfect_matching(graph, matching) else None
 
 


### PR DESCRIPTION
If this graph is always bipartite (which I think is the case) then this matching algorithm should be faster. 

Timing for me on the following case: 
```
(n, k): (288, 12)
orders: {x: 12, y: 12}
poly_a: x**2/y**3 + x + 1
poly_b: x**3*y**2 + y + 1
```

was about 15% faster... so if such a change isn't significant enough, then feel free to close this PR.