### PR TITLE
Replace uint with uint64 for improved compatibility

### DIFF
--- a/src/qldpc/codes/distance.py
+++ b/src/qldpc/codes/distance.py
@@ -212,7 +212,7 @@ def _symplectic_weight(
     out &= _MASK0F
 
     out *= _MASK01
-    out >>= np.uint(56)
+    out >>= np.uint64(56)
     return out
 
 

--- a/src/qldpc/codes/distance.py
+++ b/src/qldpc/codes/distance.py
@@ -22,10 +22,10 @@ from collections.abc import Callable
 import numpy as np
 import numpy.typing as npt
 
-_MASK55 = np.uint(0x5555555555555555)
-_MASK33 = np.uint(0x3333333333333333)
-_MASK0F = np.uint(0x0F0F0F0F0F0F0F0F)
-_MASK01 = np.uint(0x0101010101010101)
+_MASK55 = np.uint64(0x5555555555555555)
+_MASK33 = np.uint64(0x3333333333333333)
+_MASK0F = np.uint64(0x0F0F0F0F0F0F0F0F)
+_MASK01 = np.uint64(0x0101010101010101)
 
 
 def get_distance_classical(
@@ -105,8 +105,8 @@ def get_distance_quantum(
         logical_ops = _riffle(logical_ops)
         stabilizers = _riffle(stabilizers)
 
-    int_logical_ops = _rows_to_ints(logical_ops, dtype=np.uint)
-    int_stabilizers = _rows_to_ints(stabilizers, dtype=np.uint)
+    int_logical_ops = _rows_to_ints(logical_ops, dtype=np.uint64)
+    int_stabilizers = _rows_to_ints(stabilizers, dtype=np.uint64)
     num_stabilizers = len(int_stabilizers)
 
     # Number of generators to include in the operational array. Most calculations will then be
@@ -117,7 +117,7 @@ def get_distance_quantum(
     )
 
     # Vectorize all combinations of first `num_vectorized_ops` stabilizers
-    array = np.zeros((1, int_logical_ops.shape[-1]), dtype=np.uint)
+    array = np.zeros((1, int_logical_ops.shape[-1]), dtype=np.uint64)
     for op in int_stabilizers[:num_vectorized_ops]:
         array = np.vstack([array, array ^ op])
 
@@ -131,7 +131,7 @@ def get_distance_quantum(
     int_stabilizers = int_stabilizers[num_vectorized_ops:]
 
     # Everything below will run much faster if we use Fortran-style ordering
-    arrayf = np.asarray(array, order="F")
+    arrayf = np.asarray(array, order="F", dtype=np.uint64)
 
     out = np.empty_like(arrayf)
     bufs = [np.empty_like(arrayf) for _ in range(nbuf)]
@@ -160,10 +160,10 @@ def get_distance_quantum(
 
 
 def _hamming_weight(
-    arr: npt.NDArray[np.uint],
-    buf: npt.NDArray[np.uint] | None = None,
-    out: npt.NDArray[np.uint] | None = None,
-) -> npt.NDArray[np.uint]:
+    arr: npt.NDArray[np.uint64],
+    buf: npt.NDArray[np.uint64] | None = None,
+    out: npt.NDArray[np.uint64] | None = None,
+) -> npt.NDArray[np.uint64]:
     """Somewhat efficient (vectorized) Hamming weight calculation. Assumes 64-bit uints.
 
     For `numpy >= 2.0.0`, it's generally better to use `np.bitwise_count` (which uses processors'
@@ -184,15 +184,15 @@ def _hamming_weight(
 
     # out *= _mask01
     out = np.multiply(out, _MASK01, out=out)
-    out >>= np.uint(56)
+    out >>= np.uint64(56)
     return out
 
 
 def _symplectic_weight(
-    arr: npt.NDArray[np.uint],
-    buf: npt.NDArray[np.uint] | None = None,
-    out: npt.NDArray[np.uint] | None = None,
-) -> npt.NDArray[np.uint]:
+    arr: npt.NDArray[np.uint64],
+    buf: npt.NDArray[np.uint64] | None = None,
+    out: npt.NDArray[np.uint64] | None = None,
+) -> npt.NDArray[np.uint64]:
     """Somewhat efficient (vectorized) symplectic weight calculation. Assumes 64-bit uints.
 
     This function is equivalent to (but slightly more efficient than) the expression
@@ -216,53 +216,53 @@ def _symplectic_weight(
     return out
 
 
-def _hamming_weight_single(val: np.uint) -> np.uint:
+def _hamming_weight_single(val: np.uint64) -> np.uint64:
     """Unbuffered version of `_hamming_weight`, useful for vectorization."""
-    out = val >> np.uint(1)
+    out = val >> np.uint64(1)
     out &= _MASK55
     out = val - out
 
-    buf = out >> np.uint(2)
+    buf = out >> np.uint64(2)
     buf &= _MASK33
     out &= _MASK33
     out += buf
 
-    buf = out >> np.uint(4)
+    buf = out >> np.uint64(4)
     out += buf
     out &= _MASK0F
 
     out = np.multiply(out, _MASK01)
-    out >>= np.uint(56)
+    out >>= np.uint64(56)
     return out
 
 
-def _symplectic_weight_single(val: np.uint) -> np.uint:
+def _symplectic_weight_single(val: np.uint64) -> np.uint64:
     """Unbuffered version of `_symplectic_weight`, useful for vectorization."""
-    out = val >> np.uint(1)
+    out = val >> np.uint64(1)
     out |= val
     out &= _MASK55
 
-    buf = out >> np.uint(2)
+    buf = out >> np.uint64(2)
     buf &= _MASK33
     out &= _MASK33
     out += buf
 
-    buf = out >> np.uint(4)
+    buf = out >> np.uint64(4)
     out += buf
     out &= _MASK0F
 
     out = np.multiply(out, _MASK01)
-    out >>= np.uint(56)
+    out >>= np.uint64(56)
     return out
 
 
 def _get_hamming_weight_fn(
     use_numba: bool = False,
-) -> tuple[Callable[..., npt.NDArray[np.uint]], int]:
+) -> tuple[Callable[..., npt.NDArray[np.uint64]], int]:
     if use_numba:
         import numba
 
-        weight_fn = numba.vectorize([numba.uint(numba.uint)])(_hamming_weight_single)
+        weight_fn = numba.vectorize([numba.uint64(numba.uint64)])(_hamming_weight_single)
         return weight_fn, 0
 
     if getattr(np, "bitwise_count", None) is not None:
@@ -274,21 +274,21 @@ def _get_hamming_weight_fn(
 
 def _get_symplectic_weight_fn(
     use_numba: bool = False,
-) -> tuple[Callable[..., npt.NDArray[np.uint]], int]:
+) -> tuple[Callable[..., npt.NDArray[np.uint64]], int]:
     if use_numba:
         import numba
 
-        weight_fn = numba.vectorize([numba.uint(numba.uint)])(_symplectic_weight_single)
+        weight_fn = numba.vectorize([numba.uint64(numba.uint64)])(_symplectic_weight_single)
         return weight_fn, 0
 
     if getattr(np, "bitwise_count", None) is not None:
         np_bitwise_count = getattr(np, "bitwise_count")
 
         def weight_fn(
-            arr: npt.NDArray[np.uint],
-            buf: npt.NDArray[np.uint] | None = None,
-            out: npt.NDArray[np.uint] | None = None,
-        ) -> npt.NDArray[np.uint]:
+            arr: npt.NDArray[np.uint64],
+            buf: npt.NDArray[np.uint64] | None = None,
+            out: npt.NDArray[np.uint64] | None = None,
+        ) -> npt.NDArray[np.uint64]:
             """Symplectic weight of an integer."""
             buf = np.right_shift(arr, 1, out=buf)
             buf |= arr
@@ -305,7 +305,7 @@ def _count_trailing_zeros(val: int) -> int:
     return (val & -val).bit_length() - 1
 
 
-def _inplace_rowsum(arr: npt.NDArray[np.uint]) -> npt.NDArray[np.uint]:
+def _inplace_rowsum(arr: npt.NDArray[np.uint64]) -> npt.NDArray[np.uint64]:
     """Destructively compute ``arr.sum(-1)``, placing the result in the first column or `arr`.
 
     When complete, the returned sum will be stored in ``arr[..., 0]``, while other entries in
@@ -321,8 +321,8 @@ def _inplace_rowsum(arr: npt.NDArray[np.uint]) -> npt.NDArray[np.uint]:
 
 
 def _rows_to_ints(
-    array: npt.ArrayLike, dtype: npt.DTypeLike = np.uint, axis: int = -1
-) -> npt.NDArray[np.uint]:
+    array: npt.ArrayLike, dtype: npt.DTypeLike = np.uint64, axis: int = -1
+) -> npt.NDArray[np.uint64]:
     """Pack rows of a binary array into rows of the given integral type."""
     array = np.asarray(array, dtype=dtype)
     tsize = array.itemsize * 8
@@ -331,11 +331,11 @@ def _rows_to_ints(
         num_words = int(np.ceil(array.shape[-1] / tsize))
         return np.empty((*array.shape[:-1], num_words), dtype=dtype)
 
-    def _to_int(bits: npt.NDArray[np.uint]) -> npt.NDArray[np.uint]:
+    def _to_int(bits: npt.NDArray[np.uint64]) -> npt.NDArray[np.uint64]:
         """Pack `bits` into a single integer (of type `dtype`)."""
         return (bits << np.arange(len(bits) - 1, -1, -1, dtype=dtype)).sum(dtype=dtype)
 
-    def _to_ints(bits: npt.NDArray[np.uint]) -> list[npt.NDArray[np.uint]]:
+    def _to_ints(bits: npt.NDArray[np.uint64]) -> list[npt.NDArray[np.uint64]]:
         """Pack a single row of bits into a row of integers."""
         return [_to_int(bits[i : i + tsize]) for i in range(0, np.shape(bits)[-1], tsize)]
 

--- a/src/qldpc/codes/distance_test.py
+++ b/src/qldpc/codes/distance_test.py
@@ -29,8 +29,8 @@ import qldpc
 
 
 def _bitwise_count(
-    val: npt.ArrayLike, out: npt.NDArray[np.uint] | None = None
-) -> npt.NDArray[np.uint]:
+    val: npt.ArrayLike, out: npt.NDArray[np.uint64] | None = None
+) -> npt.NDArray[np.uint64]:
     """Simplistic implementation of `bitwise_count` used to validate optimized variants."""
     val = np.asarray(val)
     nbits = 8 * val.itemsize
@@ -46,7 +46,7 @@ def _bitwise_count(
 
 
 def test_hamming_weight() -> None:
-    vals = np.random.randint(0, 2**64, size=(7, 11), dtype=np.uint)
+    vals = np.random.randint(0, 2**64, size=(7, 11), dtype=np.uint64)
     expected_weights = _bitwise_count(vals)
 
     weights = qldpc.codes.distance._hamming_weight(vals)
@@ -63,9 +63,9 @@ def test_hamming_weight() -> None:
 
 
 def test_symplectic_weight() -> None:
-    vals = np.random.randint(0, 2**64, size=(7, 11), dtype=np.uint)
+    vals = np.random.randint(0, 2**64, size=(7, 11), dtype=np.uint64)
     weights = qldpc.codes.distance._symplectic_weight(vals)
-    expected_weights = _bitwise_count((vals | (vals >> np.uint(1))) & 0x5555555555555555)
+    expected_weights = _bitwise_count((vals | (vals >> np.uint64(1))) & 0x5555555555555555)
     np.testing.assert_array_equal(weights, expected_weights)
 
     weight_fn = np.vectorize(qldpc.codes.distance._symplectic_weight_single, signature="()->()")
@@ -79,7 +79,7 @@ def test_symplectic_weight() -> None:
 
 
 def test_get_hamming_weight_fn() -> None:
-    generators = np.random.randint(2, size=(4, 64), dtype=np.uint)
+    generators = np.random.randint(2, size=(4, 64), dtype=np.uint64)
     weight_fn, nbuf = qldpc.codes.distance._get_hamming_weight_fn()
     weights_default = weight_fn(generators)
 
@@ -123,7 +123,7 @@ def test_get_hamming_weight_fn() -> None:
 
 
 def test_get_symplectic_weight_fn() -> None:
-    generators = np.random.randint(2, size=(4, 56), dtype=np.uint)
+    generators = np.random.randint(2, size=(4, 56), dtype=np.uint64)
     weight_fn, nbuf = qldpc.codes.distance._get_symplectic_weight_fn()
     weights_default = weight_fn(generators)
 
@@ -176,7 +176,7 @@ def test_get_symplectic_weight_fn() -> None:
 
 @pytest.mark.parametrize(
     "base_val",
-    [1, 2**64 - 1, int(np.random.randint(2**64, dtype=np.uint)) | 1],
+    [1, 2**64 - 1, int(np.random.randint(2**64, dtype=np.uint64)) | 1],
 )
 def test_count_trailing_zeros(base_val: int) -> None:
     for i in range(128):
@@ -185,7 +185,7 @@ def test_count_trailing_zeros(base_val: int) -> None:
 
 @pytest.mark.parametrize("width", range(1, 8))
 def test_inplace_rowsum(width: int) -> None:
-    arr = np.random.randint(2**31, size=(10, width), dtype=np.uint)
+    arr = np.random.randint(2**31, size=(10, width), dtype=np.uint64)
     expected = arr.sum(-1)
     actual = qldpc.codes.distance._inplace_rowsum(arr)
     np.testing.assert_array_equal(actual, expected)
@@ -202,7 +202,7 @@ def test_rows_to_ints_endianness() -> None:
     np.testing.assert_array_equal(ints, expected)
 
 
-@pytest.mark.parametrize("dtype", [int, np.uint, np.uint8, np.int16])
+@pytest.mark.parametrize("dtype", [int, np.uint64, np.uint8, np.int16])
 def test_rows_to_ints(dtype: npt.DTypeLike) -> None:
     bits = np.random.randint(2, size=(10, 93))
     ints = qldpc.codes.distance._rows_to_ints(bits, dtype=dtype)
@@ -250,10 +250,10 @@ def test_get_distance_classical(block_size: int) -> None:
     observed_bitstrings: list[tuple[int, ...]] = []
 
     def _mock_hamming_weight(
-        arr: npt.NDArray[np.uint],
-        buf: npt.NDArray[np.uint] | None = None,
-        out: npt.NDArray[np.uint] | None = None,
-    ) -> npt.NDArray[np.uint]:
+        arr: npt.NDArray[np.uint64],
+        buf: npt.NDArray[np.uint64] | None = None,
+        out: npt.NDArray[np.uint64] | None = None,
+    ) -> npt.NDArray[np.uint64]:
         observed_bitstrings.extend(map(tuple, arr.tolist()))
         return qldpc.codes.distance._hamming_weight(arr, buf=buf, out=out)
 
@@ -272,7 +272,7 @@ def test_get_distance_classical(block_size: int) -> None:
     assert len(observed_bitstrings) == len(expected_bitstrings)
     assert set(observed_bitstrings) == set(expected_bitstrings)
 
-    observed_array = np.array(observed_bitstrings, dtype=np.uint)
+    observed_array = np.array(observed_bitstrings, dtype=np.uint64)
     expected_distance = _bitwise_count(observed_array).sum(-1).min()
     assert distance == expected_distance
 
@@ -287,10 +287,10 @@ def test_get_distance_quantum(block_size: int) -> None:
     observed_bitstrings: list[tuple[int, ...]] = []
 
     def _mock_hamming_weight(
-        arr: npt.NDArray[np.uint],
-        buf: npt.NDArray[np.uint] | None = None,
-        out: npt.NDArray[np.uint] | None = None,
-    ) -> npt.NDArray[np.uint]:
+        arr: npt.NDArray[np.uint64],
+        buf: npt.NDArray[np.uint64] | None = None,
+        out: npt.NDArray[np.uint64] | None = None,
+    ) -> npt.NDArray[np.uint64]:
         observed_bitstrings.extend(map(tuple, arr.tolist()))
         return qldpc.codes.distance._hamming_weight(arr, buf=buf, out=out)
 
@@ -314,7 +314,7 @@ def test_get_distance_quantum(block_size: int) -> None:
     assert len(observed_bitstrings) == len(expected_bitstrings)
     assert set(observed_bitstrings) == set(expected_bitstrings)
 
-    observed_array = np.array(observed_bitstrings, dtype=np.uint)
+    observed_array = np.array(observed_bitstrings, dtype=np.uint64)
     expected_distance = _bitwise_count(observed_array).sum(-1).min()
     assert distance == expected_distance
 
@@ -329,10 +329,10 @@ def test_get_distance_quantum_symplectic(block_size: int) -> None:
     observed_bitstrings: list[tuple[int, ...]] = []
 
     def _mock_symplectic_weight(
-        arr: npt.NDArray[np.uint],
-        buf: npt.NDArray[np.uint] | None = None,
-        out: npt.NDArray[np.uint] | None = None,
-    ) -> npt.NDArray[np.uint]:
+        arr: npt.NDArray[np.uint64],
+        buf: npt.NDArray[np.uint64] | None = None,
+        out: npt.NDArray[np.uint64] | None = None,
+    ) -> npt.NDArray[np.uint64]:
         observed_bitstrings.extend(map(tuple, arr.tolist()))
         return qldpc.codes.distance._symplectic_weight(arr, buf=buf, out=out)
 
@@ -364,7 +364,7 @@ def test_get_distance_quantum_symplectic(block_size: int) -> None:
 
 
 def test_get_distance_classical_methods() -> None:
-    generators = np.random.randint(2, size=(6, 56), dtype=np.uint)
+    generators = np.random.randint(2, size=(6, 56), dtype=np.uint64)
     distance_default = qldpc.codes.distance.get_distance_classical(generators, block_size=3)
 
     # Tests should work with numpy < 2.0.0 so provide a backup `np.bitwise_count` implementation
@@ -412,8 +412,8 @@ def test_get_distance_classical_methods() -> None:
 
 
 def test_get_distance_quantum_methods() -> None:
-    stabilizers = np.random.randint(2, size=(4, 56), dtype=np.uint)
-    logical_ops = np.random.randint(2, size=(3, 56), dtype=np.uint)
+    stabilizers = np.random.randint(2, size=(4, 56), dtype=np.uint64)
+    logical_ops = np.random.randint(2, size=(3, 56), dtype=np.uint64)
     distance_default = qldpc.codes.distance.get_distance_quantum(
         logical_ops, stabilizers, block_size=3, homogeneous=True
     )
@@ -467,8 +467,8 @@ def test_get_distance_quantum_methods() -> None:
 
 
 def test_get_distance_quantum_methods_symplectic() -> None:
-    stabilizers = np.random.randint(2, size=(4, 56), dtype=np.uint)
-    logical_ops = np.random.randint(2, size=(3, 56), dtype=np.uint)
+    stabilizers = np.random.randint(2, size=(4, 56), dtype=np.uint64)
+    logical_ops = np.random.randint(2, size=(3, 56), dtype=np.uint64)
     distance_default = qldpc.codes.distance.get_distance_quantum(
         logical_ops, stabilizers, block_size=3, homogeneous=False
     )


### PR DESCRIPTION
Fixes a compatibility bug by explicitly setting numpy uint size rather than using OS dependant default. Closes #454 