### PR TITLE
fix bug in subsystem code distance calculation

### DIFF
--- a/qldpc/codes/common.py
+++ b/qldpc/codes/common.py
@@ -1293,7 +1293,7 @@ class QuditCode(AbstractCode):
         logical_ops = self.get_logical_ops()
         stabilizers = self.get_stabilizer_ops(canonicalized=True)
         if self.is_subsystem_code:
-            stabilizers = np.vstack([stabilizers, self.get_gauge_ops()])
+            stabilizers = np.vstack([stabilizers, self.get_gauge_ops()])  # type:ignore[assignment]
 
         if self.field.order == 2:
             distance = get_distance_quantum(
@@ -2006,7 +2006,7 @@ class CSSCode(QuditCode):
         logical_ops = self.get_logical_ops(pauli)
         stabilizers = self.get_stabilizer_ops(pauli, canonicalized=True)
         if self.is_subsystem_code:
-            stabilizers = np.vstack([stabilizers, self.get_gauge_ops(pauli)])
+            stabilizers = np.vstack([stabilizers, self.get_gauge_ops(pauli)])  # type:ignore[assignment]
 
         if self.field.order == 2:
             distance = get_distance_quantum(

--- a/qldpc/codes/common_test.py
+++ b/qldpc/codes/common_test.py
@@ -285,6 +285,7 @@ def test_qudit_code() -> None:
 def test_distance_qudit() -> None:
     """Distance calculations."""
     code = codes.FiveQubitCode()
+    code._is_subsystem_code = True  # test that this does not break anything
 
     # cover calls to the known code exact distance
     assert code.get_code_params() == (5, 1, 3)
@@ -527,6 +528,7 @@ def test_distance_css() -> None:
 
     # qubit code distance
     code = codes.HGPCode(codes.RepetitionCode(2, field=2))
+    code._is_subsystem_code = True  # test that this does not break anything
     assert code.get_distance_exact() == 2
 
     # an empty quantum code has distance infinity


### PR DESCRIPTION
`QuditCode.get_distance_exact` previously only computed the minimum weight of **_pure_** logicals.  Oops.  They should instead compute the minimum weight of [logicals] mod [stabilizers and gauge ops].

This PR also fixes a minor bug in the construction of logical operators for non-CSS subsystem codes; namely that [this line](https://github.com/Infleqtion/qLDPC/blob/c88cc575707291a676b6ef94d42ebe6c1846c3c7/qldpc/codes/common.py#L1113) could cause `matrix_x` to have Z-type gauge ops (because the operators in `checks_x` may contain factors of Z-type gauge ops).  Those gauge ops can just be [removed](https://github.com/Infleqtion/qLDPC/blob/1bdde8a8965ac68c9891eadb24a854f0ebfea74a/qldpc/codes/common.py#L1113).