### PR TITLE
Return only X/Z support of `code.get_logical_ops(Pauli.[X/Z])` for `CSSCode`s

### DIFF
--- a/qldpc/circuits.py
+++ b/qldpc/circuits.py
@@ -52,8 +52,8 @@ def get_encoding_tableau(code: codes.QuditCode) -> stim.Tableau:
     mapped to destabilizers.
     """
     # identify logical operators
-    logicals_x = [op_to_string(op) for op in code.get_logical_ops(Pauli.X)]
-    logicals_z = [op_to_string(op) for op in code.get_logical_ops(Pauli.Z)]
+    logicals_x = [op_to_string(op) for op in codes.QuditCode.get_logical_ops(code, Pauli.X)]
+    logicals_z = [op_to_string(op) for op in codes.QuditCode.get_logical_ops(code, Pauli.Z)]
 
     # identify stabilizers
     matrix = codes.ClassicalCode(code.matrix).canonicalized().matrix
@@ -205,7 +205,9 @@ def get_transversal_automorphism_group(
     deformations for which the logical Pauli group of the original QuditCode is a valid choice of
     logical Pauli group for the deformed QuditCode.
     """
-    effective_stabilizers = code.matrix if not deform_code else conjugate_xz(code.get_logical_ops())
+    effective_stabilizers = (
+        code.matrix if not deform_code else conjugate_xz(codes.QuditCode.get_logical_ops(code))
+    )
     matrix_x = effective_stabilizers.reshape(-1, 2, len(code))[:, 0, :]
     matrix_z = effective_stabilizers.reshape(-1, 2, len(code))[:, 1, :]
     if not local_gates or local_gates == {"H"}:
