### PR TITLE
Clean up `external` module

### DIFF
--- a/qldpc/external/codes.py
+++ b/qldpc/external/codes.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import ast
 import re
 
+import qldpc
 import qldpc.cache
 import qldpc.external.gap
 
@@ -27,9 +28,6 @@ import qldpc.external.gap
 @qldpc.cache.use_disk_cache("codes")
 def get_code(code: str) -> tuple[list[list[int]], int | None]:
     """Retrieve a group from GAP."""
-
-    if not qldpc.external.gap.is_installed():
-        raise ValueError("GAP 4 is not installed")
     qldpc.external.gap.require_package("GUAVA")
 
     # run GAP commands

--- a/qldpc/external/codes_test.py
+++ b/qldpc/external/codes_test.py
@@ -26,14 +26,6 @@ from qldpc import external
 
 def test_get_code() -> None:
     """Retrieve parity check matrix from GAP 4."""
-
-    # GAP is not installed
-    with (
-        unittest.mock.patch("qldpc.external.gap.is_installed", return_value=False),
-        pytest.raises(ValueError, match="GAP 4 is not installed"),
-    ):
-        external.codes.get_code("")
-
     # extract parity check and finite field
     check = [1, 1]
     with (

--- a/qldpc/external/gap_test.py
+++ b/qldpc/external/gap_test.py
@@ -59,19 +59,26 @@ def test_get_output() -> None:
 
 def test_require_package() -> None:
     """Install missing GAP packages."""
-    # user declines to install missing package
     with (
-        unittest.mock.patch("qldpc.external.gap.get_output", return_value="fail"),
-        unittest.mock.patch("builtins.input", return_value="n"),
-        pytest.raises(ValueError, match="Cannot proceed without the required package"),
+        unittest.mock.patch("qldpc.external.gap.is_installed", return_value=False),
+        pytest.raises(FileNotFoundError, match="GAP 4 .* installation cannot be found"),
     ):
         external.gap.require_package("")
 
-    # fail to install missing package
-    with (
-        unittest.mock.patch("qldpc.external.gap.get_output", return_value="fail"),
-        unittest.mock.patch("builtins.input", return_value="y"),
-        unittest.mock.patch("subprocess.run", return_value=get_mock_process("", "error")),
-        pytest.raises(ValueError, match="Failed to install"),
-    ):
-        external.gap.require_package("")
+    with unittest.mock.patch("qldpc.external.gap.is_installed", return_value=True):
+        # user declines to install missing package
+        with (
+            unittest.mock.patch("qldpc.external.gap.get_output", return_value="fail"),
+            unittest.mock.patch("builtins.input", return_value="n"),
+            pytest.raises(ValueError, match="Cannot proceed without the required package"),
+        ):
+            external.gap.require_package("")
+
+        # fail to install missing package
+        with (
+            unittest.mock.patch("qldpc.external.gap.get_output", return_value="fail"),
+            unittest.mock.patch("builtins.input", return_value="y"),
+            unittest.mock.patch("subprocess.run", return_value=get_mock_process("", "error")),
+            pytest.raises(ValueError, match="Failed to install"),
+        ):
+            external.gap.require_package("")


### PR DESCRIPTION
Most checks to `external.gap.is_installed()` should now be replaced by something like `external.gap.require_package(...)`