### PR TITLE
combine linting and type checking workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
           python3 -m pip install '.[dev]'
 
   format:
-    name: Linting check
+    name: Linting and type check
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 2
@@ -54,35 +54,13 @@ jobs:
           python3 -m pip install --upgrade pip
           python3 -m pip install '.[dev]'
       - name: Run ruff format
-        run: |
-          checks/format_.py
+        run: checks/format_.py
+        continue-on-error: true
       - name: Run ruff check
-        run: |
-          checks/lint_.py
-
-  mypy:
-    name: Type check
-    if: github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
-    timeout-minutes: 2
-    needs: install
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python 3.11
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-      - uses: actions/cache@v4
-        with:
-          path: ${{ env.pythonLocation }}
-          key: ${{ env.pythonLocation }}-${{ hashFiles('pyproject.toml', 'build-cython.py') }}
-      - name: Install package and dependencies
-        run: |
-          python3 -m pip install --upgrade pip
-          python3 -m pip install '.[dev]'
+        run: checks/lint_.py
+        continue-on-error: true
       - name: Run mypy
-        run: |
-          checks/mypy_.py
+        run: checks/mypy_.py
 
   coverage:
     name: Pytest and coverage check
@@ -105,5 +83,4 @@ jobs:
           python3 -m pip install --upgrade pip
           python3 -m pip install '.[dev]'
       - name: Run coverage
-        run: |
-          checks/coverage_.py
+        run: checks/coverage_.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
           python3 -m pip install '.[dev]'
 
   format:
-    name: Linting and type check
+    name: Lint and type check
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,13 +54,33 @@ jobs:
           python3 -m pip install --upgrade pip
           python3 -m pip install '.[dev]'
       - name: Run ruff format
+        id: ruff-format
         run: checks/format_.py
         continue-on-error: true
       - name: Run ruff check
+        id: ruff-check
         run: checks/lint_.py
         continue-on-error: true
       - name: Run mypy
+        id: mypy
         run: checks/mypy_.py
+        continue-on-error: true
+      - name: Check for failures
+        run: |
+          FAILED=0
+          if [ ${{ steps.ruff-format.outcome }} != 'success' ]; then
+            echo "ruff format failed"
+            FAILED=1
+          fi
+          if [ ${{ steps.ruff-check.outcome }} != 'success' ]; then
+            echo "ruff check failed"
+            FAILED=1
+          fi
+          if [ ${{ steps.mypy.outcome }} != 'success' ]; then
+            echo "mypy failed"
+            FAILED=1
+          fi
+          exit $FAILED
 
   coverage:
     name: Pytest and coverage check

--- a/qldpc/codes/common.py
+++ b/qldpc/codes/common.py
@@ -32,9 +32,9 @@ import numpy as np
 import numpy.typing as npt
 import scipy.linalg
 import scipy.special
-import stim
 
 from qldpc import abstract, decoders, external
+import stim
 from qldpc.abstract import DEFAULT_FIELD_ORDER
 from qldpc.objects import PAULIS_XZ, Node, Pauli, PauliXZ, QuditOperator, conjugate_xz, op_to_string
 
@@ -42,12 +42,12 @@ from ._distance import get_distance_classical, get_distance_quantum
 
 
 def get_scrambled_seed(seed: int) -> int:
-    """Scramble a seed, allowing us to safely increment seeds in repeat-until-success protocols."""
-    state = np.random.get_state()
-    np.random.seed(seed)
-    new_seed = np.random.randint(np.iinfo(np.int32).max + 1)
-    np.random.set_state(state)
-    return new_seed
+     """Scramble a seed, allowing us to safely increment seeds in repeat-until-success protocols."""
+     state = np.random.get_state()
+     np.random.seed(seed)
+     new_seed = np.random.randint(np.iinfo(np.int32).max + 1)
+     np.random.set_state(state)
+     return new_seed
 
 
 def get_random_array(

--- a/qldpc/codes/common.py
+++ b/qldpc/codes/common.py
@@ -32,9 +32,9 @@ import numpy as np
 import numpy.typing as npt
 import scipy.linalg
 import scipy.special
+import stim
 
 from qldpc import abstract, decoders, external
-import stim
 from qldpc.abstract import DEFAULT_FIELD_ORDER
 from qldpc.objects import PAULIS_XZ, Node, Pauli, PauliXZ, QuditOperator, conjugate_xz, op_to_string
 
@@ -42,12 +42,12 @@ from ._distance import get_distance_classical, get_distance_quantum
 
 
 def get_scrambled_seed(seed: int) -> int:
-     """Scramble a seed, allowing us to safely increment seeds in repeat-until-success protocols."""
-     state = np.random.get_state()
-     np.random.seed(seed)
-     new_seed = np.random.randint(np.iinfo(np.int32).max + 1)
-     np.random.set_state(state)
-     return new_seed
+    """Scramble a seed, allowing us to safely increment seeds in repeat-until-success protocols."""
+    state = np.random.get_state()
+    np.random.seed(seed)
+    new_seed = np.random.randint(np.iinfo(np.int32).max + 1)
+    np.random.set_state(state)
+    return new_seed
 
 
 def get_random_array(


### PR DESCRIPTION
The format and lint was spending < 1 second on the check, and pretty much all of its time on package installation.  This PR just merges it with the type checker.  The corresponding workflow runs all three checks unconditionally, and reports which of them failed (if any).