### PR TITLE
Add `ErrorRateFunc` class

### DIFF
--- a/src/qldpc/codes/__init__.py
+++ b/src/qldpc/codes/__init__.py
@@ -14,6 +14,7 @@ from .common import (
     AbstractCode,
     ClassicalCode,
     CSSCode,
+    ErrorRateFunc,
     QuditCode,
 )
 from .distance import (
@@ -62,6 +63,7 @@ __all__ = [
     "AbstractCode",
     "ClassicalCode",
     "CSSCode",
+    "ErrorRateFunc",
     "QuditCode",
     "BaconShorCode",
     "BBCode",

--- a/src/qldpc/codes/common.py
+++ b/src/qldpc/codes/common.py
@@ -769,7 +769,7 @@ class ClassicalCode(AbstractCode):
                 weight, sample_allocation[weight], decoder
             )
 
-        return ErrorRateFunc(len(self), max_error_weight, max_error_rate, fidelities, variances)
+        return ErrorRateFunc(fidelities, variances, len(self), max_error_rate)
 
     def _estimate_decoding_fidelity_and_variance(
         self, error_weight: int, num_samples: int, decoder: decoders.Decoder
@@ -1985,7 +1985,7 @@ class QuditCode(AbstractCode):
                 pauli_bias_zxy,
             )
 
-        return ErrorRateFunc(len(self), max_error_weight, max_error_rate, fidelities, variances)
+        return ErrorRateFunc(fidelities, variances, len(self), max_error_rate)
 
     def _estimate_decoding_fidelity_and_variance(
         self,
@@ -3070,7 +3070,7 @@ class CSSCode(QuditCode):
                 )
             )
 
-        return ErrorRateFunc(len(self), max_error_weight, max_error_rate, fidelities, variances)
+        return ErrorRateFunc(fidelities, variances, len(self), max_error_rate)
 
     def _estimate_css_decoding_fidelity_and_variance(
         self,
@@ -3210,12 +3210,12 @@ class ErrorRateFunc:
     If called with an array of physical error rates, this function returns two arrays.
     """
 
-    num_error_locations: int  # the total number of error locations
-    max_error_rate: float  # the largest physical error rate we can consider
-
     # mean fidelity (and variance thereof) conditioned on the weight of an error, specified by index
     fixed_weight_fidelities: npt.NDArray[np.floating]
     fixed_weight_variances: npt.NDArray[np.floating]
+
+    num_error_locations: int  # the total number of error locations
+    max_error_rate: float  # the largest physical error rate we can consider
 
     def __call__(self, error_rate: OneOrManyFloats) -> tuple[OneOrManyFloats, OneOrManyFloats]:
         """Compute the logical error rate at a given physical error rate."""
@@ -3231,8 +3231,9 @@ class ErrorRateFunc:
                 f" {self.max_error_rate}.  Try calling <your_code>.get_logical_error_rate_func with"
                 " a larger max_error_rate."
             )
+        max_error_weight = self.fixed_weight_fidelities.size - 1
         fixed_weight_probs = _get_error_probs_by_weight(
-            self.num_error_locations, error_rate, self.max_error_weight
+            self.num_error_locations, error_rate, max_error_weight
         )
         fidelity = fixed_weight_probs @ self.fixed_weight_fidelities
         variance = np.sqrt(fixed_weight_probs**2 @ self.fixed_weight_variances)

--- a/src/qldpc/codes/common.py
+++ b/src/qldpc/codes/common.py
@@ -3201,8 +3201,13 @@ OneOrManyFloats = TypeVar("OneOrManyFloats", float, Iterable[float])
 class ErrorRateFunc:
     """Container for importance-sampled fidelities at fixed error weights.
 
-    An instance "func" of this class can be called as "func(p)" or "func([p1, p2])" to combine
-    simulation data and determine a logical error rate at physical error rates p or (p1, p2).
+    An instance of this class is built and returned by the .get_logical_error_rate_func method of
+    ClassicalCode, QuditCode, and CSSCode.  If
+        func = code.get_logical_error_rate_func(...),
+    then "func" takes a physical error rate "p" as an argument, and returns two numbers:
+    (1) A logical error rate.
+    (2) An uncertainty (standard error) in the logical error rate.
+    If called with an array of physical error rates, this function returns two arrays.
     """
 
     num_error_locations: int  # the total number of error locations

--- a/src/qldpc/codes/common.py
+++ b/src/qldpc/codes/common.py
@@ -19,12 +19,13 @@ from __future__ import annotations
 
 import abc
 import collections
+import dataclasses
 import functools
 import itertools
 import random
 import warnings
-from collections.abc import Callable, Collection, Mapping, Sequence
-from typing import Any, Iterator, cast
+from collections.abc import Callable, Collection, Iterable, Mapping, Sequence
+from typing import Any, Iterator, TypeVar, cast
 
 import galois
 import networkx as nx
@@ -725,9 +726,7 @@ class ClassicalCode(AbstractCode):
 
     def get_logical_error_rate_func(
         self, num_samples: int, max_error_rate: float = 0.3, **decoder_kwargs: Any
-    ) -> Callable[
-        [float | Sequence[float]], tuple[npt.NDArray[np.floating], npt.NDArray[np.floating]]
-    ]:
+    ) -> ErrorRateFunc:
         """Construct a function from physical --> logical error rate in a code capacity model.
 
         In addition to the logical error rate, the constructed function returns an uncertainty
@@ -768,19 +767,7 @@ class ClassicalCode(AbstractCode):
                 weight, sample_allocation[weight], decoder
             )
 
