### PR TITLE
Revert dependency on stim>=1.15.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ numpy = ">=1.24.0"
 platformdirs = ">=4.0.0"
 pymatching = ">=2.1.0"
 scipy = ">=1.14.1"
-stim = ">=1.15.0"
+stim = ">=1.14.0"
 sympy = ">=1.12"
 
 checks-superstaq = { version = ">=0.5.45", optional = true }

--- a/qldpc/circuits/memory.py
+++ b/qldpc/circuits/memory.py
@@ -142,7 +142,7 @@ def get_memory_experiment(
     circuit.append(f"R{basis}", data_ids)
 
     # first round of QEC and detectors
-    circuit.append(one_cycle)
+    circuit += one_cycle
     measurement_record.append(cycle_measurements)
     for kk, check_id in enumerate(check_ids):
         circuit.append("DETECTOR", [measurement_record.get_target_rec(check_id)], (0, kk))
@@ -150,7 +150,7 @@ def get_memory_experiment(
     # following repeated rounds of QEC and detectors
     if num_rounds > 1:
         repeat_circuit = stim.Circuit()
-        repeat_circuit.append(one_cycle)
+        repeat_circuit += one_cycle
         measurement_record.append(cycle_measurements)
         for kk, check_id in enumerate(check_ids):
             repeat_circuit.append(

--- a/qldpc/circuits/noise_model.py
+++ b/qldpc/circuits/noise_model.py
@@ -439,9 +439,9 @@ class NoiseModel:
             else:
                 noisy_op, after = rule.noisy_operation(op, immune_qubits=immune_qubits)
                 circuit.append(noisy_op)
-                noise_after_moment.append(after)
+                noise_after_moment += after
 
-        circuit.append(noise_after_moment)
+        circuit += noise_after_moment
 
         if self.idle_error or self.additional_error_waiting_for_m_or_r:
             self._inplace_append_idle_errors(

--- a/qldpc/circuits/syndrome_measurement_test.py
+++ b/qldpc/circuits/syndrome_measurement_test.py
@@ -71,7 +71,8 @@ def test_syndrome_measurement(
     errors = random.choices([Pauli.I, Pauli.X, Pauli.Y, Pauli.Z], k=len(code))
     error_ops = stim.Circuit()
     for qubit, pauli in enumerate(errors):
-        error_ops.append(f"{pauli}_error", [qubit], [1])
+        if pauli is not Pauli.I:  # I_ERROR is only recognized in stim>=1.15.0
+            error_ops.append(f"{pauli}_error", [qubit], [1])
 
     # measure syndromes
     syndrome_extraction, record = strategy.get_circuit(code)


### PR DESCRIPTION
Alternative fix to #335, making the library compatible with `stim>=1.14.0`