### PR TITLE
Fix bug in calculation of code distance for non-CSS codes

### DIFF
--- a/qldpc/codes/_distance.pyx
+++ b/qldpc/codes/_distance.pyx
@@ -55,7 +55,7 @@ cdef uint64_t EVEN_BITS_MASK = 0xAAAAAAAAAAAAAAAA  # 1 on the even bits of a 64-
 
 cdef uint64_t symplectic_weight(uint64_t num):
     """Symplectic weight of an integer."""
-    return hamming_weight((num & ODD_BITS_MASK) | (num & EVEN_BITS_MASK))
+    return hamming_weight((num | (num << 1)) & EVEN_BITS_MASK)
 
 
 def gray_code_flips(uint64_t num) -> Iterator[uint64_t]:


### PR DESCRIPTION
Caught by @richrines1 [here](https://github.com/Infleqtion/qLDPC/issues/248#issuecomment-2802903244).  It would be nice to think of a simple test that catches this bug...