-        @np.vectorize
-        def get_logical_error_rate(error_rate: float) -> tuple[float, float]:
-            """Compute a logical error rate in a code-capacity model."""
-            if error_rate > max_error_rate:
-                raise ValueError(
-                    "Cannot determine logical error rates for physical error rates greater than"
-                    f" {max_error_rate}.  Try running get_logical_error_rate_func with a larger"
-                    " max_error_rate."
-                )
-            probs = _get_error_probs_by_weight(len(self), error_rate, max_error_weight)
-            return 1 - float(probs @ fidelities), float(np.sqrt(probs**2 @ variances))
-
-        return get_logical_error_rate
+        return ErrorRateFunc(len(self), max_error_weight, max_error_rate, fidelities, variances)
 
     def _estimate_decoding_fidelity_and_variance(
         self, error_weight: int, num_samples: int, decoder: decoders.Decoder
@@ -1942,9 +1929,7 @@ class QuditCode(AbstractCode):
         max_error_rate: float = 0.3,
         pauli_bias: Sequence[float] | None = None,
         **decoder_kwargs: Any,
-    ) -> Callable[
-        [float | Sequence[float]], tuple[npt.NDArray[np.floating], npt.NDArray[np.floating]]
-    ]:
+    ) -> ErrorRateFunc:
         """Construct a function from physical --> logical error rate in a code capacity model.
 
         In addition to the logical error rate, the constructed function returns an uncertainty
@@ -1998,19 +1983,7 @@ class QuditCode(AbstractCode):
                 pauli_bias_zxy,
             )
 
-        @np.vectorize
-        def get_logical_error_rate(error_rate: float) -> tuple[float, float]:
-            """Compute a logical error rate in a code-capacity model."""
-            if error_rate > max_error_rate:
-                raise ValueError(
-                    "Cannot determine logical error rates for physical error rates greater than"
-                    f" {max_error_rate}.  Try running get_logical_error_rate_func with a larger"
-                    " max_error_rate."
-                )
-            probs = _get_error_probs_by_weight(len(self), error_rate, max_error_weight)
-            return 1 - float(probs @ fidelities), float(np.sqrt(probs**2 @ variances))
-
-        return get_logical_error_rate
+        return ErrorRateFunc(len(self), max_error_weight, max_error_rate, fidelities, variances)
 
     def _estimate_decoding_fidelity_and_variance(
         self,
@@ -3032,9 +3005,7 @@ class CSSCode(QuditCode):
         decoder_x_kwargs: dict[str, Any] | None = None,
         decoder_z_kwargs: dict[str, Any] | None = None,
         **decoder_kwargs: Any,
-    ) -> Callable[
-        [float | Sequence[float]], tuple[npt.NDArray[np.floating], npt.NDArray[np.floating]]
-    ]:
+    ) -> ErrorRateFunc:
         """Construct a function from physical --> logical error rate in a code capacity model.
 
         In addition to the logical error rate, the constructed function returns an uncertainty
