### PR TITLE
move `op_to_string` to `qldpc.math`

### DIFF
--- a/qldpc/circuits.py
+++ b/qldpc/circuits.py
@@ -25,8 +25,8 @@ import numpy as np
 import stim
 
 from qldpc import abstract, cache, codes
-from qldpc.math import symplectic_conjugate
-from qldpc.objects import Pauli, op_to_string
+from qldpc.math import op_to_string, symplectic_conjugate
+from qldpc.objects import Pauli
 
 CACHE_NAME = "qldpc_automorphisms"
 

--- a/qldpc/circuits_test.py
+++ b/qldpc/circuits_test.py
@@ -22,6 +22,7 @@ import pytest
 import stim
 
 from qldpc import circuits, codes, external
+from qldpc.math import op_to_string
 from qldpc.objects import Pauli
 
 
@@ -45,17 +46,17 @@ def test_state_prep() -> None:
 
         # the state of the simulator is a +1 eigenstate of code stabilizers
         for row in code.get_stabilizer_ops():
-            string = circuits.op_to_string(row)
+            string = op_to_string(row)
             assert simulator.peek_observable_expectation(string) == 1
 
         # the state of the simulator is a +1 eigenstate of all logical Z operators
         for op in codes.QuditCode.get_logical_ops(code, Pauli.Z):
-            string = circuits.op_to_string(op)
+            string = op_to_string(op)
             assert simulator.peek_observable_expectation(string) == 1
 
         # the state of the simulator is a +1 eigenstate of all gauge Z operators
         for op in codes.QuditCode.get_gauge_ops(code, Pauli.Z):
-            string = circuits.op_to_string(op)
+            string = op_to_string(op)
             assert simulator.peek_observable_expectation(string) == 1
 
 

--- a/qldpc/codes/common.py
+++ b/qldpc/codes/common.py
@@ -35,8 +35,8 @@ import stim
 
 from qldpc import abstract, decoders, external
 from qldpc.abstract import DEFAULT_FIELD_ORDER
-from qldpc.math import first_nonzero_cols, log_choose, symplectic_conjugate
-from qldpc.objects import PAULIS_XZ, Node, Pauli, PauliXZ, QuditOperator, op_to_string
+from qldpc.math import first_nonzero_cols, log_choose, op_to_string, symplectic_conjugate
+from qldpc.objects import PAULIS_XZ, Node, Pauli, PauliXZ, QuditOperator
 
 from ._distance import get_distance_classical, get_distance_quantum
 

--- a/qldpc/math.py
+++ b/qldpc/math.py
@@ -24,8 +24,29 @@ import galois
 import numpy as np
 import numpy.typing as npt
 import scipy.special
+import stim
+
+from qldpc.objects import Pauli
 
 IntegerArray = TypeVar("IntegerArray", npt.NDArray[np.int_], galois.FieldArray)
+
+
+def op_to_string(op: npt.NDArray[np.int_]) -> stim.PauliString:
+    """Convert an integer array that represents a Pauli string into a stim.PauliString.
+
+    The (first, second) half the array indicates the support of (X, Z) Paulis.
+    """
+    support_xz = np.array(op, dtype=int).reshape(2, -1)
+    paulis = [Pauli((support_xz[0, qq], support_xz[1, qq])) for qq in range(support_xz.shape[1])]
+    return stim.PauliString(map(str, paulis))
+
+    num_qubits = len(op) // 2
+    paulis = ""
+    for qubit in range(num_qubits):
+        val_x = int(op[qubit])
+        val_z = int(op[qubit + num_qubits])
+        paulis = str(Pauli((val_x, val_z)))
+    return stim.PauliString(paulis)
 
 
 def symplectic_conjugate(vectors: IntegerArray) -> IntegerArray:

--- a/qldpc/math_test.py
+++ b/qldpc/math_test.py
@@ -18,8 +18,18 @@ limitations under the License.
 from __future__ import annotations
 
 import numpy as np
+import stim
 
 import qldpc
+
+
+def test_pauli_strings() -> None:
+    """Stabilizers correctly converted into stim.PauliString objects."""
+    code = qldpc.codes.FiveQubitCode()
+    assert all(
+        qldpc.math.op_to_string(row) == stim.PauliString(stabilizer.replace(" ", ""))
+        for row, stabilizer in zip(code.matrix, code.get_strings())
+    )
 
 
 def test_vectors() -> None:

--- a/qldpc/objects.py
+++ b/qldpc/objects.py
@@ -28,28 +28,9 @@ import galois
 import networkx as nx
 import numpy as np
 import numpy.typing as npt
-import stim
 
 from qldpc import abstract
 from qldpc.abstract import DEFAULT_FIELD_ORDER
-
-
-def op_to_string(op: npt.NDArray[np.int_]) -> stim.PauliString:
-    """Convert an integer array that represents a Pauli string into a stim.PauliString.
-
-    The (first, second) half the array indicates the support of (X, Z) Paulis.
-    """
-    support_xz = np.array(op, dtype=int).reshape(2, -1)
-    paulis = [Pauli((support_xz[0, qq], support_xz[1, qq])) for qq in range(support_xz.shape[1])]
-    return stim.PauliString(map(str, paulis))
-
-    num_qubits = len(op) // 2
-    paulis = ""
-    for qubit in range(num_qubits):
-        val_x = int(op[qubit])
-        val_z = int(op[qubit + num_qubits])
-        paulis = str(Pauli((val_x, val_z)))
-    return stim.PauliString(paulis)
 
 
 class Pauli(enum.Enum):

--- a/qldpc/objects_test.py
+++ b/qldpc/objects_test.py
@@ -20,18 +20,8 @@ from __future__ import annotations
 import galois
 import numpy as np
 import pytest
-import stim
 
-from qldpc import abstract, codes, objects
-
-
-def test_pauli_strings() -> None:
-    """Stabilizers correctly converted into stim.PauliString objects."""
-    code = codes.FiveQubitCode()
-    assert all(
-        objects.op_to_string(row) == stim.PauliString(stabilizer.replace(" ", ""))
-        for row, stabilizer in zip(code.matrix, code.get_strings())
-    )
+from qldpc import abstract, objects
 
 
 def test_pauli() -> None:


### PR DESCRIPTION
There is now a cleaner separation: `qldpc.objects` includes custom classes, while `qldpc.math` has various utility functions.