### PR TITLE
Allow initializing `Record`s with `dict[Hashable, int]`

### DIFF
--- a/src/qldpc/circuits/benchmarking.py
+++ b/src/qldpc/circuits/benchmarking.py
@@ -97,7 +97,7 @@ def get_state_prep_diagnostic_circuit(
     stabilizer_detectors = stim.Circuit()
     for meas_index in range(-stabilizer_measurements.num_measurements, 0):
         stabilizer_detectors.append("DETECTOR", [stim.target_rec(meas_index)])
-    detector_record.append({ss: [ss] for ss in range(len(code.get_stabilizer_ops()))})
+    detector_record.append({ss: ss for ss in range(len(code.get_stabilizer_ops()))})
 
     # if none were provided, automatically find the logical Pauli stabilizers of the prepared state
     if observables is None:
@@ -297,7 +297,7 @@ def get_logical_error_and_discard_rates(
     noise_model_family: Callable[[float], NoiseModel] = DepolarizingNoiseModel,
     *,
     sinter_decoder: sinter.Decoder | Sequence[sinter.Decoder],
-    num_samples: int | Sequence[float],
+    num_samples: int | Sequence[int],
     observables: npt.NDArray[np.int_]
     | Sequence[Sequence[int]]
     | Sequence[stim.PauliString]
@@ -348,9 +348,9 @@ def get_logical_error_and_discard_rates(
     diagnostic_circuit, detector_record = get_state_prep_diagnostic_circuit(
         code, state_prep_circuit, observables=observables
     )
-    if not hasattr(num_samples, "__getitem__"):
+    if not isinstance(num_samples, Sequence):
         num_samples = [num_samples] * len(error_rates)
-    if not hasattr(sinter_decoder, "__getitem__"):
+    if not isinstance(sinter_decoder, Sequence):
         sinter_decoder = [sinter_decoder] * len(error_rates)
 
     logical_error_rates = np.zeros(len(error_rates), dtype=float)

--- a/src/qldpc/circuits/bookkeeping.py
+++ b/src/qldpc/circuits/bookkeeping.py
@@ -21,7 +21,7 @@ import collections
 import copy
 import dataclasses
 import itertools
-from collections.abc import Hashable, ItemsView, Iterator, Mapping, Sequence
+from collections.abc import Hashable, ItemsView, Iterable, Iterator, Mapping, Sequence
 from typing import NamedTuple
 
 import numpy as np
@@ -121,10 +121,16 @@ class Record(Mapping[Hashable, list[int]]):
     num_events: int
     key_to_events: dict[Hashable, list[int]]
 
-    def __init__(self, initial_record: Mapping[Hashable, Sequence[int]] | None = None) -> None:
+    def __init__(
+        self, initial_record: Mapping[Hashable, Iterable[int] | int] | None = None
+    ) -> None:
         self.key_to_events = collections.defaultdict(list)
         if initial_record:
-            self.key_to_events |= {key: list(events) for key, events in initial_record.items()}
+            _record = {  # convert initial_record into dict[int, list[int]]
+                key: list(events) if isinstance(events, Iterable) else [events]
+                for key, events in initial_record.items()
+            }
+            self.key_to_events |= _record
         self.num_events = sum(len(events) for events in self.key_to_events.values())
 
     def __repr__(self) -> str:
@@ -159,7 +165,7 @@ class Record(Mapping[Hashable, list[int]]):
             {copy.deepcopy(key): copy.deepcopy(events) for key, events in self.items()}
         )
 
-    def append(self, record: Mapping[Hashable, Sequence[int]], repeat: int = 1) -> None:
+    def append(self, record: Mapping[Hashable, Iterable[int] | int], repeat: int = 1) -> None:
         """Append the given record to this one.
 
         All event numbers in the appended record are increased by the number of events in the current
@@ -167,8 +173,12 @@ class Record(Mapping[Hashable, list[int]]):
         (0, 1, ...) in the appended record are added to the current record as (n, n+1, ...).
         """
         assert repeat >= 0
-        num_events_in_record = sum(len(events) for _, events in record.items())
-        for key, events in record.items():
+        _record = {  # convert input record into dict[int, list[int]]
+            key: list(events) if isinstance(events, Iterable) else [events]
+            for key, events in record.items()
+        }
+        num_events_in_record = sum(len(events) for _, events in _record.items())
+        for key, events in _record.items():
             self.key_to_events[key].extend(
                 [
                     self.num_events + measurement + repetition * num_events_in_record
@@ -178,7 +188,7 @@ class Record(Mapping[Hashable, list[int]]):
             )
         self.num_events += num_events_in_record * repeat
 
-    def __iadd__(self, other: Mapping[Hashable, Sequence[int]]) -> Self:
+    def __iadd__(self, other: Mapping[Hashable, Iterable[int] | int]) -> Self:
         """Append the given record to this one.  See help(qldpc.circuits.Record.append)."""
         self.append(other)
         return self

--- a/src/qldpc/circuits/bookkeeping.py
+++ b/src/qldpc/circuits/bookkeeping.py
@@ -126,7 +126,7 @@ class Record(Mapping[Hashable, list[int]]):
     ) -> None:
         self.key_to_events = collections.defaultdict(list)
         if initial_record:
-            _record = {  # convert initial_record into dict[int, list[int]]
+            _record = {  # convert initial_record into dict[Hashable, list[int]]
                 key: list(events) if isinstance(events, Iterable) else [events]
                 for key, events in initial_record.items()
             }
@@ -173,7 +173,7 @@ class Record(Mapping[Hashable, list[int]]):
         (0, 1, ...) in the appended record are added to the current record as (n, n+1, ...).
         """
         assert repeat >= 0
-        _record = {  # convert input record into dict[int, list[int]]
+        _record = {  # convert input record into dict[Hashable, list[int]]
             key: list(events) if isinstance(events, Iterable) else [events]
             for key, events in record.items()
         }

--- a/src/qldpc/circuits/bookkeeping_test.py
+++ b/src/qldpc/circuits/bookkeeping_test.py
@@ -55,17 +55,18 @@ def test_records() -> None:
     base_record = base_record + circuits.Record({0: [1], 2: [0]})
     assert base_record.num_events == 3
     base_record += {1: [0, 1]}
+    base_record.append({1: 0}, repeat=2)
     base_record.append({1: [0, 1]}, repeat=2)
-    assert base_record[1] == [3, 4, 5, 6, 7, 8]
+    assert base_record[1] == [3, 4, 5, 6, 7, 8, 9, 10]
     assert len(base_record) == 3
     assert list(iter(base_record)) == list(base_record.keys())
     assert dict(base_record.items()) == base_record.key_to_events
 
     measurement_record = circuits.MeasurementRecord(base_record.key_to_events)
-    assert measurement_record.num_events == 9
-    assert measurement_record.get_target_rec(2) == stim.target_rec(-8)
-    assert measurement_record.get_target_rec(0) == stim.target_rec(-7)
-    assert measurement_record.get_target_rec(0, -2) == stim.target_rec(-9)
+    assert measurement_record.num_events == 11
+    assert measurement_record.get_target_rec(2) == stim.target_rec(-10)
+    assert measurement_record.get_target_rec(0) == stim.target_rec(-9)
+    assert measurement_record.get_target_rec(0, -2) == stim.target_rec(-11)
 
     with pytest.raises(ValueError, match="Invalid measurement index"):
         measurement_record.get_target_rec(3)
@@ -73,7 +74,7 @@ def test_records() -> None:
         measurement_record.get_target_rec(0, 2)
 
     detector_record = circuits.DetectorRecord(base_record.key_to_events)
-    assert detector_record.num_events == 9
+    assert detector_record.num_events == 11
     assert detector_record.get_detector(2) == 1
     assert detector_record.get_detector(0) == 2
     assert detector_record.get_detector(0, -2) == 0

--- a/src/qldpc/circuits/memory.py
+++ b/src/qldpc/circuits/memory.py
@@ -263,7 +263,7 @@ def _get_basis_memory_experiment_parts(
     # measure out the data qubits
     readout = stim.Circuit()
     readout.append(f"M{basis}", data_ids)
-    measurement_record.append({data_id: [mm] for mm, data_id in enumerate(data_ids)})
+    measurement_record.append({data_id: mm for mm, data_id in enumerate(data_ids)})
 
     # detectors for stabilizers that can be inferred from data qubit measurements
     readout.append("SHIFT_COORDS", [], (1, 0, 0))
@@ -276,7 +276,7 @@ def _get_basis_memory_experiment_parts(
             + [measurement_record.get_target_rec(check_id)],
             (0, 0, kk),
         )
-    detector_record.append({check_id: [dd] for dd, check_id in enumerate(basis_check_ids)})
+    detector_record.append({check_id: dd for dd, check_id in enumerate(basis_check_ids)})
 
     # annotate all basis-type observables
     targets = [measurement_record.get_target_rec(data_id) for data_id in data_ids]
@@ -327,14 +327,14 @@ def _get_combined_memory_simulation_parts(
 
     # update the measurement record, add detectors, and update the detector record
     readout.append("SHIFT_COORDS", [], (1, 0, 0))
-    measurement_record.append({check_id: [mm] for mm, check_id in enumerate(check_ids)})
+    measurement_record.append({check_id: mm for mm, check_id in enumerate(check_ids)})
     for kk, check_id in enumerate(check_ids):
         targets = [
             measurement_record.get_target_rec(check_id, -1),
             measurement_record.get_target_rec(check_id, -2),
         ]
         readout.append("DETECTOR", targets, (0, 0, kk))
-    detector_record.append({check_id: [dd] for dd, check_id in enumerate(check_ids)})
+    detector_record.append({check_id: dd for dd, check_id in enumerate(check_ids)})
 
     # annotate all observables
     observables = get_observables(code, data_ids)
@@ -508,7 +508,7 @@ def _get_qec_cycle(
     measurement_record.append(round_measurement_record)
     for kk, check_id in enumerate(check_ids):
         circuit.append("DETECTOR", [measurement_record.get_target_rec(check_id)], (0, 0, kk))
-    detector_record.append({check_id: [dd] for dd, check_id in enumerate(check_ids)})
+    detector_record.append({check_id: dd for dd, check_id in enumerate(check_ids)})
 
     # apply following repeated rounds of QEC and detectors
     if num_rounds > 1:
@@ -526,7 +526,7 @@ def _get_qec_cycle(
         # update the measurement and detector records to account for repetitions
         measurement_record.append(round_measurement_record, repeat=num_rounds - 2)
         detector_record.append(
-            {check_id: [dd] for dd, check_id in enumerate(check_ids)}, repeat=num_rounds - 1
+            {check_id: dd for dd, check_id in enumerate(check_ids)}, repeat=num_rounds - 1
         )
 
     return circuit, measurement_record, detector_record

--- a/src/qldpc/codes/quantum.py
+++ b/src/qldpc/codes/quantum.py
@@ -23,7 +23,7 @@ import functools
 import itertools
 import math
 import os
-from collections.abc import Collection, Iterator, Sequence
+from collections.abc import Collection, Iterable, Iterator, Sequence
 
 import galois
 import networkx as nx
@@ -1166,7 +1166,7 @@ class CHGPCode(HGPCode):
 
         If provided only one block length or one polynomial, use it for both underlying CyclicCodes.
         """
-        if hasattr(dims, "__iter__"):
+        if isinstance(dims, Iterable):
             bits_a, bits_b = dims
         else:
             bits_a = bits_b = int(dims)


### PR DESCRIPTION
This is always how I initialize `Record`s in practice (as opposed to the previously only allowable `dict[Hashable, Sequence[int]]`).

Also clean up some unrelated type checks.