@@ -492,9 +494,9 @@ def get_transversal_circuits(
         *_, x_signs_m, z_signs_m = matching_tableau.to_numpy()
         for logical_qubit in range(code.dimension):
             if x_signs_l[logical_qubit] != x_signs_m[logical_qubit]:  # pragma: no cover
-                correction = correction + code.get_logical_ops(Pauli.Z)[logical_qubit]
+                correction += codes.QuditCode.get_logical_ops(code, Pauli.Z)[logical_qubit]
             if z_signs_l[logical_qubit] != z_signs_m[logical_qubit]:  # pragma: no cover
-                correction += code.get_logical_ops(Pauli.X)[logical_qubit]
+                correction += codes.QuditCode.get_logical_ops(code, Pauli.X)[logical_qubit]
         correction_circuit = _get_pauli_circuit(op_to_string(correction))
 
         physical_circuits[tt] = correction_circuit + matching_circuit

--- a/qldpc/circuits_test.py
+++ b/qldpc/circuits_test.py
@@ -49,7 +49,7 @@ def test_state_prep() -> None:
             assert simulator.peek_observable_expectation(string) == 1
 
         # the state of the simulator is a +1 eigenstate of all logical Z operators
-        for op in code.get_logical_ops(Pauli.Z):
+        for op in codes.QuditCode.get_logical_ops(code, Pauli.Z):
             string = circuits.op_to_string(op)
             assert simulator.peek_observable_expectation(string) == 1
 

--- a/qldpc/codes/common.py
+++ b/qldpc/codes/common.py
@@ -1545,6 +1545,7 @@ class CSSCode(QuditCode):
 
         # if requested, retrieve logical operators of one type only
         if pauli is not None:
+            shape: tuple[int, ...]
             if symplectic:
                 shape = (2, self.dimension, 2 * len(self))
                 logical_ops = self.get_logical_ops(recompute=recompute).reshape(shape)

--- a/qldpc/codes/common.py
+++ b/qldpc/codes/common.py
@@ -1518,7 +1518,7 @@ class CSSCode(QuditCode):
         return int(np.count_nonzero(candidate_logical_op))
 
     def get_logical_ops(
-        self, pauli: PauliXZ | None = None, *, recompute: bool = False
+        self, pauli: PauliXZ | None = None, *, recompute: bool = False, symplectic: bool = False
     ) -> galois.FieldArray:
         """Complete basis of nontrivial logical Pauli operators for this code.
 
@@ -1532,7 +1532,8 @@ class CSSCode(QuditCode):
         operators in all other rows except row j+k.
 
         If this method is passed a pauli operator (Pauli.X or Pauli.Z), it returns only the logical
-        operators of that type, in a matrix with shape (k, n).
+        operators of that type.  This matrix has shape (k, n) by default, but is expanded into a
+        matrix with shape (k, 2 * n) if this method is called with symplectic=True.
 
         Logical X-type operators only address physical qudits by physical X-type operators, and
         logical Z-type operators only address physical qudits by physical Z-type operators.
@@ -1544,6 +1545,10 @@ class CSSCode(QuditCode):
 
         # if requested, retrieve logical operators of one type only
         if pauli is not None:
+            if symplectic:
+                shape = (2, self.dimension, 2, -1)
+                logical_ops = self.get_logical_ops(recompute=recompute).reshape(shape)
+                return logical_ops[pauli, :, :]  # type:ignore[return-value]
             shape = (2, self.dimension, 2, -1)
             logical_ops = self.get_logical_ops(recompute=recompute).reshape(shape)
             return logical_ops[pauli, :, pauli, :]  # type:ignore[return-value]

--- a/qldpc/codes/common.py
+++ b/qldpc/codes/common.py
@@ -1546,10 +1546,10 @@ class CSSCode(QuditCode):
         # if requested, retrieve logical operators of one type only
         if pauli is not None:
             if symplectic:
-                shape = (2, self.dimension, 2, -1)
+                shape = (2, self.dimension, 2 * len(self))
                 logical_ops = self.get_logical_ops(recompute=recompute).reshape(shape)
                 return logical_ops[pauli, :, :]  # type:ignore[return-value]
-            shape = (2, self.dimension, 2, -1)
+            shape = (2, self.dimension, 2, len(self))
             logical_ops = self.get_logical_ops(recompute=recompute).reshape(shape)
             return logical_ops[pauli, :, pauli, :]  # type:ignore[return-value]
 

--- a/qldpc/codes/common_test.py
+++ b/qldpc/codes/common_test.py
@@ -430,9 +430,8 @@ def test_css_ops() -> None:
     code: codes.CSSCode
 
     code = codes.HGPCode(codes.ClassicalCode.random(4, 2, field=3))
-    assert len(code.get_random_logical_op(Pauli.X, ensure_nontrivial=False)) == len(code)
-    assert len(code.get_random_logical_op(Pauli.X, ensure_nontrivial=True)) == len(code)
-    assert len(code.get_random_logical_op(Pauli.X, symplectic=True)) == 2 * len(code)
+    assert not np.any(code.matrix_z @ code.get_random_logical_op(Pauli.X, ensure_nontrivial=False))
+    assert not np.any(code.matrix_z @ code.get_random_logical_op(Pauli.X, ensure_nontrivial=True))
 
     # swap around logical operators
     code.set_logical_ops_xz(

--- a/qldpc/codes/common_test.py
+++ b/qldpc/codes/common_test.py
@@ -442,10 +442,12 @@ def test_css_ops() -> None:
     # successfully construct and reduce logical operators in a code with "over-complete" checks
     dist = 4
     code = codes.ToricCode(dist, rotated=True, field=2)
-    code.reduce_logical_ops()
     assert code.get_code_params() == (dist**2, 2, dist)
-    assert not any(np.count_nonzero(op) < dist for op in code.get_logical_ops(Pauli.X))
-    assert not any(np.count_nonzero(op) < dist for op in code.get_logical_ops(Pauli.Z))
+    code.reduce_logical_ops()
+    logical_ops_x = code.get_logical_ops(Pauli.X)
+    logical_ops_z = code.get_logical_ops(Pauli.Z, symplectic=True)
+    assert not np.any(np.count_nonzero(logical_ops_x.view(np.ndarray), axis=1) < dist)
+    assert not np.any(np.count_nonzero(logical_ops_z.view(np.ndarray), axis=1) < dist)
 
     # the 2x2 toric code has redundant stabilizers
     code = codes.ToricCode(2)

--- a/qldpc/codes/common_test.py
+++ b/qldpc/codes/common_test.py
@@ -435,8 +435,8 @@ def test_css_ops() -> None:
 
     # swap around logical operators
     code.set_logical_ops_xz(
-        code.get_logical_ops(Pauli.X)[::-1, : len(code)],
-        code.get_logical_ops(Pauli.Z)[::-1, len(code) :],
+        code.get_logical_ops(Pauli.X)[::-1],
+        code.get_logical_ops(Pauli.Z)[::-1],
     )
 
     # successfully construct and reduce logical operators in a code with "over-complete" checks

--- a/qldpc/codes/common_test.py
+++ b/qldpc/codes/common_test.py
@@ -430,8 +430,9 @@ def test_css_ops() -> None:
     code: codes.CSSCode
 
     code = codes.HGPCode(codes.ClassicalCode.random(4, 2, field=3))
-    code.get_random_logical_op(Pauli.X, ensure_nontrivial=False)
-    code.get_random_logical_op(Pauli.X, ensure_nontrivial=True)
+    assert len(code.get_random_logical_op(Pauli.X, ensure_nontrivial=False)) == len(code)
+    assert len(code.get_random_logical_op(Pauli.X, ensure_nontrivial=True)) == len(code)
+    assert len(code.get_random_logical_op(Pauli.X, symplectic=True)) == 2 * len(code)
 
     # swap around logical operators
     code.set_logical_ops_xz(


### PR DESCRIPTION
The full [X|Z] support is returned by, for example, `code.get_logical_ops(Pauli.X, symplectic=True)`