### PR TITLE
Allow `HGPCode.get_canonical_logical_ops` to accept/return `abstract.RingArray`s

### DIFF
--- a/src/qldpc/abstract.py
+++ b/src/qldpc/abstract.py
@@ -859,8 +859,8 @@ class RingArray(npt.NDArray[np.object_]):
         for value in array.ravel():
             if not isinstance(value, RingMember):
                 raise ValueError(
-                    "Requirement failed: all entries of a RingArray must be RingMember-valued\n"
-                    "Try building an array with RingArray.build(...)"
+                    "Requirement failed: all entries of a RingArray must be RingMember-valued."
+                    "\nTry building an array with RingArray.build(...)"
                 )
             else:
                 if not (ring is None or ring == value.ring):
@@ -993,7 +993,7 @@ class RingArray(npt.NDArray[np.object_]):
         group = ring.group if isinstance(ring, GroupRing) else ring
         assert array.shape[-1] == group.order
         vals = [RingMember.from_vector(ring, entry) for entry in array.reshape(-1, group.order)]
-        return RingArray(np.array(vals, dtype=object).reshape(array.shape[:-1]))
+        return RingArray(np.array(vals, dtype=object).reshape(array.shape[:-1]), ring=ring)
 
     def to_field_array(self) -> galois.FieldArray:
         """Convert a RingArray into an array of coefficients (in a finite field) for each entry.
@@ -1032,17 +1032,17 @@ class RingArray(npt.NDArray[np.object_]):
         # collect ring-valued null row vectors (that is, transposed null column vectors)
         null_space = ~RingArray.from_field_array(
             self.ring,
-            null_field_vectors.reshape(len(null_field_vectors), -1, self.group.order),
+            null_field_vectors.reshape(len(null_field_vectors), self.shape[1], self.group.order),
         )
-        if not row_reduce:
+        if not row_reduce or not null_field_vectors.size:
             return null_space
 
         try:
             return null_space.row_reduce()
-        except NotImplementedError as error:
+        except NotImplementedError:
             raise NotImplementedError(
-                "Cannot row-reduce the null-space matrix of this RingArray.  Try calling"
-                f" RingArray.null_space(row_reduce=False).  Error from row reduction:\n{error}"
+                "Cannot row-reduce the null-space matrix of this RingArray."
+                "\nTry calling RingArray.null_space(row_reduce=False)"
             )
 
     def row_reduce(self) -> RingArray:
@@ -1053,7 +1053,7 @@ class RingArray(npt.NDArray[np.object_]):
         """
         if isinstance(self.group, CyclicGroup):
             return self._row_reduce_cyclic()
-        # TODO: special case for principal ideal rings that are not based on a cyclic group
+        # TODO: add special case for principal ideal rings that are not based on a cyclic group
         if self.ring.is_semisimple:
             return self._row_reduce_semisimple()
         return self._row_reduce_general()

--- a/src/qldpc/codes/quantum.py
+++ b/src/qldpc/codes/quantum.py
@@ -24,7 +24,7 @@ import itertools
 import math
 import os
 from collections.abc import Collection, Iterable, Iterator, Sequence
-from typing import TypeVar, Union
+from typing import TypeVar
 
 import galois
 import networkx as nx
@@ -829,9 +829,7 @@ class BBCode(QCCode):
 # hypergraph product code, lifted product code, and their subsystem variants
 
 
-FieldOrRingArray = TypeVar(
-    "FieldOrRingArray", bound=Union[npt.NDArray[np.int_], npt.NDArray[np.object_]]
-)
+FieldOrRingArray = TypeVar("FieldOrRingArray", galois.FieldArray, abstract.RingArray)
 
 
 class HGPCode(CSSCode):
@@ -940,7 +938,9 @@ class HGPCode(CSSCode):
         )
 
         if set_logicals:
-            logical_ops_xz = HGPCode.get_canonical_logical_ops(self.code_a, self.code_b)
+            logical_ops_xz = HGPCode.get_canonical_logical_ops(
+                self.code_a.matrix, self.code_b.matrix
+            )
             self.set_logical_ops_xz(*logical_ops_xz, skip_validation=True)
 
     def get_syndrome_subgraphs(self, *, strategy: str = "smallest_last") -> tuple[nx.DiGraph, ...]:
@@ -1092,8 +1092,8 @@ class HGPCode(CSSCode):
 
     @staticmethod
     def get_canonical_logical_ops(
-        matrix_a: ClassicalCode | galois.FieldArray, matrix_b: ClassicalCode | galois.FieldArray
-    ) -> tuple[galois.FieldArray, galois.FieldArray]:
+        matrix_a: FieldOrRingArray, matrix_b: FieldOrRingArray
+    ) -> tuple[FieldOrRingArray, FieldOrRingArray]:
         """Canonical logical operators for the hypergraph product code.
 
         These operators are essentially those in Lemma 1 of arXiv:2204.10812v3, modified using pivot
@@ -1103,24 +1103,20 @@ class HGPCode(CSSCode):
         X-type logical operators are "horizontal" in sector (0, 0) and "vertical" in sector (1, 1).
         Vice versa for Z-type logical operators.
         """