@@ -3097,19 +3068,7 @@ class CSSCode(QuditCode):
                 )
             )
 
-        @np.vectorize
-        def get_logical_error_rate(error_rate: float) -> tuple[float, float]:
-            """Compute a logical error rate in a code-capacity model."""
-            if error_rate > max_error_rate:
-                raise ValueError(
-                    "Cannot determine logical error rates for physical error rates greater than"
-                    f" {max_error_rate}.  Try running get_logical_error_rate_func with a larger"
-                    " max_error_rate."
-                )
-            probs = _get_error_probs_by_weight(len(self), error_rate, max_error_weight)
-            return 1 - float(probs @ fidelities), float(np.sqrt(probs**2 @ variances))
-
-        return get_logical_error_rate
+        return ErrorRateFunc(len(self), max_error_weight, max_error_rate, fidelities, variances)
 
     def _estimate_css_decoding_fidelity_and_variance(
         self,
@@ -3231,3 +3190,36 @@ def _get_error_probs_by_weight(
         for kk in range(max_weight + 1)
     ]
     return np.exp(log_probs)
+
+
+OneOrManyFloats = TypeVar("OneOrManyFloats", float, Iterable[float])
+
+
+@dataclasses.dataclass
+class ErrorRateFunc:
+    block_length: int
+    max_weight: int
+    max_error_rate: float
+    fixed_weight_fidelities: npt.NDArray[np.floating]
+    fixed_weight_variances: npt.NDArray[np.floating]
+
+    def __call__(self, error_rate: OneOrManyFloats) -> tuple[OneOrManyFloats, OneOrManyFloats]:
+        """Compute a logical error rate in a code-capacity model."""
+        if isinstance(error_rate, Iterable):
+            results = [self(rate) for rate in error_rate]
+            return (  # type:ignore[return-value]
+                np.array([results[0] for result in results]),
+                np.array([results[1] for result in results]),
+            )
+        if error_rate > self.max_error_rate:
+            raise ValueError(
+                "Cannot determine logical error rates for physical error rates greater than"
+                f" {self.max_error_rate}.  Try calling <your_code>.get_logical_error_rate_func with"
+                " a larger max_error_rate."
+            )
+        fixed_weight_probs = _get_error_probs_by_weight(
+            self.block_length, error_rate, self.max_weight
+        )
+        fidelity = fixed_weight_probs @ self.fixed_weight_fidelities
+        variance = np.sqrt(fixed_weight_probs**2 @ self.fixed_weight_variances)
+        return 1 - float(fidelity), float(variance)

--- a/src/qldpc/codes/common.py
+++ b/src/qldpc/codes/common.py
@@ -739,15 +739,17 @@ class ClassicalCode(AbstractCode):
         The logical error rate returned by the constructed function the probability with which a
         code error (obtained by sampling independent errors on all bits) is decoded incorrectly.
 
-        The basic idea in this method is to first think of the decoding fidelity F(p) = 1 -
-        logical_error_rate(p) as a function of the physical error rate p, and decompose
+        The basic idea in this method is to think of the fidelity
+            F(p) = 1 - logical_error_rate(p)
+        as a function of the physical error rate p, and decompose
             F(p) = sum_k q_k(p) F_k,
-        where q_k(p) = (n choose k) p**k (1-p)**(n-k) is the probability of a weight-k error (here n
-        is total number of bits in the code), and F_k is the probability with which a weight-k error
-        is corrected by the decoder.  Importantly, F_k is independent of p.  We therefore use our
-        sample budget to compute estimates of F_k (according to some allocation of samples to each
-        weight k, which depends on the max_error_rate), and then recycle the values of F_k to
-        compute each F(p).
+        where
+            q_k(p) = (n choose k) p**k (1-p)**(n-k)
+        is the probability of a weight-k error (here n is total number of bits in the code), and F_k
+        is the probability with which a weight-k error is corrected by the decoder.  Importantly,
+        F_k is independent of p.  We therefore use our sample budget to compute estimates of F_k
+        (according to some allocation of samples to each weight k, which depends on the
+        max_error_rate), and then recycle the values of F_k to compute each F(p).
 
         There is one more minor trick, which is that we can use the fact that F_0 = 1 to simplify
             F(p) = q_0(p) + sum_(k>0) q_k(p) F_k.
@@ -3197,19 +3199,26 @@ OneOrManyFloats = TypeVar("OneOrManyFloats", float, Iterable[float])
 
 @dataclasses.dataclass
 class ErrorRateFunc:
-    block_length: int
-    max_weight: int
-    max_error_rate: float
+    """Container for importance-sampled fidelities at fixed error weights.
+
+    An instance "func" of this class can be called as "func(p)" or "func([p1, p2])" to combine
+    simulation data and determine a logical error rate at physical error rates p or (p1, p2).
+    """
+
+    num_error_locations: int  # the total number of error locations
+    max_error_rate: float  # the largest physical error rate we can consider
+
+    # mean fidelity (and variance thereof) conditioned on the weight of an error, specified by index
     fixed_weight_fidelities: npt.NDArray[np.floating]
     fixed_weight_variances: npt.NDArray[np.floating]
 
     def __call__(self, error_rate: OneOrManyFloats) -> tuple[OneOrManyFloats, OneOrManyFloats]:
-        """Compute a logical error rate in a code-capacity model."""
+        """Compute the logical error rate at a given physical error rate."""
         if isinstance(error_rate, Iterable):
             results = [self(rate) for rate in error_rate]
             return (  # type:ignore[return-value]
-                np.array([results[0] for result in results]),
-                np.array([results[1] for result in results]),
+                np.array([result[0] for result in results]),
+                np.array([result[1] for result in results]),
             )
         if error_rate > self.max_error_rate:
             raise ValueError(
@@ -3218,7 +3227,7 @@ class ErrorRateFunc:
                 " a larger max_error_rate."
             )
         fixed_weight_probs = _get_error_probs_by_weight(
-            self.block_length, error_rate, self.max_weight
+            self.num_error_locations, error_rate, self.max_error_weight
         )
         fidelity = fixed_weight_probs @ self.fixed_weight_fidelities
         variance = np.sqrt(fixed_weight_probs**2 @ self.fixed_weight_variances)

--- a/src/qldpc/codes/common_test.py
+++ b/src/qldpc/codes/common_test.py
@@ -227,7 +227,7 @@ def test_classical_capacity() -> None:
     code = codes.RepetitionCode(2)
     logical_error_rate = code.get_logical_error_rate_func(num_samples=1, max_error_rate=1)
     assert logical_error_rate(0) == (0, 0)  # no logical error with zero uncertainty
-    assert logical_error_rate(1)[0] == 1  # guaranteed logical error
+    assert logical_error_rate([1])[0] == 1  # guaranteed logical error
 
     logical_error_rate = code.get_logical_error_rate_func(num_samples=10, max_error_rate=0.5)
     with pytest.raises(ValueError, match="error rates greater than"):


### PR DESCRIPTION
Instances of this class are built and returned by, for example, `ClassicalCode.get_logical_error_rate_func` (also `QuditCode` and `CSSCode`).  The class is essentially a container for importance-sampled simulation data that is used to compute logical error rates, together with a function that computes logical error rates from this data.

"Factoring out" this class enables saving simulation results to, say, an external file or cache.