### PR TITLE
Some gap fixes

### DIFF
--- a/src/qldpc/external/gap.py
+++ b/src/qldpc/external/gap.py
@@ -33,7 +33,7 @@ GAP_ROOT = os.path.join(os.path.dirname(os.path.dirname(qldpc.__file__)), "gap")
 @functools.cache
 def is_callable() -> bool:
     """Can we call GAP 4 from the command line?"""
-    commands = ["gap", "-q", "-c", r'Print(GAPInfo.Version, "\n"); QUIT;']
+    commands = ["gap", "-q", "-c", r'Print(GAPInfo.Version, "\n");; QUIT;;']
     try:
         result = subprocess.run(commands, capture_output=True, text=True)
         version = result.stdout.strip()
@@ -58,10 +58,10 @@ def sanitize_commands(commands: Sequence[str]) -> tuple[str, ...]:
     """Sanitize GAP commands: don't format Print statements, and quit at the end."""
     stream = "__stream__"
     prefix = [
-        f"{stream} := OutputTextUser();",
-        f"SetPrintFormattingStatus({stream},false);",
+        f"{stream} := OutputTextUser();;",
+        f"SetPrintFormattingStatus({stream},false);;",
     ]
-    suffix = ["QUIT;"]
+    suffix = ["QUIT;;"]
     commands = [cmd.replace("Print(", f"PrintTo({stream}, ") for cmd in commands]
     return tuple(prefix + commands + suffix)
 
@@ -163,7 +163,7 @@ def require_package(name: str, repo: str | None = None) -> bool:
     Returns:
         True if the requirement is satisfied (raises an error otherwise).
     """
-    availability = get_output(f'Print(TestPackageAvailability("{name.lower()}"));')
+    availability = get_output(f'Print(TestPackageAvailability("{name.lower()}"));;')
 
     if availability.strip() == "fail":
         repo = repo or f"https://github.com/gap-packages/{name}"

--- a/src/qldpc/external/groups.py
+++ b/src/qldpc/external/groups.py
@@ -327,7 +327,7 @@ def get_primitive_central_idempotents(
     )
 
     coefficient_pattern = r"\(Z\(\d+(?:\^\d+)?\)(?:\^\d+)?\)"
-    cycle_pattern = r"\(\s?\d+(?:,\s?\d+)*\)|\(\)"
+    cycle_pattern = r"\(\s*\d+(?:,\s*\d+)*\)|\(\)"
     cycles_pattern = f"(?:{cycle_pattern})+"
     ring_term_pattern = rf"{coefficient_pattern}\*{cycles_pattern}"
     ring_member_pattern = rf"(?:{ring_term_pattern})(?:\+{ring_term_pattern})*"

--- a/src/qldpc/external/groups.py
+++ b/src/qldpc/external/groups.py
@@ -189,12 +189,12 @@ def maybe_get_generators_from_gap(
 
     # run GAP commands
     commands = [
-        'LoadPackage("guava", false);',
-        f"group := {group};",
-        "iso := IsomorphismPermGroup(group);",
-        "perm_group := Image(iso, group);",
-        "gens := GeneratorsOfGroup(perm_group);",
-        r'for gen in gens do Print(gen, "\n"); od;',
+        'LoadPackage("guava", false);;',
+        f"group := {group};;",
+        "iso := IsomorphismPermGroup(group);;",
+        "perm_group := Image(iso, group);;",
+        "gens := GeneratorsOfGroup(perm_group);;",
+        r'for gen in gens do Print(gen, "\n");; od;',
     ]
     permutations = qldpc.external.gap.get_output(*commands)
     return parse_gap_permutations(permutations)
@@ -319,15 +319,15 @@ def get_primitive_central_idempotents(
     qldpc.external.gap.require_package("Wedderga")
 
     idempotents_str = qldpc.external.gap.get_output(
-        'LoadPackage("wedderga", false);',
-        f"group := {group};",
-        f"ring := GroupRing(GF({field}), group);",
-        "idempotents := PrimitiveCentralIdempotentsByCharacterTable(ring);",
-        "Print(idempotents);",
+        'LoadPackage("wedderga", false);;',
+        f"group := {group};;",
+        f"ring := GroupRing(GF({field}), group);;",
+        "idempotents := PrimitiveCentralIdempotentsByCharacterTable(ring);;",
+        "Print(idempotents);;",
     )
 
     coefficient_pattern = r"\(Z\(\d+(?:\^\d+)?\)(?:\^\d+)?\)"
-    cycle_pattern = r"\(\d+(?:,\d+)*\)|\(\)"
+    cycle_pattern = r"\(\s?\d+(?:,\s?\d+)*\)|\(\)"
     cycles_pattern = f"(?:{cycle_pattern})+"
     ring_term_pattern = rf"{coefficient_pattern}\*{cycles_pattern}"
     ring_member_pattern = rf"(?:{ring_term_pattern})(?:\+{ring_term_pattern})*"


### PR DESCRIPTION
1. Use double semicolons to suppress more output.
2. Fix parsing of primitive central idempotents for large groups.