### PR TITLE
Simplify cache keys and add option to delete cache entries

### DIFF
--- a/qldpc/cache.py
+++ b/qldpc/cache.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import functools
 import os
 import sys
+import warnings
 from collections.abc import Callable, Hashable
 from typing import Any
 
@@ -27,13 +28,17 @@ import diskcache
 import platformdirs
 
 
+def get_disk_cache_path(cache_name: str, *, cache_dir: str | None = None) -> str:
+    """Retrieve the path of a cache."""
+    cache_dir = cache_dir or os.path.join(platformdirs.user_cache_dir(), "qldpc")
+    return os.path.join(cache_dir, cache_name)
+
+
 def get_disk_cache(cache_name: str, *, cache_dir: str | None = None) -> diskcache.Cache:
     """Retrieve a dictionary-like cache object."""
     if running_with_pytest():
         return {}
-    cache_dir = cache_dir or os.path.join(platformdirs.user_cache_dir(), "qldpc")
-    cache_path = os.path.join(cache_dir, cache_name)
-    return diskcache.Cache(cache_path)
+    return diskcache.Cache(get_disk_cache_path(cache_name, cache_dir=cache_dir))
 
 
 def use_disk_cache(
@@ -56,6 +61,7 @@ def use_disk_cache(
                 key = key_func(*args, **kwargs)
             else:
                 key = args + tuple(kwargs.items())
+                key = key if len(key) != 1 else key[0]  # unpack length-1 tuples
             if key in cache:
                 return cache[key]
 
@@ -72,3 +78,17 @@ def use_disk_cache(
 def running_with_pytest() -> bool:
     """Are we currently running  with pytest?"""
     return "pytest" in sys.modules
+
+
+def clear_entry(cache_name: str, key: Hashable, *, cache_dir: str | None = None) -> None:
+    """Clear an entry from a local cache."""
+    cache = get_disk_cache(cache_name, cache_dir=cache_dir)
+    if key in cache:
+        del cache[key]
+    else:
+        cache_path = get_disk_cache_path(cache_name, cache_dir=cache_dir)
+        warnings.warn(
+            f"Attempted to delete the entry '{key}' from the cache '{cache_name}'"
+            + ("" if cache_dir is None else f" (located at '{cache_path}')")
+            + ", but this entry does not exist."
+        )


### PR DESCRIPTION
To migrate the old cache to the new one with simplified keys:

```python
import glob
import os
import diskcache
import qldpc

for directory in glob.glob(os.path.join(qldpc.cache.get_disk_cache_path(""), "*")):
    cache = diskcache.Cache(directory)
    for key in cache:
        if isinstance(key, tuple) and len(key) == 1:
            cache[key[0]] = cache[key]
            del cache[key]
```