### PR TITLE
Fix `get_distance_bound()` for large codes

### DIFF
--- a/src/qldpc/external/codes.py
+++ b/src/qldpc/external/codes.py
@@ -96,7 +96,7 @@ def _gap_define_sparse_matrix(matrix_var: str, field_order: int, matrix: np.ndar
         [np.nonzero(row == val)[0] for val in range(1, field_order)] for row in matrix
     ]
 
-    def nonzero_row_str(nonzeros):
+    def nonzero_row_str(nonzeros: list[np.ndarray]) -> str:
         all_field_vals = [f"[{','.join(str(int(val)) for val in columns)}]" for columns in nonzeros]
         return f"[{','.join(all_field_vals)}]"
 

--- a/src/qldpc/external/codes.py
+++ b/src/qldpc/external/codes.py
@@ -21,11 +21,11 @@ import ast
 import re
 import urllib
 
+import numpy as np
+
 import qldpc
 import qldpc.cache
 import qldpc.external.gap
-
-import numpy as np
 
 
 @qldpc.cache.use_disk_cache(
@@ -105,15 +105,15 @@ def _gap_define_sparse_matrix(matrix_var: str, field_order: int, matrix: np.ndar
         f"nz:=[{nonzero_str}];;",
         f"F:=GF({field_order});;",
         f"{matrix_var}:=[];",
-        f"for r in nz do",
+        "for r in nz do",
         f"  v:=ListWithIdenticalEntries({matrix_width},Zero(F));;",
         f"  for f in [1..{field_order - 1}] do",
-        f"    for i in r[f] do",
-        f"      v[i+1]:=f*One(F);;",
-        f"    od;;",
-        f"  od;;",
+        "    for i in r[f] do",
+        "      v[i+1]:=f*One(F);;",
+        "    od;;",
+        "  od;;",
         f"  Append({matrix_var},[v]);;",
-        f"od;;",
+        "od;;",
     ]
     commands = [cmd.strip() for cmd in commands]
     return commands

--- a/src/qldpc/external/codes.py
+++ b/src/qldpc/external/codes.py
@@ -96,7 +96,7 @@ def _gap_define_sparse_matrix(matrix_var: str, field_order: int, matrix: np.ndar
         [np.nonzero(row == val)[0] for val in range(1, field_order)] for row in matrix
     ]
 
-    def nonzero_row_str(nonzeros: list[np.ndarray]) -> str:
+    def nonzero_row_str(nonzeros: list[np.NDArray[np.int_]]) -> str:
         all_field_vals = [f"[{','.join(str(int(val)) for val in columns)}]" for columns in nonzeros]
         return f"[{','.join(all_field_vals)}]"
 

--- a/src/qldpc/external/codes.py
+++ b/src/qldpc/external/codes.py
@@ -89,7 +89,7 @@ def get_quantum_code(code_id: str) -> tuple[list[str], int, bool]:
     return stabilizers, distance, is_css
 
 
-def _gap_define_sparse_matrix(matrix_var: str, field_order: int, matrix: np.ndarray) -> list[str]:
+def _gap_define_sparse_matrix(matrix_var: str, field_order: int, matrix: npt.NDArray[np.int_]) -> list[str]:
     _, matrix_width = matrix.shape
     # Turn matrix into sparse representation where `nonzero_entries[i][j][_]=l`
     # means `matrix[i,l] == j+1`.

--- a/src/qldpc/external/codes.py
+++ b/src/qldpc/external/codes.py
@@ -91,8 +91,23 @@ def get_quantum_code(code_id: str) -> tuple[list[str], int, bool]:
 
 def _gap_define_sparse_matrix(matrix_var: str, field_order: int, matrix: npt.NDArray[np.int_]) -> list[str]:
     _, matrix_width = matrix.shape
-    # Turn matrix into sparse representation where `nonzero_entries[i][j][_]=l`
-    # means `matrix[i,l] == j+1`.
+    # Turn matrix into sparse representation where `nonzero_entries[i][j]` is a list of integers
+    # where, for all values `l` in that list, `matrix[i,l] == j+1`.
+    # Example:
+    #     matrix_var: NDArray[F3] = [
+    #         [0, 0, 0, 1, 2, 1],
+    #         [1, 0, 0, 0, 0, 0],
+    #     ]
+    #     nonzero_entries: list[list[np.NDArray[np.int_]]] = [
+    #         [ # Sparse definition of the first matrix row, `matrix_var[0]`
+    #             [3, 5],  # Columns in this row that contain 1's: `matrix_var[0, 3] == 1`
+    #             [4],  # Columns in this row that contain 2's: `matrix_var[0, 4] == 2`
+    #         ],
+    #         [ # Sparse definition of the second matrix row, `matrix_var[1]`
+    #             [0],  # Columns in this row that contain 1's
+    #             [],  # Columns in this row that contain 2's
+    #         ],
+    #     ]
     nonzero_entries = [
         [np.nonzero(row == val)[0] for val in range(1, field_order)] for row in matrix
     ]

--- a/src/qldpc/external/codes.py
+++ b/src/qldpc/external/codes.py
@@ -25,6 +25,8 @@ import qldpc
 import qldpc.cache
 import qldpc.external.gap
 
+import numpy as np
+
 
 @qldpc.cache.use_disk_cache(
     "codes",
@@ -86,6 +88,38 @@ def get_quantum_code(code_id: str) -> tuple[list[str], int, bool]:
     return stabilizers, distance, is_css
 
 
+def _gap_define_sparse_matrix(matrix_var: str, field_order: int, matrix: np.ndarray) -> list[str]:
+    _, matrix_width = matrix.shape
+    # Turn matrix into sparse representation where `nonzero_entries[i][j][_]=l`
+    # means `matrix[i,l] == j+1`.
+    nonzero_entries = [
+        [np.nonzero(row == val)[0] for val in range(1, field_order)]
+        for row in matrix
+    ]
+    def nonzero_row_str(nonzeros):
+        all_field_vals = [
+            f'[{",".join(str(int(val)) for val in columns)}]'
+            for columns in nonzeros
+        ]
+        return f'[{",".join(all_field_vals)}]'
+    nonzero_str = ','.join( nonzero_row_str(nonzeros) for nonzeros in nonzero_entries)
+    commands = [
+        f'nz:=[{nonzero_str}];;',
+        f'F:=GF({field_order});;',
+        f'{matrix_var}:=[];',
+        f'for r in nz do',
+        f'  v:=ListWithIdenticalEntries({matrix_width},Zero(F));;',
+        f'  for f in [1..{field_order-1}] do',
+        f'    for i in r[f] do',
+        f'      v[i+1]:=f*One(F);;',
+        f'    od;;',
+        f'  od;;',
+        f'  Append({matrix_var},[v]);;',
+        f'od;;',
+    ]
+    commands = [cmd.strip() for cmd in commands]
+    return commands
+
 def get_distance_bound(
     code: qldpc.codes.QuditCode,
     num_trials: int = 1,
@@ -115,8 +149,8 @@ def get_distance_bound(
         args = ",".join([f"{one}*matrix_x", f"{one}*matrix_z", f"{num_trials}", f"{cutoff}"])
         commands = [
             'LoadPackage("QDistRnd", false);;',
-            f"matrix_x := {code_x.matrix_as_string()};;",
-            f"matrix_z := {code_z.matrix_as_string()};;",
+            *_gap_define_sparse_matrix("matrix_x", code.field.order, code_x.matrix),
+            *_gap_define_sparse_matrix("matrix_z", code.field.order, code_z.matrix),
             f"Print(DistRandCSS({args}:{kwargs}));;",
         ]
 
@@ -130,11 +164,12 @@ def get_distance_bound(
         args = ",".join([f"{one}*matrix", f"{num_trials}", f"{cutoff}"])
         commands = [
             'LoadPackage("QDistRnd", false);',
-            f"matrix := {riffled_code.matrix_as_string()};",
+            *_gap_define_sparse_matrix("matrix", code.field.order, riffled_code.matrix),
             f"Print(DistRandStab({args}:{kwargs}));",
         ]
 
-    output = qldpc.external.gap.get_output(*commands)
+    # Issue: Piped input somehow causes extra terminal output.  Fix: Ignore all but last line.
+    output = qldpc.external.gap.get_output(*commands, use_pipe=True).strip().splitlines()[-1]
 
     # strip whitespace and comments, and interpret the remaining text as the bound
     lines = [line.strip() for line in output.splitlines()]

--- a/src/qldpc/external/codes.py
+++ b/src/qldpc/external/codes.py
@@ -89,7 +89,9 @@ def get_quantum_code(code_id: str) -> tuple[list[str], int, bool]:
     return stabilizers, distance, is_css
 
 
-def _gap_define_sparse_matrix(matrix_var: str, field_order: int, matrix: npt.NDArray[np.int_]) -> list[str]:
+def _gap_define_sparse_matrix(
+    matrix_var: str, field_order: int, matrix: npt.NDArray[np.int_]
+) -> list[str]:
     _, matrix_width = matrix.shape
     # Turn matrix into sparse representation where `nonzero_entries[i][j]` is a list of integers
     # where, for all values `l` in that list, `matrix[i,l] == j+1`.
@@ -112,7 +114,7 @@ def _gap_define_sparse_matrix(matrix_var: str, field_order: int, matrix: npt.NDA
         [np.nonzero(row == val)[0] for val in range(1, field_order)] for row in matrix
     ]
 
-    def nonzero_row_str(nonzeros: list[np.NDArray[np.int_]]) -> str:
+    def nonzero_row_str(nonzeros: list[npt.NDArray[np.int_]]) -> str:
         all_field_vals = [f"[{','.join(str(int(val)) for val in columns)}]" for columns in nonzeros]
         return f"[{','.join(all_field_vals)}]"
 

--- a/src/qldpc/external/codes.py
+++ b/src/qldpc/external/codes.py
@@ -22,6 +22,7 @@ import re
 import urllib
 
 import numpy as np
+import numpy.typing as npt
 
 import qldpc
 import qldpc.cache

--- a/src/qldpc/external/codes.py
+++ b/src/qldpc/external/codes.py
@@ -93,32 +93,31 @@ def _gap_define_sparse_matrix(matrix_var: str, field_order: int, matrix: np.ndar
     # Turn matrix into sparse representation where `nonzero_entries[i][j][_]=l`
     # means `matrix[i,l] == j+1`.
     nonzero_entries = [
-        [np.nonzero(row == val)[0] for val in range(1, field_order)]
-        for row in matrix
+        [np.nonzero(row == val)[0] for val in range(1, field_order)] for row in matrix
     ]
+
     def nonzero_row_str(nonzeros):
-        all_field_vals = [
-            f'[{",".join(str(int(val)) for val in columns)}]'
-            for columns in nonzeros
-        ]
-        return f'[{",".join(all_field_vals)}]'
-    nonzero_str = ','.join( nonzero_row_str(nonzeros) for nonzeros in nonzero_entries)
+        all_field_vals = [f"[{','.join(str(int(val)) for val in columns)}]" for columns in nonzeros]
+        return f"[{','.join(all_field_vals)}]"
+
+    nonzero_str = ",".join(nonzero_row_str(nonzeros) for nonzeros in nonzero_entries)
     commands = [
-        f'nz:=[{nonzero_str}];;',
-        f'F:=GF({field_order});;',
-        f'{matrix_var}:=[];',
-        f'for r in nz do',
-        f'  v:=ListWithIdenticalEntries({matrix_width},Zero(F));;',
-        f'  for f in [1..{field_order-1}] do',
-        f'    for i in r[f] do',
-        f'      v[i+1]:=f*One(F);;',
-        f'    od;;',
-        f'  od;;',
-        f'  Append({matrix_var},[v]);;',
-        f'od;;',
+        f"nz:=[{nonzero_str}];;",
+        f"F:=GF({field_order});;",
+        f"{matrix_var}:=[];",
+        f"for r in nz do",
+        f"  v:=ListWithIdenticalEntries({matrix_width},Zero(F));;",
+        f"  for f in [1..{field_order - 1}] do",
+        f"    for i in r[f] do",
+        f"      v[i+1]:=f*One(F);;",
+        f"    od;;",
+        f"  od;;",
+        f"  Append({matrix_var},[v]);;",
+        f"od;;",
     ]
     commands = [cmd.strip() for cmd in commands]
     return commands
+
 
 def get_distance_bound(
     code: qldpc.codes.QuditCode,

--- a/src/qldpc/external/gap.py
+++ b/src/qldpc/external/gap.py
@@ -80,13 +80,15 @@ def get_output(*commands: str, use_pipe: bool = False) -> str:
             "-q",
             "--quitonbreak",
         ]
-        input = " ".join(commands)
+        script_input = " ".join(commands)
         if not use_pipe:
-            shell_commands.extend(["-c", input])
-            input = None
+            shell_commands.extend(["-c", script_input])
+            pipe_input = None
+        else:
+            pipe_input = script_input
         result = subprocess.run(
             shell_commands,
-            input=input,
+            input=pipe_input,
             capture_output=True,
             text=True,
         )

--- a/src/qldpc/external/gap.py
+++ b/src/qldpc/external/gap.py
@@ -66,7 +66,7 @@ def sanitize_commands(commands: Sequence[str]) -> tuple[str, ...]:
     return tuple(prefix + commands + suffix)
 
 
-def get_output(*commands: str, use_pipe: bool=False) -> str:
+def get_output(*commands: str, use_pipe: bool = False) -> str:
     """Get the output from the given GAP commands."""
     if not is_installed():
         raise FileNotFoundError("GAP 4 is required to proceed, but is not installed")
@@ -85,7 +85,10 @@ def get_output(*commands: str, use_pipe: bool=False) -> str:
             shell_commands.extend(["-c", input])
             input = None
         result = subprocess.run(
-            shell_commands, input=input, capture_output=True, text=True,
+            shell_commands,
+            input=input,
+            capture_output=True,
+            text=True,
         )
         if result.stderr:
             raise ValueError(

--- a/src/qldpc/external/gap.py
+++ b/src/qldpc/external/gap.py
@@ -66,7 +66,7 @@ def sanitize_commands(commands: Sequence[str]) -> tuple[str, ...]:
     return tuple(prefix + commands + suffix)
 
 
-def get_output(*commands: str) -> str:
+def get_output(*commands: str, use_pipe: bool=False) -> str:
     """Get the output from the given GAP commands."""
     if not is_installed():
         raise FileNotFoundError("GAP 4 is required to proceed, but is not installed")
@@ -79,10 +79,14 @@ def get_output(*commands: str) -> str:
             f";{GAP_ROOT}",
             "-q",
             "--quitonbreak",
-            "-c",
-            " ".join(commands),
         ]
-        result = subprocess.run(shell_commands, capture_output=True, text=True)
+        input = " ".join(commands)
+        if not use_pipe:
+            shell_commands.extend(["-c", input])
+            input = None
+        result = subprocess.run(
+            shell_commands, input=input, capture_output=True, text=True,
+        )
         if result.stderr:
             raise ValueError(
                 f"Error encountered when running GAP:\n{result.stderr}\n\n"

--- a/src/qldpc/external/gap_test.py
+++ b/src/qldpc/external/gap_test.py
@@ -94,6 +94,13 @@ def test_get_output(monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixtu
         ):
             assert external.gap.get_output() == "_TEST_"
 
+        # GAP is callable, and succeeds with piped input
+        with (
+            unittest.mock.patch("qldpc.external.gap.is_callable", return_value=True),
+            unittest.mock.patch("subprocess.run", return_value=get_mock_process("_TEST_")),
+        ):
+            assert external.gap.get_output(use_pipe=True) == "_TEST_"
+
         # GAP is not callable, so the user must pass around commands and outputs
         cache: dict[str, str] = {}
         inputs = iter(["_OUTPUT_", ""])


### PR DESCRIPTION
Motivation: `get_distance_bound()` uses the external tool QDistRnd by running a script essentially on the command line via Python's `subprocess`.  To do this, it writes the check matrix of the QEC code on the command line which triggers `OSError("command line too long")` for large codes.  (This code was written as part of checking the distance of codes for https://arxiv.org/abs/2604.16209)

Two fixes:
- Instead of serializing the matrix in dense form, as a list of lists, serialize it in sparse form along with a GAP script to convert the sparse form to a dense matrix within the GAP process.
- Instead of sending the matrix and GAP script on the command line via `-c`, write the matrix and script over a pipe (which has no size limit).