-        matrix_a = matrix_a.matrix if isinstance(matrix_a, ClassicalCode) else matrix_a
-        matrix_b = matrix_b.matrix if isinstance(matrix_b, ClassicalCode) else matrix_b
-
-        assert type(matrix_a) is type(matrix_a)
-        field = type(matrix_a)
+        field_or_ring = type(matrix_a) if isinstance(matrix_a, galois.FieldArray) else matrix_a.ring
 
         generator_a = matrix_a.null_space()
         generator_b = matrix_b.null_space()
         generator_a_T = matrix_a.T.null_space()
         generator_b_T = matrix_b.T.null_space()
 
-        pivots_a = field.Zeros(generator_a.shape)
-        pivots_b = field.Zeros(generator_b.shape)
+        pivots_a = np.zeros(generator_a.shape, dtype=int)
+        pivots_b = np.zeros(generator_b.shape, dtype=int)
         pivots_a[range(len(pivots_a)), qldpc.math.first_nonzero_cols(generator_a)] = 1
         pivots_b[range(len(pivots_b)), qldpc.math.first_nonzero_cols(generator_b)] = 1
 
-        pivots_a_T = field.Zeros(generator_a_T.shape)
-        pivots_b_T = field.Zeros(generator_b_T.shape)
+        pivots_a_T = np.zeros(generator_a_T.shape, dtype=int)
+        pivots_b_T = np.zeros(generator_b_T.shape, dtype=int)
         pivots_a_T[range(len(pivots_a_T)), qldpc.math.first_nonzero_cols(generator_a_T)] = 1
         pivots_b_T[range(len(pivots_b_T)), qldpc.math.first_nonzero_cols(generator_b_T)] = 1
 
@@ -1132,7 +1128,13 @@ class HGPCode(CSSCode):
 
         logical_ops_x = scipy.linalg.block_diag(logical_ops_x_l, logical_ops_x_r)
         logical_ops_z = scipy.linalg.block_diag(logical_ops_z_l, logical_ops_z_r)
