### PR TITLE
Human-readable `RingArray`s and Howell normal form

### DIFF
--- a/src/qldpc/abstract.py
+++ b/src/qldpc/abstract.py
@@ -969,11 +969,11 @@ class RingArray(npt.NDArray[np.object_]):
         vals = [val.to_vector() for val in self.ravel()]
         return np.asarray(vals).ravel().view(self.field)
 
-    def null_space(self, *, force_heuristic: bool = True) -> RingArray:
+    def null_space(self, *, row_reduce: bool = True) -> RingArray:
         """Construct a matrix of null-space row vectors for this RingArray.
 
         The transpose of the null-space matrix is annihilated by this RingArray, such that
-        np.any(self @ self.null_space().T) is False
+        np.any(self @ self.null_space().T) is np.False_.
         """
         assert self.ndim == 2
 
@@ -982,137 +982,70 @@ class RingArray(npt.NDArray[np.object_]):
         null_field_vectors = self.regular_lift().null_space()
 
         # collect ring-valued null row vectors (that is, transposed null column vectors)
-        null_vectors = ~RingArray.from_field_array(
+        null_space = ~RingArray.from_field_array(
             self.ring,
             null_field_vectors.reshape(len(null_field_vectors), -1, self.group.order),
         )
+        if not row_reduce:
+            return null_space
 
-        return null_vectors.row_reduce(force_heuristic=force_heuristic)
+        try:
+            return null_space.row_reduce()
+        except NotImplementedError as error:
+            raise NotImplementedError(
+                "Cannot row-reduce the null-space matrix of this RingArray.  Try calling"
+                f" RingArray.null_space(row_reduce=False).  Error from row reduction:\n{error}"
+            )
 
-    def row_reduce(self, *, force_heuristic: bool = True) -> RingArray:
-        """Compute the reduced row Echelon form of this RingArray, or the closest we can get to it.
+    def row_reduce(self) -> RingArray:
+        """Compute an appropriate generalization of the reduced row Echelon form for this RingArray.
 
-        Use a series of heuristics for (possibly only partial) row reduction.  Every row in the
-        returned RingArray is guaranteed to satisfy one the following:
-        (a) there is some column at which the row is 1 and all other rows are 0, or
-        (b) all entries of the row are non-invertible.
-        Moreover, all rows of the returned RingArray are linearly independent and nonzero.
+        In full generality, what we seek is a reduced Groebner basis for the row module of this
+        RingArray.  In some special cases, this basis coincides with the Howell normal form.
+        """
+        if isinstance(self.ring.group, CyclicGroup):
+            return self._row_reduce_principal_ideal()
+        if self.ring.is_semisimple:
+            return self._row_reduce_semisimple()
+        return self._row_reduce_general()
+
+    def _row_reduce_principal_ideal(self) -> RingArray:
+        """Compute the Howell normal form of this RingArray.
+
+        This method currently only supports rings whose underlying group is a cyclic group.
+        It can in principle be generalized to support any Principal ideal ring.
         """
         assert self.ndim == 2
+        assert isinstance(self.ring.group, CyclicGroup)
+        raise NotImplementedError("Work in progress...")
 
-        if self.ring.is_semisimple and not force_heuristic:
-            return self._exact_row_reduce()
-
-        if not force_heuristic:
-            warnings.warn(
-                "RingArray.row_reduce only supports exact row reduction for semisimple group"
-                " algebras, for which the field.characteristic does not divide the group.order."
-                "  Using heuristics for (possibly only partial) row reduction instead.",
-            )
-        return self._heuristic_row_reduce()
-
-    def _exact_row_reduce(self) -> RingArray:
-        """Perform exact row reduction based on the Wedderburn-Artin decomposition of the base ring.
+    def _row_reduce_semisimple(self) -> RingArray:
+        """Perform row reduction based on the Wedderburn-Artin decomposition of the base ring.
 
         A semisimple ring can be decomposed into a direct product of simple rings, which are in turn
         isomorphic to matrix algebras over finite fields.  This method thereby row-reduces a
-        RingArray over a semisimple ring by
+        RingArray over a semisimple ring by...
         (a) decomposing the RingArray into its simple components,
         (b) "lifting" each component to a matrix over a finite field,
-        (c) row-reducing these matrices, and
-        (d) mapping back to a RingArray over the original semisimple ring.
-        At least, that's the plan.  It has yet to be implemented.
-        """
-        assert self.ring.is_semisimple
-        raise NotImplementedError(
-            "We only aspire to perform exact row reduction over semisimple rings :("
-        )
-
-    def _heuristic_row_reduce(self) -> RingArray:
-        """Use heuristics for (possibly only partial) row reduction.
-
-        Warning: this method is unoptimized.  There is a lot of room for speeding things up.
-        """
-
-        # greedily convert invertible entries into "pivots" that are uniquely nonzero in some column
-        matrix = self._reduce_rows_with_invertible_entries()
-
-        # split matrix into rows with pivots, and all other rows
-        pivot_matrix, non_pivot_matrix = matrix._split_by_pivots()
-
-        if non_pivot_matrix.size:
-            # identify a minimal basis for the span of the non-pivot rows
-            non_pivot_matrix = non_pivot_matrix._remove_linearly_dependent_rows()
-
-        return np.vstack([pivot_matrix, non_pivot_matrix]).view(RingArray)
-
-    def _reduce_rows_with_invertible_entries(self, *, restart_call: bool = False) -> RingArray:
-        """Row-reduce greedily using invertible entries.
-
-        Loop over every row.  If that row contains an invertible entry, normalize the row by this
-        entry's inverse, and zero out all other rows at the corresponding column by subtracting off
-        an appropriate multiple of this row (as you would with ordinary Gaussian elimination).
+        (c) row-reducing these matrices using ordinary linear algebra over fields,
+        (d) mapping back to a RingArray over the original semisimple ring,
+        (e) removing rows that are ring-linear combinations of others, and
+        (f) putting the remaining rows into a normal form, with pivots.
         """
         assert self.ndim == 2
-        rows: slice | list[int]
-
-        matrix = self if restart_call else self.copy()
-        num_rows, num_cols = self.shape
-
-        row_reductions_made = False  # did we perform row reductions?
-        noninvertible_rows = []  # which rows have only non-invertible entries?
-        for row in range(num_rows):
-            row_vector = matrix[row]
-
-            # look for an invertible entry in this row
-            for col, entry in enumerate(row_vector):
-                if inverse := entry.inverse():
-                    break
-
-            """
-            If we found an invertible entry,
-            - multiply this row by the inverse, so that this entry is 1, and
-            - zero out the corresponding column in all other rows.
-            """
-            if inverse:
-                # "normalize" the entry to 1, and zero out its column in all other rows
-                new_vector = inverse * row_vector
-                matrix[row] = new_vector
-                for rows in [slice(None, row), slice(row + 1, num_rows)]:
-                    matrix[rows] = matrix[rows] - matrix[rows, col, None] * new_vector[None, :]
-                row_reductions_made = True
-
-            else:
-                noninvertible_rows.append(row)
-
-        if row_reductions_made and noninvertible_rows:
-            # some non-invertible entries may have become invertible, so try row-reducing again
-            rows = [row for row in noninvertible_rows if np.any(matrix[row])]
-            matrix[rows].view(RingArray)._reduce_rows_with_invertible_entries(restart_call=True)
-
-        return matrix
-
-    def _split_by_pivots(self, *, allow_non_units: bool = True) -> tuple[RingArray, RingArray]:
-        """Split into a matrix with all "pivot" rows, and a matrix with all other nonzero rows.
-
-        "Pivot" rows are those that are uniquely nonzero in some column.  If allow_non_unit is
-        False, this nonzero entry is also required to be a unit (invertible entry) of the base ring
-        (group algebra) of this RingArray.
-        """
-        self_as_bool = self.astype(bool)
-        pivot_rows = np.zeros(len(self), dtype=bool)
-        pivot_cols = np.sum(self_as_bool, axis=0) == 1
-        for col in np.argwhere(pivot_cols):
-            row = np.argwhere(self_as_bool[:, col])[0][0]
-            pivot_rows[row] = allow_non_units or self[row, col][0].inverse()
-        pivot_matrix = self[pivot_rows]
-        non_pivot_matrix = self[~pivot_rows]
-        return (
-            pivot_matrix.view(RingArray),
-            non_pivot_matrix[np.any(non_pivot_matrix, axis=1)].view(RingArray),
+        assert self.ring.is_semisimple
+        raise NotImplementedError(
+            "We only aspire to support row reduction for RingArrays over semisimple rings :("
         )
 
-    def _remove_linearly_dependent_rows(self) -> RingArray:
+    def _row_reduce_general(self) -> RingArray:
+        """Compute a reduced Groebner basis for the row module of this RingArray."""
+        assert self.ndim == 2
+        raise NotImplementedError(
+            "We need to compute a reduced Groebner basis, in full generality.  Here be dragons."
+        )
+
+    def _remove_ring_linearly_dependent_rows(self) -> RingArray:
         """Remove rows that can be expressed as ring-linear combinations of others.
 
         Due to peculiarities of working with modules (the generalization of a vector space when

--- a/src/qldpc/abstract.py
+++ b/src/qldpc/abstract.py
@@ -41,6 +41,7 @@ from typing import Any, Literal, TypeVar, Union
 import galois
 import numpy as np
 import numpy.typing as npt
+import sympy.abc
 import scipy.linalg
 import sympy.combinatorics as comb
 import sympy.core
@@ -624,9 +625,12 @@ class RingMember:
             value, member = (1, term) if isinstance(term, GroupMember) else term
             self._vec[member] += self.field(value)
 
-    def __str__(self):
+    def __str__(self) -> str:
         if isinstance(self.group, CyclicGroup):
-            return galois.Poly(self.to_vector()[::-1], field=self.field).__str__()
+            terms = [
+                int(coeff) * sympy.abc.x**pow for pow, coeff in enumerate(self.to_vector()) if coeff
+            ]
+            return str(sum(terms) + sympy.core.numbers.Zero())
         return super().__str__()
 
     def __eq__(self, other: object) -> bool:
@@ -877,7 +881,7 @@ class RingArray(npt.NDArray[np.object_]):
             setattr(result, "_ring", next(iter(rings), None))
         return result
 
-    def __str__(self):
+    def __str__(self) -> str:
         if isinstance(self.group, CyclicGroup):
             return np.array2string(self, formatter={"object": str}, separator=", ")
         return super().__str__()

--- a/src/qldpc/abstract.py
+++ b/src/qldpc/abstract.py
@@ -626,24 +626,43 @@ class RingMember:
             self._vec[member] += self.field(value)
 
     def __str__(self) -> str:
-        if isinstance(self.group, AbelianGroup):
-            num_gens = len(self.group.generators)
-            if num_gens <= 3:
-                gens = [sympy.abc.x, sympy.abc.y, sympy.abc.z][:num_gens]
-            elif num_gens <= 26:
-                gens = sympy.symbols("a:z")[: len(self.group.orders)]
-            else:
-                index_length = int(np.ceil(np.log10(num_gens + 1)))
-                gens = [sympy.Symbol(f"x_{index:0{index_length}}") for index in range(num_gens)]
-            symbols = []
-            for powers in itertools.product(*[range(order) for order in self.group.orders]):
-                factors = [gen**power for gen, power in zip(gens, powers)]
-                symbols.append(functools.reduce(operator.mul, factors))
-            terms = [
-                int(coeff) * symbol for coeff, symbol in zip(self.to_vector(), symbols) if coeff
+        """Write this RingMember as a polynomial."""
+        # identify symbols for the generators of the base group
+        num_gens = len(self.group.generators)
+        if num_gens <= 26:
+            symbols = sympy.symbols("a:z", commutative=self.group.is_abelian)[-num_gens:]
+        else:
+            index_length = int(np.ceil(np.log10(num_gens + 1)))
+            symbols = [
+                sympy.Symbol(f"x_{index:0{index_length}}", commutative=self.group.is_abelian)
+                for index in range(num_gens)
             ]
-            return str(sum(terms) + sympy.core.numbers.Zero()).replace("**", "^")
-        return super().__str__()
+
+        if isinstance(self.group, AbelianGroup):
+            # Abelian groups are an easy special case for building the polynomial
+            monomials = []
+            for powers in itertools.product(*[range(order) for order in self.group.orders]):
+                factors = [symbol**power for symbol, power in zip(symbols, powers)]
+                monomials.append(functools.reduce(operator.mul, factors))
+            terms = [
+                int(coeff) * monomial
+                for coeff, monomial in zip(self.to_vector(), monomials)
+                if coeff
+            ]
+
+        else:
+            # general-purpose fallback
+            sympy_group = self.group.to_sympy()
+            gen_to_symbol = {gen: symbol for gen, symbol in zip(sympy_group.generators, symbols)}
+
+            terms = []
+            for x_g, gg in self:
+                gens = sympy_group.generator_product(gg, original=True)
+                factors = [gen_to_symbol[gen] for gen in gens]
+                monomial = functools.reduce(operator.mul, factors, 1)
+                terms.append(int(x_g) * monomial)
+
+        return str(sum(terms) + sympy.core.numbers.Zero()).replace("**", "^")
 
     def __eq__(self, other: object) -> bool:
         return (
@@ -894,9 +913,7 @@ class RingArray(npt.NDArray[np.object_]):
         return result
 
     def __str__(self) -> str:
-        if isinstance(self.group, (CyclicGroup, AbelianGroup)):
-            return np.array2string(self, formatter={"object": str}, separator=", ")
-        return super().__str__()
+        return np.array2string(self, formatter={"object": str}, separator=", ")
 
     @property
     def ring(self) -> GroupRing:

--- a/src/qldpc/abstract.py
+++ b/src/qldpc/abstract.py
@@ -36,7 +36,7 @@ import math
 import operator
 import warnings
 from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
-from typing import Any, Literal, TypeVar, Union
+from typing import Any, Literal, Union
 
 import galois
 import numpy as np
@@ -49,10 +49,6 @@ import sympy.core
 from qldpc import external
 
 DEFAULT_FIELD_ORDER = 2
-
-FieldOrRingArray = TypeVar(
-    "FieldOrRingArray", bound=Union[npt.NDArray[np.int_], npt.NDArray[np.object_]]
-)
 
 
 ################################################################################

--- a/src/qldpc/abstract.py
+++ b/src/qldpc/abstract.py
@@ -1205,8 +1205,11 @@ class RingArray(npt.NDArray[np.object_]):
             "We need to compute a reduced Groebner basis, in full generality.  Here be dragons."
         )
 
-    def without_linearly_dependent_rows(self) -> RingArray:
-        """Remove rows that can be expressed as ring-linear combinations of others.
+    def without_dependent_rows(self) -> RingArray:
+        r"""Remove rows that can be expressed as left-ring-linear combinations of others.
+
+        A row v is a left-ring-linear combination of rows (w_1, w_2, ...) iff v = sum_i r_i w_i,
+        where (r_1, r_2, ...) are elements of the base ring.
 
         Due to peculiarities of working with modules (the generalization of a vector space when
         working over rings, rather than fields), we have to start by considering all rows in the
@@ -1215,8 +1218,8 @@ class RingArray(npt.NDArray[np.object_]):
         by accumulating linearly independent row vectors, is necessary because rows may have
         nontrivial annihilators, which is to say that a row v may have a ring element r for which
         r * v = 0 even though r and v are both nonzero.  It is therefore possible, for examle, for a
-        row v to lie in the left-ring-linear span of another row w (v = r * w for some r), but not
-        the other way around (there is no r for which w = r * v).
+        row v to lie in the ring-linear span of another row w (v = r * w for some r), but not the
+        other way around (there is no r for which w = r * v).
         """
         assert self.ndim == 2
 

--- a/src/qldpc/abstract.py
+++ b/src/qldpc/abstract.py
@@ -1032,17 +1032,17 @@ class RingArray(npt.NDArray[np.object_]):
         # Analogous to N in the ring of integers modulo N.
         modulus_poly = galois.Poly([1] + [0] * (self.group.order - 2) + [-1], self.field)
 
-        def _multiply(poly: galois.Poly, vec: galois.FieldArray) -> galois.FieldArray:
-            """Multiply a member of a cyclic group algebra into an group-algebra-valued vector.
+        def _multiply(poly: galois.Poly, vecs: galois.FieldArray) -> galois.FieldArray:
+            """Multiply a member of a polynomial ring into a ring-valued matrix.
 
-            The first argument is represented by a galois polynomial, while the second element is
-            represented by an two-dimensional array of coefficients in the field, such that
-            vec[i, p] is the coefficient of x^p in the i-th entry of vec.
+            The first argument represents a ring member by a polynomial, while the second argument
+            represents a (vecs.ndim-1)-dimensional array of polynomials, such that
+            vecs[*entry, c] is the coefficient of x^c in the given entry of vec.
             """
-            new_vec = vec.Zeros(vec.shape)
+            new_vecs = vecs.Zeros(vecs.shape)
             for coeff, degree in zip(poly.nonzero_coeffs, poly.nonzero_degrees):
-                new_vec += coeff * np.roll(vec, degree, axis=1)
-            return new_vec
+                new_vecs += coeff * np.roll(vecs, degree, axis=-1)
+            return new_vecs
 
         pivot_row = 0
         pivot_col = 0
@@ -1063,6 +1063,8 @@ class RingArray(npt.NDArray[np.object_]):
             for other_row in range(pivot_row + 1, self.shape[0]):
                 aa_vec = field_array[pivot_row]
                 bb_vec = field_array[other_row]
+                if not np.any(bb_vec):
+                    continue
                 """
                 Let:
                     aa = aa_vec[pivot_row]
@@ -1076,8 +1078,8 @@ class RingArray(npt.NDArray[np.object_]):
                 Condition (3) ensures that this transformation is invertible.
                 Condition (2) ensures that bb_vec gets zeroed out at the pivot column.
                 """
-                aa_poly = galois.Poly(field_array[pivot_row, pivot_col, ::-1], field=self.field)
-                bb_poly = galois.Poly(field_array[other_row, pivot_col, ::-1], field=self.field)
+                aa_poly = galois.Poly(aa_vec[pivot_col, ::-1], field=self.field)
+                bb_poly = galois.Poly(bb_vec[pivot_col, ::-1], field=self.field)
 
                 # find gg, ss, tt, uu, vv, and work around some typing bugs/errors in galois/mypy
                 gg_poly: galois.Poly
@@ -1094,14 +1096,14 @@ class RingArray(npt.NDArray[np.object_]):
 
             """
             "Reduce" the pivot:
-            (1) Find ss for which ss * pivot = gcd(pivot, modulus).
-            (2) Multiply the pivot row by ss, reducing the pivot to gcd(pivot, modulus).
+            (1) Find ff for which ff * pivot = gcd(pivot, modulus).
+            (2) Multiply the pivot row by ff, reducing the pivot to gcd(pivot, modulus).
             """
             pivot_poly = galois.Poly(field_array[pivot_row, pivot_col, ::-1], field=self.field)
-            gg_poly, ss_poly, _ = galois.egcd(pivot_poly, modulus_poly)
-            if pivot_poly != gg_poly:
-                field_array[pivot_row] = _multiply(ss_poly, field_array[pivot_row])
-                pivot_poly = galois.Poly(field_array[pivot_row, pivot_col, ::-1], field=self.field)
+            gcd_poly, ff_poly, _ = galois.egcd(pivot_poly, modulus_poly)
+            if pivot_poly != gcd_poly:
+                field_array[pivot_row] = _multiply(ff_poly, field_array[pivot_row])
+                pivot_poly = gcd_poly
 
             # reduce all rows above the pivot_row at the pivot_column
             pivot_vec = field_array[pivot_row, pivot_col]
@@ -1112,20 +1114,20 @@ class RingArray(npt.NDArray[np.object_]):
                     field_array[other_row] -= _multiply(div_poly, pivot_vec)
 
             """
-            Check whether the pivot has a nontrivial annihilator, for which
-                annihilator * pivot = 0
+            Check whether the pivot has a nontrivial annihilator, with annihilator * pivot = 0.
             If a nontrivial annihilator is found, append a new row with the pivot annihilated.
             """
             annihilator_poly = modulus_poly // pivot_poly
             if annihilator_poly != 0:
-                field_array.append(_multiply(annihilator_poly, pivot_vec))
+                new_row = _multiply(annihilator_poly, field_array[pivot_row])
+                field_array = np.concatenate([field_array, new_row[np.newaxis]], axis=0)
 
             pivot_row += 1
             pivot_col += 1
 
         # remove all-zero rows and return
         field_array = field_array[np.any(field_array, axis=(1, 2))]
-        raise RingArray.from_field_array(self.ring, field_array)
+        return RingArray.from_field_array(self.ring, field_array)
 
     def _row_reduce_semisimple(self) -> RingArray:
         """Perform row reduction based on the Wedderburn-Artin decomposition of the base ring.

--- a/src/qldpc/abstract.py
+++ b/src/qldpc/abstract.py
@@ -5,6 +5,9 @@ a subgroup of the symmetric group.  Group members subclass the SymPy Permutation
 
 !!! WARNINGS !!!
 
+First and foremoest, this module does not promise to be performant.  If you need to do heavy
+numerical abstract algebra, you're probably better served by GAP or MAGMA (or maybe SageMath).
+
 This module only supports representations of group members by orthogonal matrices over finite
 fields.  The restriction to orthogonal representations allows identifying the "transpose" of a group
 member p with respect to a representation (lift) L, which is defined by enforcing L(p.T) = L(p).T.

--- a/src/qldpc/abstract.py
+++ b/src/qldpc/abstract.py
@@ -36,7 +36,7 @@ import math
 import operator
 import warnings
 from collections.abc import Callable, Iterable, Iterator, Mapping, Sequence
-from typing import Any, Literal, Union
+from typing import Any, Literal, TypeVar, Union
 
 import galois
 import numpy as np
@@ -48,6 +48,10 @@ import sympy.core
 from qldpc import external
 
 DEFAULT_FIELD_ORDER = 2
+
+FieldOrRingArray = TypeVar(
+    "FieldOrRingArray", bound=Union[npt.NDArray[np.int_], npt.NDArray[np.object_]]
+)
 
 
 ################################################################################
@@ -1100,7 +1104,9 @@ class RingArray(npt.NDArray[np.object_]):
             (2) Multiply the pivot row by ff, reducing the pivot to gcd(pivot, modulus).
             """
             pivot_poly = galois.Poly(field_array[pivot_row, pivot_col, ::-1], field=self.field)
-            gcd_poly, ff_poly, _ = galois.egcd(pivot_poly, modulus_poly)
+            gcd_poly: galois.Poly
+            ff_poly: galois.Poly
+            gcd_poly, ff_poly, _ = galois.egcd(pivot_poly, modulus_poly)  # type:ignore[assignment,arg-type]
             if pivot_poly != gcd_poly:
                 field_array[pivot_row] = _multiply(ff_poly, field_array[pivot_row])
                 pivot_poly = gcd_poly

--- a/src/qldpc/abstract.py
+++ b/src/qldpc/abstract.py
@@ -1192,9 +1192,8 @@ class RingArray(npt.NDArray[np.object_]):
         (a) decomposing the RingArray into its simple components,
         (b) "lifting" each component to a matrix over a finite field,
         (c) row-reducing these matrices using ordinary linear algebra over fields,
-        (d) mapping back to a RingArray over the original semisimple ring,
-        (e) removing rows that are ring-linear combinations of others, and
-        (f) putting the remaining rows into a normal form, with pivots.
+        (d) mapping back to a RingArray over the original semisimple ring, and
+        (e) doing some final cleanup (TBD).
         """
         assert self.ndim == 2
         assert self.ring.is_semisimple

--- a/src/qldpc/abstract.py
+++ b/src/qldpc/abstract.py
@@ -1004,16 +1004,23 @@ class RingArray(npt.NDArray[np.object_]):
         RingArray.  In some special cases, this basis coincides with the Howell normal form.
         """
         if isinstance(self.group, CyclicGroup):
-            return self._row_reduce_principal_ideal()
+            return self._row_reduce_cyclic()
+        # TODO: special case for principal ideal rings that are not based on a cyclic group
         if self.ring.is_semisimple:
             return self._row_reduce_semisimple()
         return self._row_reduce_general()
 
-    def _row_reduce_principal_ideal(self) -> RingArray:
-        """Compute the Howell normal form of this RingArray.
+    def _row_reduce_cyclic(self) -> RingArray:
+        """Compute the Howell normal form of a RingArray based on the cyclic group.
 
-        This method currently only supports rings whose underlying group is a cyclic group.
-        It can in principle be generalized to support any Principal ideal ring.
+        If the base group is a cyclic group, then the base ring is a univariate polynomial ring.
+        The extended Euclidean algorithm (galois.egcd) then equips us with invertible row operations
+        that we can use to "reduce" the RingArray into a Howell normal form, which is the closest we
+        can get to a reduced row Echelon form (RREF) for this RingArray.
+
+        References:
+        - https://en.wikipedia.org/wiki/Howell_normal_form
+        - https://github.com/m-webster/XPFpackage/blob/570ea89/Examples/A.1_howell_matrix.ipynb
         """
         assert self.ndim == 2
         assert isinstance(self.group, CyclicGroup)
@@ -1048,63 +1055,77 @@ class RingArray(npt.NDArray[np.object_]):
                     pivot_found = True
                     break
 
-            if pivot_found:
-                # zero out all rows below the pivot_row at the pivot column
-                for other_row in range(pivot_row + 1, self.shape[0]):
-                    aa_vec = field_array[pivot_row]
-                    bb_vec = field_array[other_row]
-                    """
-                    Let:
-                        aa = aa_vec[pivot_row]
-                        bb = bb_vec[other_row]
-                    We will transform rows as
-                        [aa_vec, bb_vec] --> [[ss, tt], [uu, vv]] @ [aa_vec, bb_vec]
-                    where
-                        (1) ss * aa + tt * bb = gcd(aa, bb) = gg
-                        (2) uu * aa + vv * bb = 0
-                        (3) det([[ss, tt], [uu, vv]]) = ss * vv - tt * uu = 1
-                    Condition (3) ensures that this transformation is invertible, while condition
-                    (2) ensures that bb_vec gets zeroed out at the pivot column.
-                    """
-                    aa_poly = galois.Poly(field_array[pivot_row, pivot_col, ::-1], field=self.field)
-                    bb_poly = galois.Poly(field_array[other_row, pivot_col, ::-1], field=self.field)
+            if not pivot_found:
+                pivot_col += 1
+                continue
 
-                    # find gg, ss, tt, uu, vv, and work around some typing bugs/errors in galois/mypy
-                    gg_poly: galois.Poly
-                    ss_poly: galois.Poly
-                    tt_poly: galois.Poly
-                    gg_poly, ss_poly, tt_poly = galois.egcd(aa_poly, bb_poly)  # type:ignore[assignment,arg-type]
-                    uu_poly = -bb_poly // gg_poly
-                    vv_poly = aa_poly // gg_poly
-
-                    new_aa_vec = _multiply(ss_poly, aa_vec) + _multiply(tt_poly, bb_vec)
-                    new_bb_vec = _multiply(uu_poly, aa_vec) + _multiply(vv_poly, bb_vec)
-                    field_array[pivot_row] = new_aa_vec
-                    field_array[other_row] = new_bb_vec
-
+            # use invertible row operations to zero out all rows below at the pivot column
+            for other_row in range(pivot_row + 1, self.shape[0]):
+                aa_vec = field_array[pivot_row]
+                bb_vec = field_array[other_row]
                 """
-                Reduce the pivot, aa: find a ss for which ss * aa = gcd(aa, modulus) = gg.
-                Multiply the pivot row by ss, reducing aa to gg.
+                Let:
+                    aa = aa_vec[pivot_row]
+                    bb = bb_vec[other_row]
+                We will transform rows as
+                    [aa_vec, bb_vec] --> [[ss, tt], [uu, vv]] @ [aa_vec, bb_vec]
+                where
+                    (1) ss * aa + tt * bb = gcd(aa, bb) = gg
+                    (2) uu * aa + vv * bb = 0
+                    (3) det([[ss, tt], [uu, vv]]) = ss * vv - tt * uu = 1
+                Condition (3) ensures that this transformation is invertible.
+                Condition (2) ensures that bb_vec gets zeroed out at the pivot column.
                 """
                 aa_poly = galois.Poly(field_array[pivot_row, pivot_col, ::-1], field=self.field)
-                gg_poly, ss_poly, _ = galois.egcd(aa_poly, modulus_poly)
-                if aa_poly != gg_poly:
-                    field_array[pivot_row] = _multiply(ss_poly, _multiply)
+                bb_poly = galois.Poly(field_array[other_row, pivot_col, ::-1], field=self.field)
 
-                # reduce all rows above the pivot_row at the pivot_column
-                for other_row in range(pivot_row):
-                    bb_poly = galois.Poly(field_array[other_row, pivot_col, ::-1], field=self.field)
-                    ss_poly = bb_poly // aa_poly
-                    field_array[other_row] -= _multiply(ss_poly, aa_vec)
+                # find gg, ss, tt, uu, vv, and work around some typing bugs/errors in galois/mypy
+                gg_poly: galois.Poly
+                ss_poly: galois.Poly
+                tt_poly: galois.Poly
+                gg_poly, ss_poly, tt_poly = galois.egcd(aa_poly, bb_poly)  # type:ignore[assignment,arg-type]
+                uu_poly = -bb_poly // gg_poly
+                vv_poly = aa_poly // gg_poly
 
-                # if the pivot is a zero divisor, append a row that annihilates the pivot
-                ...
+                new_aa_vec = _multiply(ss_poly, aa_vec) + _multiply(tt_poly, bb_vec)
+                new_bb_vec = _multiply(uu_poly, aa_vec) + _multiply(vv_poly, bb_vec)
+                field_array[pivot_row] = new_aa_vec
+                field_array[other_row] = new_bb_vec
 
-                pivot_row += 1
+            """
+            "Reduce" the pivot:
+            (1) Find ss for which ss * pivot = gcd(pivot, modulus).
+            (2) Multiply the pivot row by ss, reducing the pivot to gcd(pivot, modulus).
+            """
+            pivot_poly = galois.Poly(field_array[pivot_row, pivot_col, ::-1], field=self.field)
+            gg_poly, ss_poly, _ = galois.egcd(pivot_poly, modulus_poly)
+            if pivot_poly != gg_poly:
+                field_array[pivot_row] = _multiply(ss_poly, field_array[pivot_row])
+                pivot_poly = galois.Poly(field_array[pivot_row, pivot_col, ::-1], field=self.field)
 
+            # reduce all rows above the pivot_row at the pivot_column
+            pivot_vec = field_array[pivot_row, pivot_col]
+            for other_row in range(pivot_row):
+                other_poly = galois.Poly(field_array[other_row, pivot_col, ::-1], field=self.field)
+                div_poly = other_poly // pivot_poly
+                if div_poly != 0:
+                    field_array[other_row] -= _multiply(div_poly, pivot_vec)
+
+            """
+            Check whether the pivot has a nontrivial annihilator, for which
+                annihilator * pivot = 0
+            If a nontrivial annihilator is found, append a new row with the pivot annihilated.
+            """
+            annihilator_poly = modulus_poly // pivot_poly
+            if annihilator_poly != 0:
+                field_array.append(_multiply(annihilator_poly, pivot_vec))
+
+            pivot_row += 1
             pivot_col += 1
 
-        raise NotImplementedError("Work in progress...")
+        # remove all-zero rows and return
+        field_array = field_array[np.any(field_array, axis=(1, 2))]
+        raise RingArray.from_field_array(self.ring, field_array)
 
     def _row_reduce_semisimple(self) -> RingArray:
         """Perform row reduction based on the Wedderburn-Artin decomposition of the base ring.

--- a/src/qldpc/abstract.py
+++ b/src/qldpc/abstract.py
@@ -1155,7 +1155,12 @@ class RingArray(npt.NDArray[np.object_]):
                 field_array[pivot_row] = _multiply(ff_poly, field_array[pivot_row])
                 pivot_poly = gcd_poly
 
-            # reduce all rows above the pivot_row at the pivot_column
+            """
+            Reduce all rows above the pivot_row at the pivot_column.
+            If some value in the pivot_col above the pivot_row can be written as a multiple of the
+            pivot plus a remainder, use row operations to subtract off that multiple of the pivot,
+            leaving only the remainder.
+            """
             for other_row in range(pivot_row):
                 other_poly = galois.Poly(field_array[other_row, pivot_col, ::-1], field=self.field)
                 div_poly = other_poly // pivot_poly

--- a/src/qldpc/abstract.py
+++ b/src/qldpc/abstract.py
@@ -1168,8 +1168,8 @@ class RingArray(npt.NDArray[np.object_]):
             """
             annihilator_poly = modulus_poly // pivot_poly
             if annihilator_poly != 0:
-                new_row = _multiply(annihilator_poly, field_array[pivot_row])[np.newaxis]
-                field_array = np.concatenate([field_array, new_row], axis=0).view(self.field)
+                new_row = _multiply(annihilator_poly, field_array[pivot_row])
+                field_array = np.append(field_array, [new_row], axis=0).view(self.field)
 
             pivot_row += 1
             pivot_col += 1

--- a/src/qldpc/abstract.py
+++ b/src/qldpc/abstract.py
@@ -1051,8 +1051,6 @@ class RingArray(npt.NDArray[np.object_]):
             if pivot_found:
                 # zero out all rows below the pivot_row at the pivot column
                 for lower_row in range(pivot_row + 1, self.shape[0]):
-                    if lower_row == pivot_row:
-                        continue
                     aa_vec = field_array[pivot_row]
                     bb_vec = field_array[lower_row]
                     """

--- a/src/qldpc/abstract.py
+++ b/src/qldpc/abstract.py
@@ -1157,12 +1157,11 @@ class RingArray(npt.NDArray[np.object_]):
                 pivot_poly = gcd_poly
 
             # reduce all rows above the pivot_row at the pivot_column
-            pivot_vec = field_array[pivot_row, pivot_col]
             for other_row in range(pivot_row):
                 other_poly = galois.Poly(field_array[other_row, pivot_col, ::-1], field=self.field)
                 div_poly = other_poly // pivot_poly
                 if div_poly != 0:
-                    field_array[other_row] -= _multiply(div_poly, pivot_vec)
+                    field_array[other_row] -= _multiply(div_poly, field_array[pivot_row])
 
             """
             Check whether the pivot has a nontrivial annihilator, with annihilator * pivot = 0.

--- a/src/qldpc/abstract.py
+++ b/src/qldpc/abstract.py
@@ -624,6 +624,11 @@ class RingMember:
             value, member = (1, term) if isinstance(term, GroupMember) else term
             self._vec[member] += self.field(value)
 
+    def __repr__(self):
+        if isinstance(self.group, CyclicGroup):
+            return galois.Poly(self.to_vector()[::-1], field=self.field).__repr__()
+        return super().__repr__()
+
     def __eq__(self, other: object) -> bool:
         return (
             isinstance(other, RingMember)

--- a/src/qldpc/abstract.py
+++ b/src/qldpc/abstract.py
@@ -1213,9 +1213,9 @@ class RingArray(npt.NDArray[np.object_]):
         we remove that row.  "Trimming down" to a minimal basis, as opposed to "building one up"
         by accumulating linearly independent row vectors, is necessary because rows may have
         nontrivial annihilators, which is to say that a row v may have a ring element r for which
-        r * v = 0 even though r and v are both nonzero.  It is therefore possible, for examle, for a
-        row v to lie in the ring-linear span of another row w (v = r * w for some r), but not the
-        other way around (there is no r for which w = r * v).
+        r * v = 0 even though r and v are both nonzero.  It is therefore possible, for example, for
+        a row v to lie in the left-ring-linear span of another row w (v = r * w for some r), but not
+        the other way around (there is no r for which w = r * v).
         """
         assert self.ndim == 2
 
@@ -1236,7 +1236,7 @@ class RingArray(npt.NDArray[np.object_]):
         """
         field_matrix = (~ring_matrix).view(RingArray).regular_lift()
 
-        # throw out rows that can be expressed as ring-linear combinations of other rows
+        # throw out rows that can be expressed as left-ring-linear combinations of other rows
         rows_to_keep = np.ones((len(ring_matrix), self.group.order), dtype=bool)
         for row in range(len(ring_matrix) - 1, -1, -1):
             rows_to_keep[row, :] = False

--- a/src/qldpc/abstract.py
+++ b/src/qldpc/abstract.py
@@ -633,7 +633,7 @@ class RingMember:
             symbols = sympy.symbols("x:z", commutative=self.group.is_abelian)[:num_gens]
         elif num_gens <= 26:
             symbols = sympy.symbols("a:z", commutative=self.group.is_abelian)[-num_gens:]
-        else:
+        else:  # pragma: no cover
             index_length = int(np.ceil(np.log10(num_gens + 1)))
             symbols = [
                 sympy.Symbol(f"x_{index:0{index_length}}", commutative=self.group.is_abelian)

--- a/src/qldpc/abstract.py
+++ b/src/qldpc/abstract.py
@@ -1168,8 +1168,8 @@ class RingArray(npt.NDArray[np.object_]):
             """
             annihilator_poly = modulus_poly // pivot_poly
             if annihilator_poly != 0:
-                new_row = _multiply(annihilator_poly, field_array[pivot_row])
-                field_array = np.concatenate([field_array, new_row[np.newaxis]], axis=0)
+                new_row = _multiply(annihilator_poly, field_array[pivot_row])[np.newaxis]
+                field_array = np.concatenate([field_array, new_row], axis=0).view(self.field)
 
             pivot_row += 1
             pivot_col += 1

--- a/src/qldpc/abstract.py
+++ b/src/qldpc/abstract.py
@@ -1205,18 +1205,18 @@ class RingArray(npt.NDArray[np.object_]):
             "We need to compute a reduced Groebner basis, in full generality.  Here be dragons."
         )
 
-    def _remove_ring_linearly_dependent_rows(self) -> RingArray:
+    def without_linearly_dependent_rows(self) -> RingArray:
         """Remove rows that can be expressed as ring-linear combinations of others.
 
         Due to peculiarities of working with modules (the generalization of a vector space when
-        working over rings, as opposed to fields), we have to start by considering all rows in the
+        working over rings, rather than fields), we have to start by considering all rows in the
         RingArray, and checking individually whether each row lies in the span of the rest; if so,
         we remove that row.  "Trimming down" to a minimal basis, as opposed to "building one up"
         by accumulating linearly independent row vectors, is necessary because rows may have
         nontrivial annihilators, which is to say that a row v may have a ring element r for which
-        r * v = 0 even though r and v are nonzero.  It is therefore possible, for examle, for a row
-        v to lie in the left-ring-linear span of another row w (v = r * w for some r), but not the
-        other way around (there is no r for which w = r * v).
+        r * v = 0 even though r and v are both nonzero.  It is therefore possible, for examle, for a
+        row v to lie in the left-ring-linear span of another row w (v = r * w for some r), but not
+        the other way around (there is no r for which w = r * v).
         """
         assert self.ndim == 2
 

--- a/src/qldpc/abstract.py
+++ b/src/qldpc/abstract.py
@@ -1003,7 +1003,7 @@ class RingArray(npt.NDArray[np.object_]):
         In full generality, what we seek is a reduced Groebner basis for the row module of this
         RingArray.  In some special cases, this basis coincides with the Howell normal form.
         """
-        if isinstance(self.ring.group, CyclicGroup):
+        if isinstance(self.group, CyclicGroup):
             return self._row_reduce_principal_ideal()
         if self.ring.is_semisimple:
             return self._row_reduce_semisimple()
@@ -1016,7 +1016,83 @@ class RingArray(npt.NDArray[np.object_]):
         It can in principle be generalized to support any Principal ideal ring.
         """
         assert self.ndim == 2
-        assert isinstance(self.ring.group, CyclicGroup)
+        assert isinstance(self.group, CyclicGroup)
+
+        # convert into 3-D, where the third dimension stores coefficients for group members
+        field_array = self.to_field_array()
+
+        def _multiply(poly: galois.Poly, vec: galois.FieldArray) -> galois.FieldArray:
+            """Multiply a member of a cyclic group algebra into an group-algebra-valued vector.
+
+            The first argument is represented by a galois polynomial, while the second element is
+            represented by an two-dimensional array of coefficients in the field, such that
+            vec[i, p] is the coefficient of x^p in the i-th entry of vec.
+            """
+            new_vec = vec.Zeros(vec.shape)
+            for coeff, degree in zip(poly.nonzero_coeffs, poly.nonzero_degrees):
+                new_vec += coeff * np.roll(vec, degree, axis=1)
+            return new_vec
+
+        pivot_row = 0
+        pivot_col = 0
+        while pivot_row < field_array.shape[0] and pivot_col < field_array.shape[1]:
+            # look for a pivot in this column
+            pivot_found = False
+            for row in range(pivot_row, field_array.shape[0]):
+                if np.any(field_array[row, pivot_col]):
+                    field_array[[pivot_row, row]] = field_array[[row, pivot_row]]
+                    pivot_found = True
+                    break
+
+            if pivot_found:
+                # zero out all rows below the pivot_row at the pivot column
+                for lower_row in range(pivot_row + 1, self.shape[0]):
+                    if lower_row == pivot_row:
+                        continue
+                    aa_vec = field_array[pivot_row]
+                    bb_vec = field_array[lower_row]
+                    """
+                    Let:
+                        aa = aa_vec[pivot_row]
+                        bb = bb_vec[other_row]
+                    We will transform rows as
+                        [aa_vec, bb_vec] --> [[ss, tt], [uu, vv]] @ [aa_vec, bb_vec]
+                    where
+                        (1) ss * aa + tt * bb = gcd(aa, bb) = gg
+                        (2) uu * aa + vv * bb = 0
+                        (3) det([[ss, tt], [uu, vv]]) = ss * vv - tt * uu = 1
+                    Condition (3) ensures that this transformation is invertible, while condition
+                    (2) ensures that bb_vec gets zeroed out at the pivot column.
+                    """
+                    aa_poly = galois.Poly(field_array[pivot_row, pivot_col, ::-1], field=self.field)
+                    bb_poly = galois.Poly(field_array[lower_row, pivot_col, ::-1], field=self.field)
+
+                    # find gg, ss, tt, uu, vv, and work around some typing bugs/errors in galois/mypy
+                    gg_poly: galois.Poly
+                    ss_poly: galois.Poly
+                    tt_poly: galois.Poly
+                    gg_poly, ss_poly, tt_poly = galois.egcd(aa_poly, bb_poly)  # type:ignore[assignment,arg-type]
+                    uu_poly = -bb_poly // gg_poly
+                    vv_poly = aa_poly // gg_poly
+
+                    new_aa_vec = _multiply(ss_poly, aa_vec) + _multiply(tt_poly, bb_vec)
+                    new_bb_vec = _multiply(uu_poly, aa_vec) + _multiply(vv_poly, bb_vec)
+                    field_array[pivot_row] = new_aa_vec
+                    field_array[lower_row] = new_bb_vec
+
+                # reduce the pivot to a minimal representative
+                ...
+
+                # reduce all rows above the pivot_row at the pivot_column
+                ...
+
+                # if the pivot is a zero divisor, append a row that annihilates the pivot
+                ...
+
+                pivot_row += 1
+
+            pivot_col += 1
+
         raise NotImplementedError("Work in progress...")
 
     def _row_reduce_semisimple(self) -> RingArray:

--- a/src/qldpc/abstract.py
+++ b/src/qldpc/abstract.py
@@ -664,7 +664,7 @@ class RingMember:
                 monomial = functools.reduce(operator.mul, factors, 1)
                 terms.append(int(x_g) * monomial)
 
-        return str(sum(terms) + sympy.core.numbers.Zero()).replace("**", "^")
+        return str(sum(terms) + sympy.core.numbers.Zero()).replace("**", "^").replace("*", " ")
 
     def __eq__(self, other: object) -> bool:
         return (

--- a/src/qldpc/abstract.py
+++ b/src/qldpc/abstract.py
@@ -41,8 +41,8 @@ from typing import Any, Literal, TypeVar, Union
 import galois
 import numpy as np
 import numpy.typing as npt
-import sympy.abc
 import scipy.linalg
+import sympy.abc
 import sympy.combinatorics as comb
 import sympy.core
 
@@ -626,11 +626,23 @@ class RingMember:
             self._vec[member] += self.field(value)
 
     def __str__(self) -> str:
-        if isinstance(self.group, CyclicGroup):
+        if isinstance(self.group, AbelianGroup):
+            num_gens = len(self.group.generators)
+            if num_gens <= 3:
+                gens = [sympy.abc.x, sympy.abc.y, sympy.abc.z][:num_gens]
+            elif num_gens <= 26:
+                gens = sympy.symbols("a:z")[: len(self.group.orders)]
+            else:
+                index_length = int(np.ceil(np.log10(num_gens + 1)))
+                gens = [sympy.Symbol(f"x_{index:0{index_length}}") for index in range(num_gens)]
+            symbols = []
+            for powers in itertools.product(*[range(order) for order in self.group.orders]):
+                factors = [gen**power for gen, power in zip(gens, powers)]
+                symbols.append(functools.reduce(operator.mul, factors))
             terms = [
-                int(coeff) * sympy.abc.x**pow for pow, coeff in enumerate(self.to_vector()) if coeff
+                int(coeff) * symbol for coeff, symbol in zip(self.to_vector(), symbols) if coeff
             ]
-            return str(sum(terms) + sympy.core.numbers.Zero())
+            return str(sum(terms) + sympy.core.numbers.Zero()).replace("**", "^")
         return super().__str__()
 
     def __eq__(self, other: object) -> bool:
@@ -882,7 +894,7 @@ class RingArray(npt.NDArray[np.object_]):
         return result
 
     def __str__(self) -> str:
-        if isinstance(self.group, CyclicGroup):
+        if isinstance(self.group, (CyclicGroup, AbelianGroup)):
             return np.array2string(self, formatter={"object": str}, separator=", ")
         return super().__str__()
 
@@ -1272,7 +1284,10 @@ class AbelianGroup(Group):
     initialized with direct_sum=True, the group members get lifted to a direct sum ⨁_i L(g_i)^{a_i}.
     """
 
+    orders: tuple[int, ...]
+
     def __init__(self, *orders: int, direct_sum: bool = False) -> None:
+        self.orders = orders
         group = comb.named_groups.AbelianGroup(*orders)
         order_text = ",".join(map(str, orders))
         name = f"AbelianGroup({order_text})"
@@ -1313,6 +1328,7 @@ class CyclicGroup(AbelianGroup):
     """
 
     def __init__(self, order: int) -> None:
+        self.orders = (order,)
         identity_mat = np.eye(order, dtype=int)
 
         # build lift manually, which is faster than the default lift

--- a/src/qldpc/abstract.py
+++ b/src/qldpc/abstract.py
@@ -624,10 +624,10 @@ class RingMember:
             value, member = (1, term) if isinstance(term, GroupMember) else term
             self._vec[member] += self.field(value)
 
-    def __repr__(self):
+    def __str__(self):
         if isinstance(self.group, CyclicGroup):
-            return galois.Poly(self.to_vector()[::-1], field=self.field).__repr__()
-        return super().__repr__()
+            return galois.Poly(self.to_vector()[::-1], field=self.field).__str__()
+        return super().__str__()
 
     def __eq__(self, other: object) -> bool:
         return (
@@ -876,6 +876,11 @@ class RingArray(npt.NDArray[np.object_]):
             result = result.view(RingArray)
             setattr(result, "_ring", next(iter(rings), None))
         return result
+
+    def __str__(self):
+        if isinstance(self.group, CyclicGroup):
+            return np.array2string(self, formatter={"object": str}, separator=", ")
+        return super().__str__()
 
     @property
     def ring(self) -> GroupRing:

--- a/src/qldpc/abstract.py
+++ b/src/qldpc/abstract.py
@@ -1079,7 +1079,7 @@ class RingArray(npt.NDArray[np.object_]):
 
         # The "modulus" of underlying polynomial ring for this RingArray: x^n - 1.
         # Analogous to N in the ring of integers modulo N.
-        modulus_poly = galois.Poly([1] + [0] * (self.group.order - 2) + [-1], self.field)
+        modulus_poly = galois.Poly([1] + [0] * (self.group.order - 1) + [-1], self.field)
 
         def _multiply(poly: galois.Poly, vecs: galois.FieldArray) -> galois.FieldArray:
             """Multiply a member of a polynomial ring into a ring-valued matrix.

--- a/src/qldpc/abstract.py
+++ b/src/qldpc/abstract.py
@@ -1021,6 +1021,10 @@ class RingArray(npt.NDArray[np.object_]):
         # convert into 3-D, where the third dimension stores coefficients for group members
         field_array = self.to_field_array()
 
+        # The "modulus" of underlying polynomial ring for this RingArray: x^n - 1.
+        # Analogous to N in the ring of integers modulo N.
+        modulus_poly = galois.Poly([1] + [0] * (self.group.order - 2) + [-1], self.field)
+
         def _multiply(poly: galois.Poly, vec: galois.FieldArray) -> galois.FieldArray:
             """Multiply a member of a cyclic group algebra into an group-algebra-valued vector.
 
@@ -1080,8 +1084,14 @@ class RingArray(npt.NDArray[np.object_]):
                     field_array[pivot_row] = new_aa_vec
                     field_array[lower_row] = new_bb_vec
 
-                # reduce the pivot to a minimal representative
-                ...
+                """
+                Reduce the pivot, aa: find a ss for which ss * aa = gcd(aa, modulus) = gg.
+                Multiply the pivot row by ss, reducing aa to gg.
+                """
+                aa_poly = galois.Poly(field_array[pivot_row, pivot_col, ::-1], field=self.field)
+                gg_poly, ss_poly, _ = galois.egcd(aa_poly, modulus_poly)
+                if aa_poly != gg_poly:
+                    field_array[pivot_row] = _multiply(ss_poly, _multiply)
 
                 # reduce all rows above the pivot_row at the pivot_column
                 ...

--- a/src/qldpc/abstract.py
+++ b/src/qldpc/abstract.py
@@ -629,7 +629,9 @@ class RingMember:
         """Write this RingMember as a polynomial."""
         # identify symbols for the generators of the base group
         num_gens = len(self.group.generators)
-        if num_gens <= 26:
+        if num_gens <= 3:
+            symbols = sympy.symbols("x:z", commutative=self.group.is_abelian)[:num_gens]
+        elif num_gens <= 26:
             symbols = sympy.symbols("a:z", commutative=self.group.is_abelian)[-num_gens:]
         else:
             index_length = int(np.ceil(np.log10(num_gens + 1)))

--- a/src/qldpc/abstract.py
+++ b/src/qldpc/abstract.py
@@ -1050,9 +1050,9 @@ class RingArray(npt.NDArray[np.object_]):
 
             if pivot_found:
                 # zero out all rows below the pivot_row at the pivot column
-                for lower_row in range(pivot_row + 1, self.shape[0]):
+                for other_row in range(pivot_row + 1, self.shape[0]):
                     aa_vec = field_array[pivot_row]
-                    bb_vec = field_array[lower_row]
+                    bb_vec = field_array[other_row]
                     """
                     Let:
                         aa = aa_vec[pivot_row]
@@ -1067,7 +1067,7 @@ class RingArray(npt.NDArray[np.object_]):
                     (2) ensures that bb_vec gets zeroed out at the pivot column.
                     """
                     aa_poly = galois.Poly(field_array[pivot_row, pivot_col, ::-1], field=self.field)
-                    bb_poly = galois.Poly(field_array[lower_row, pivot_col, ::-1], field=self.field)
+                    bb_poly = galois.Poly(field_array[other_row, pivot_col, ::-1], field=self.field)
 
                     # find gg, ss, tt, uu, vv, and work around some typing bugs/errors in galois/mypy
                     gg_poly: galois.Poly
@@ -1080,7 +1080,7 @@ class RingArray(npt.NDArray[np.object_]):
                     new_aa_vec = _multiply(ss_poly, aa_vec) + _multiply(tt_poly, bb_vec)
                     new_bb_vec = _multiply(uu_poly, aa_vec) + _multiply(vv_poly, bb_vec)
                     field_array[pivot_row] = new_aa_vec
-                    field_array[lower_row] = new_bb_vec
+                    field_array[other_row] = new_bb_vec
 
                 """
                 Reduce the pivot, aa: find a ss for which ss * aa = gcd(aa, modulus) = gg.
@@ -1092,7 +1092,10 @@ class RingArray(npt.NDArray[np.object_]):
                     field_array[pivot_row] = _multiply(ss_poly, _multiply)
 
                 # reduce all rows above the pivot_row at the pivot_column
-                ...
+                for other_row in range(pivot_row):
+                    bb_poly = galois.Poly(field_array[other_row, pivot_col, ::-1], field=self.field)
+                    ss_poly = bb_poly // aa_poly
+                    field_array[other_row] -= _multiply(ss_poly, aa_vec)
 
                 # if the pivot is a zero divisor, append a row that annihilates the pivot
                 ...

--- a/src/qldpc/abstract_test.py
+++ b/src/qldpc/abstract_test.py
@@ -374,13 +374,13 @@ def test_ring_row_reduce(pytestconfig: pytest.Config) -> None:
 
 
 def test_ring_linear_reduction() -> None:
-    """Remove rows that are ring-linearly-dependent on others."""
+    """Remove rows that are left-ring-linearly-dependent on others."""
     group = abstract.CyclicGroup(2)
     ring = abstract.GroupRing(group, field=2)
     xx = ring.generators[0]
-    matrix = abstract.RingArray.build([[1 + xx, 1]], ring)
+    matrix = abstract.RingArray.build([[xx + 1, 1]], ring)
 
-    row_reduced_matrix = abstract.RingArray.build([[1 + xx, 1], [0, 1 + xx]], ring)
+    row_reduced_matrix = abstract.RingArray.build([[xx + 1, 1], [0, xx + 1]], ring)
     assert np.array_equal(matrix.row_reduce(), row_reduced_matrix)
     assert np.array_equal(row_reduced_matrix.without_dependent_rows(), matrix * xx)
 

--- a/src/qldpc/abstract_test.py
+++ b/src/qldpc/abstract_test.py
@@ -221,6 +221,26 @@ def test_ring() -> None:
         ring.eval(5, symbols)
 
 
+def test_printing() -> None:
+    """Convert ring members and ring arrays into human-readable strings."""
+    ring = abstract.GroupRing(abstract.AbelianGroup(2, 2))
+    assert str(ring.zero) == "0"
+    assert str(ring.one) == "1"
+    assert [str(gg) for gg in ring.generators] == ["x", "y"]
+
+    ring = abstract.GroupRing(abstract.AbelianGroup(2, 2, 2, 2))
+    assert [str(gg) for gg in ring.generators] == ["w", "x", "y", "z"]
+
+    # the order of generators for non-Abelian groups is preserved
+    group = abstract.DihedralGroup(6)
+    ring = abstract.GroupRing(group, 3)
+    one = ring.one
+    xx, yy = ring.generators
+    vec = [one + yy * xx**2 * yy, xx + yy]
+    ring_array = abstract.RingArray.build(vec, ring)
+    assert str(ring_array) == "[1 + y x^2 y, x + y]"
+
+
 def test_primitive_central_idempotents() -> None:
     """Convert external primitive central idempotents into RingMembers."""
     with pytest.raises(ValueError, match="Only semisimple rings"):

--- a/src/qldpc/abstract_test.py
+++ b/src/qldpc/abstract_test.py
@@ -191,6 +191,7 @@ def test_ring() -> None:
     ring = abstract.GroupRing(group, field=5)
     ring_member = abstract.RingMember(ring, group.identity, (3, group.generators[0]))
     assert ring_member.inverse() is not None
+    assert (0 * ring_member).inverse() is None
 
     # nonexistent inverse
     group = abstract.CyclicGroup(2)
@@ -310,67 +311,58 @@ def test_regular_rep(ring: abstract.GroupRing, pytestconfig: pytest.Config) -> N
         matrix.regular_lift() @ vector.to_field_vector(),
     )
 
-    assert not np.any(matrix @ matrix.null_space().T)
-    assert not np.any(matrix.regular_lift() @ matrix.null_space().regular_lift().T)
+    assert not np.any(matrix @ matrix.null_space(row_reduce=False).T)
+    assert not np.any(matrix.regular_lift() @ matrix.null_space(row_reduce=False).regular_lift().T)
     assert not np.any(matrix.regular_lift() @ matrix.regular_lift().null_space().T)
 
+    with pytest.raises(NotImplementedError, match="Cannot row-reduce"):
+        matrix.null_space(row_reduce=True)
 
-@pytest.mark.parametrize(
-    "ring",
-    [
-        abstract.GroupRing(abstract.DihedralGroup(3)),
-        abstract.GroupRing(abstract.AbelianGroup(2, 3), field=3),
-    ],
-)
-def test_ring_row_reduce(ring: abstract.GroupRing, pytestconfig: pytest.Config) -> None:
+
+def test_ring_row_reduce(pytestconfig: pytest.Config) -> None:
     """Row reduce a ring-valued matrix."""
-    seed = pytestconfig.getoption("randomly_seed")
+    np.random.seed(pytestconfig.getoption("randomly_seed"))
     matrix: list[list[int | abstract.RingMember]] | abstract.RingArray
 
+    # we can row-reduce a RingArray built on the cyclic group
+    ring = abstract.GroupRing(abstract.CyclicGroup(5), field=3)
     one = ring.one
     gen = ring.generators[0]
     gen_inverse = gen.inverse()
     assert gen_inverse is not None
 
     matrix = [
-        [one + gen, gen],
-        [gen + gen**2, gen**2],
-        [0, one + gen],
-    ]
-    reduced_matrix = [
-        [gen_inverse + one, one],
-        [-(one + gen) * (gen_inverse + one), 0],
+        [one + gen, 0, gen],
+        [gen + gen**2, 0, gen**2],
+        [0, 0, one + gen],
     ]
     assert np.array_equal(
         abstract.RingArray.build(matrix, ring).row_reduce(),
-        abstract.RingArray.build(reduced_matrix, ring),
+        abstract.RingArray.build([[1, 0, 0], [0, 0, 1]], ring),
     )
 
-    # RingArray.row_reduce and _remove_linearly_dependent_rows have the same left-ring-linear span
-    num_rows, num_cols = 3, 5
-    coefficients = ring.field.Random((num_rows, num_cols, ring.group.order), seed=seed)
-    matrix = abstract.RingArray.from_field_array(ring, coefficients)
-    matrix_1 = matrix.row_reduce().regular_lift().row_reduce()
-    matrix_2 = matrix._remove_linearly_dependent_rows().regular_lift().row_reduce()
-    assert np.array_equal(
-        matrix_1[np.any(matrix_1, axis=1)],
-        matrix_2[np.any(matrix_2, axis=1)],
-    )
+    # we cannot reduce a RingArray based on other groups
+    for group, match in [
+        (abstract.AbelianGroup(3, 3), "We only aspire"),
+        (abstract.DihedralGroup(3), "Here be dragons"),
+    ]:
+        ring = abstract.GroupRing(group)
+        coefficients = ring.field.Random((1, 2, ring.group.order))
+        matrix = abstract.RingArray.from_field_array(ring, coefficients)
+        with pytest.raises(NotImplementedError, match=match):
+            matrix.row_reduce()
 
 
-def test_row_reduce_errors() -> None:
-    """Errors and warnings from RingArray.row_reduce."""
-    ring = abstract.GroupRing(abstract.CyclicGroup(3))
-    coefficients = ring.field.Random((1, 2, ring.group.order))
-    matrix = abstract.RingArray.from_field_array(ring, coefficients)
-    with pytest.raises(NotImplementedError, match="We only aspire to perform exact row reduction"):
-        matrix.row_reduce(force_heuristic=False)
+def test_ring_linear_reduction() -> None:
+    """Remove rows that are ring-linearly-dependent on others."""
+    group = abstract.CyclicGroup(2)
+    ring = abstract.GroupRing(group, field=2)
+    xx = ring.generators[0]
+    matrix = abstract.RingArray.build([[1 + xx, 1]], ring)
 
-    ring = abstract.GroupRing(abstract.CyclicGroup(2))
-    coefficients = ring.field.Random((1, 2, ring.group.order))
-    matrix = abstract.RingArray.from_field_array(ring, coefficients)
-    with pytest.warns(UserWarning, match="Using heuristics"):
-        matrix.row_reduce(force_heuristic=False)
+    row_reduced_matrix = abstract.RingArray.build([[1 + xx, 1], [0, 1 + xx]], ring)
+    assert np.array_equal(matrix.row_reduce(), row_reduced_matrix)
+    assert np.array_equal(row_reduced_matrix.without_dependent_rows(), matrix * xx)
 
 
 @pytest.mark.parametrize("dimension,field,linear_rep", [(2, 4, True), (2, 2, False)])

--- a/src/qldpc/codes/quantum.py
+++ b/src/qldpc/codes/quantum.py
@@ -24,6 +24,7 @@ import itertools
 import math
 import os
 from collections.abc import Collection, Iterable, Iterator, Sequence
+from typing import TypeVar, Union
 
 import galois
 import networkx as nx
@@ -35,7 +36,7 @@ from sympy.matrices.normalforms import hermite_normal_form
 
 import qldpc
 from qldpc import abstract
-from qldpc.abstract import DEFAULT_FIELD_ORDER, FieldOrRingArray
+from qldpc.abstract import DEFAULT_FIELD_ORDER
 from qldpc.objects import CayleyComplex, ChainComplex, Node, Pauli, PauliXZ, QuditPauli
 
 from .classical import (
@@ -826,6 +827,11 @@ class BBCode(QCCode):
 
 ####################################################################################################
 # hypergraph product code, lifted product code, and their subsystem variants
+
+
+FieldOrRingArray = TypeVar(
+    "FieldOrRingArray", bound=Union[npt.NDArray[np.int_], npt.NDArray[np.object_]]
+)
 
 
 class HGPCode(CSSCode):

--- a/src/qldpc/codes/quantum.py
+++ b/src/qldpc/codes/quantum.py
@@ -24,7 +24,6 @@ import itertools
 import math
 import os
 from collections.abc import Collection, Iterable, Iterator, Sequence
-from typing import TypeVar, Union
 
 import galois
 import networkx as nx
@@ -36,7 +35,7 @@ from sympy.matrices.normalforms import hermite_normal_form
 
 import qldpc
 from qldpc import abstract
-from qldpc.abstract import DEFAULT_FIELD_ORDER
+from qldpc.abstract import DEFAULT_FIELD_ORDER, FieldOrRingArray
 from qldpc.objects import CayleyComplex, ChainComplex, Node, Pauli, PauliXZ, QuditPauli
 
 from .classical import (
@@ -827,11 +826,6 @@ class BBCode(QCCode):
 
 ####################################################################################################
 # hypergraph product code, lifted product code, and their subsystem variants
-
-
-FieldOrRingArray = TypeVar(
-    "FieldOrRingArray", bound=Union[npt.NDArray[np.int_], npt.NDArray[np.object_]]
-)
 
 
 class HGPCode(CSSCode):

--- a/src/qldpc/math.py
+++ b/src/qldpc/math.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import functools
 from collections.abc import Sequence
-from typing import TypeVar, Union
+from typing import Any, TypeVar, Union
 
 import galois
 import numpy as np
@@ -86,7 +86,7 @@ def symplectic_weight(vectors: npt.NDArray[np.int_]) -> int:
     return np.count_nonzero(vectors_x | vectors_z, axis=-1).reshape(vectors.shape[:-1])
 
 
-def first_nonzero_cols(matrix: npt.NDArray[np.int_]) -> npt.NDArray[np.int_]:
+def first_nonzero_cols(matrix: npt.NDArray[Any]) -> npt.NDArray[np.int_]:
     """Get the first nonzero column for every row in a matrix."""
     if matrix.size == 0:
         return np.array([], dtype=int)

--- a/src/qldpc/math.py
+++ b/src/qldpc/math.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import functools
 from collections.abc import Sequence
-from typing import Any, TypeVar, Union
+from typing import TypeVar, Union
 
 import galois
 import numpy as np
@@ -86,7 +86,7 @@ def symplectic_weight(vectors: npt.NDArray[np.int_]) -> int:
     return np.count_nonzero(vectors_x | vectors_z, axis=-1).reshape(vectors.shape[:-1])
 
 
-def first_nonzero_cols(matrix: npt.NDArray[Any]) -> npt.NDArray[np.int_]:
+def first_nonzero_cols(matrix: npt.NDArray[GenericNumpyType]) -> npt.NDArray[np.int_]:
     """Get the first nonzero column for every row in a matrix."""
     if matrix.size == 0:
         return np.array([], dtype=int)


### PR DESCRIPTION
- `RingMember`s and `RingArray`s can now be printed in human-readable form
- Added the calculation of the Howell normal form for `RingArray`s based on a `CyclicGroup`
- Removed hacky row-reducing heuristics for `RingArray`s do more to confuse than help.