-        return logical_ops_x.view(field), logical_ops_z.view(field)
+
+        if isinstance(matrix_a, abstract.RingArray):
+            return (
+                abstract.RingArray.build(logical_ops_x, field_or_ring),
+                abstract.RingArray.build(logical_ops_z, field_or_ring),
+            )
+        return logical_ops_x.view(field_or_ring), logical_ops_z.view(field_or_ring)
 
     def _get_distance_exact(self, pauli: PauliXZ | None) -> int | float:
         """Exact distance calculation for hypergraph product codes.
@@ -1251,7 +1253,9 @@ class SHPCode(CSSCode):
         self._stabilizer_ops = scipy.linalg.block_diag(stab_ops_x, stab_ops_z).view(code_field)
 
         if set_logicals:
-            logical_ops_xz = SHPCode.get_canonical_logical_ops(self.code_a, self.code_b)
+            logical_ops_xz = SHPCode.get_canonical_logical_ops(
+                self.code_a.matrix, self.code_b.matrix
+            )
             self.set_logical_ops_xz(*logical_ops_xz, skip_validation=True)
 
     @staticmethod
@@ -1265,30 +1269,31 @@ class SHPCode(CSSCode):
 
     @staticmethod
     def get_canonical_logical_ops(
-        matrix_x: ClassicalCode | galois.FieldArray, matrix_z: ClassicalCode | galois.FieldArray
-    ) -> tuple[galois.FieldArray, galois.FieldArray]:
+        matrix_a: FieldOrRingArray, matrix_b: FieldOrRingArray
+    ) -> tuple[FieldOrRingArray, FieldOrRingArray]:
         """Canonical logical operators for the subsystem hypergraph product code.
 
         These operators are essentially those in Theorem VIII.10 of arXiv:2502.07150v1, generalized
         slightly to account for the possibility that code_x != code_z.
         """
-        matrix_x = matrix_x.matrix if isinstance(matrix_x, ClassicalCode) else matrix_x
-        matrix_z = matrix_z.matrix if isinstance(matrix_z, ClassicalCode) else matrix_z
+        field_or_ring = type(matrix_a) if isinstance(matrix_a, galois.FieldArray) else matrix_a.ring
 
-        assert type(matrix_x) is type(matrix_x)
-        field = type(matrix_x)
+        generator_x = matrix_a.null_space()
+        generator_z = matrix_b.null_space()
 
-        generator_x = matrix_x.null_space()
-        generator_z = matrix_z.null_space()
-
-        pivots_x = field.Zeros(generator_x.shape)
-        pivots_z = field.Zeros(generator_z.shape)
+        pivots_x = np.zeros(generator_x.shape, dtype=int)
+        pivots_z = np.zeros(generator_z.shape, dtype=int)
         pivots_x[range(len(pivots_x)), qldpc.math.first_nonzero_cols(generator_x)] = 1
         pivots_z[range(len(pivots_z)), qldpc.math.first_nonzero_cols(generator_z)] = 1
 
         logical_ops_x = np.kron(pivots_x, generator_z)
         logical_ops_z = np.kron(generator_x, pivots_z)
-        return logical_ops_x.view(field), logical_ops_z.view(field)
+        if isinstance(matrix_a, abstract.RingArray):
+            return (
+                abstract.RingArray.build(logical_ops_x, field_or_ring),
+                abstract.RingArray.build(logical_ops_z, field_or_ring),
+            )
+        return logical_ops_x.view(field_or_ring), logical_ops_z.view(field_or_ring)
 
     def _get_distance_exact(self, pauli: PauliXZ | None) -> int | float:
         """Exact distance calculation for subsystem hypergraph product codes."""
@@ -1427,12 +1432,12 @@ class SLPCode(CSSCode):
         """Subsystem lifted product of two RingArrays."""
         if matrix_b is None:
             matrix_b = matrix_a
-        matrix_a = abstract.RingArray(matrix_a)
-        matrix_b = abstract.RingArray(matrix_b)
-        field = matrix_a.field.order
+        self.matrix_a = abstract.RingArray(matrix_a)
+        self.matrix_b = abstract.RingArray(matrix_b)
+        field = self.matrix_a.field.order
 
         # identify X-sector and Z-sector parity checks
-        matrix_x, matrix_z = SHPCode.get_matrix_product(matrix_a, matrix_b)
+        matrix_x, matrix_z = SHPCode.get_matrix_product(self.matrix_a, self.matrix_b)
         assert isinstance(matrix_x, abstract.RingArray)
         assert isinstance(matrix_z, abstract.RingArray)
 

--- a/src/qldpc/codes/quantum.py
+++ b/src/qldpc/codes/quantum.py
@@ -1010,7 +1010,7 @@ class HGPCode(CSSCode):
 
         # construct the X-sector and Z-sector parity check matrices
         matrix_x = np.block([mat_H1_In2, mat_Im1_H2_T])
-        matrix_z = np.block([-mat_In1_H2, mat_H1_T_Im2])
+        matrix_z = np.block([-mat_In1_H2, mat_H1_T_Im2])  # type:ignore[misc]
         return matrix_x.view(type(matrix_a)), matrix_z.view(type(matrix_a))
 
     @staticmethod

--- a/src/qldpc/codes/quantum_test.py
+++ b/src/qldpc/codes/quantum_test.py
@@ -369,6 +369,15 @@ def test_lift() -> None:
     assert code_HP.sector_size.sum() == code_HP.num_qudits + code_HP.num_checks
     assert code_LP.sector_size.sum() == code_LP.num_qudits + code_LP.num_checks
 
+    # build logical operators over the ring
+    ring_logicals_x, ring_logicals_z = codes.HGPCode.get_canonical_logical_ops(
+        code_LP.matrix_a, code_LP.matrix_b
+    )
+    assert np.array_equal(
+        (ring_logicals_x @ ring_logicals_z.T).lift(),
+        np.eye(code_LP.dimension, dtype=int),
+    )
+
 
 def test_twisted_XZZX(width: int = 3) -> None:
     """Verify twisted XZZX code in Eqs.(29) and (32) of arXiv:2202.01702v3."""
@@ -426,6 +435,35 @@ def test_lifted_product_codes() -> None:
         subsystem_code = codes.SLPCode(matrix)
         subsystem_rate = subsystem_code.dimension / subsystem_code.num_qudits
         assert subsystem_rate > rate
+
+
+def test_subsystem_lifted_product_codes() -> None:
+    """Subsystem lifted product codes in arXiv:2404.18302v1."""
+
+    # example 1 on page 6 of https://arxiv.org/pdf/2404.18302v1
+    group = abstract.CyclicGroup(2)
+    ring = abstract.GroupRing(group)
+    xx = ring.generators[0]
+    matrix = abstract.RingArray.build([[1, xx, xx], [xx, xx, 1]], ring)  # Eq. 21
+    code = codes.SLPCode(matrix)
+    assert code.get_code_params() == (18, 4, 2)
+
+    # example 2 on page 6 of https://arxiv.org/pdf/2404.18302v1
+    group = abstract.CyclicGroup(3)
+    ring = abstract.GroupRing(group)
+    xx = ring.generators[0]
+    matrix = abstract.RingArray.build([[xx**2 + xx + 1, xx + 1, xx]], ring)  # Eq. 23
+    code = codes.SLPCode(matrix)
+    assert code.get_code_params() == (27, 12, 2)
+
+    # build logical operators over the ring
+    ring_logicals_x, ring_logicals_z = codes.SHPCode.get_canonical_logical_ops(
+        code.matrix_a, code.matrix_b
+    )
+    assert np.array_equal(
+        (ring_logicals_x @ ring_logicals_z.T).lift(),
+        np.eye(code.dimension, dtype=int),
+    )
 
 
 def test_quantum_tanner(pytestconfig: pytest.Config) -> None:


### PR DESCRIPTION
Same for `SHPCode.get_canonical_logical_ops`.

Only works for rings for which `RingArray.row_reduce` is supported, which currently only includes cyclic group algebras.

Note additional work is needed to convert these ring-valued logicals into field-valued logicals of the corresponding `LPCode` or `SLPCode`.