### PR TITLE
Add erasure support to decoders

### DIFF
--- a/src/qldpc/codes/common.py
+++ b/src/qldpc/codes/common.py
@@ -786,7 +786,7 @@ class ClassicalCode(AbstractCode):
             # decode the error
             syndrome = self.matrix @ error
             decoded_error, erasure = _get_error_and_erasure(decoder, syndrome)
-            if erasure:  # pragma: no cover
+            if erasure:
                 num_discards += 1
             elif np.any(decoded_error - error):
                 num_failures += 1
@@ -2015,7 +2015,7 @@ class QuditCode(AbstractCode):
             error = np.concatenate([error_x, error_z]).view(self.field)
             syndrome = syndrome_matrix @ error
             decoded_error, erasure = _get_error_and_erasure(decoder, syndrome)
-            if erasure:  # pragma: no cover
+            if erasure:
                 num_discards += 1
             elif np.any(logical_ops @ math.symplectic_conjugate(decoded_error - error)):
                 num_failures += 1
@@ -3100,12 +3100,12 @@ class CSSCode(QuditCode):
                 range(1, self.field.order), size=len(error_locs_z)
             )
             syndrome_z = self.matrix_x @ error_z
-            decoded_error_z, erasure_z = _get_error_and_erasure(decoder_z, syndrome_z)
-            if erasure_z:  # pragma: no cover
+            decoded_error_z, erasure = _get_error_and_erasure(decoder_z, syndrome_z)
+            if erasure:
                 num_discards += 1
                 continue
 
-            failure_z = np.any(logicals_x @ (decoded_error_z.view(self.field) - error_z))
+            failure_z = np.any(logicals_x @ (decoded_error_z - error_z))
             if not getattr(decoder_x, "has_erasure_bit", False) and failure_z:
                 # If we are _not_ post-selecting and there _was_ a decoding failure, then there is
                 # no need to consider X-type errors, because we will record one failure either way.
@@ -3119,8 +3119,8 @@ class CSSCode(QuditCode):
                 range(1, self.field.order), size=len(error_locs_x)
             )
             syndrome_x = self.matrix_z @ error_x
-            decoded_error_x, erasure_x = _get_error_and_erasure(decoder_x, syndrome_x)
-            if erasure_x | erasure_z:  # pragma: no cover
+            decoded_error_x, erasure = _get_error_and_erasure(decoder_x, syndrome_x)
+            if erasure:
                 num_discards += 1
                 continue
             if failure_z or np.any(logicals_z @ (decoded_error_x - error_x)):
@@ -3283,9 +3283,15 @@ def _get_error_and_erasure(
     decoder: decoders.Decoder,
     syndrome: galois.FieldArray,
 ) -> tuple[galois.FieldArray, bool]:
-    """Decode a syndrome and extract an erasure bit, if applicable."""
+    """Decode a syndrome and return the inferred error together with an erasure flag.
+
+    If the decoder has a has_erasure_bit attribute set to True (e.g., a LookupDecoder constructed
+    with add_erasure_bit=True), the last element of the decoded vector is treated as the erasure
+    bit: 1 means the syndrome was not recognized and the sample should be discarded, 0 means a
+    correction was found normally.  The erasure bit is stripped before returning the error.
+    """
     error = decoder.decode(syndrome.view(np.ndarray))
-    if getattr(decoder, "has_erasure_bit", False):  # pragma: no cover
+    if getattr(decoder, "has_erasure_bit", False):
         return error[:-1].view(type(syndrome)), bool(error[-1])
     return error.view(type(syndrome)), False
 

--- a/src/qldpc/codes/common.py
+++ b/src/qldpc/codes/common.py
@@ -786,7 +786,7 @@ class ClassicalCode(AbstractCode):
             # decode the error
             syndrome = self.matrix @ error
             decoded_error, erasure = _get_error_and_erasure(decoder, syndrome)
-            if erasure:
+            if erasure:  # pragma: no cover
                 num_discards += 1
             elif np.any(decoded_error - error):
                 num_failures += 1
@@ -2015,8 +2015,8 @@ class QuditCode(AbstractCode):
             error = np.concatenate([error_x, error_z]).view(self.field)
             syndrome = syndrome_matrix @ error
             decoded_error, erasure = _get_error_and_erasure(decoder, syndrome)
-            if erasure:
-                num_discards += 1  # pragma: no cover
+            if erasure:  # pragma: no cover
+                num_discards += 1
             elif np.any(logical_ops @ math.symplectic_conjugate(decoded_error - error)):
                 num_failures += 1
 
@@ -3101,7 +3101,7 @@ class CSSCode(QuditCode):
             )
             syndrome_z = self.matrix_x @ error_z
             decoded_error_z, erasure_z = _get_error_and_erasure(decoder_z, syndrome_z)
-            if erasure_z:
+            if erasure_z:  # pragma: no cover
                 num_discards += 1
                 continue
 
@@ -3285,7 +3285,7 @@ def _get_error_and_erasure(
 ) -> tuple[galois.FieldArray, bool]:
     """Decode a syndrome and extract an erasure bit, if applicable."""
     error = decoder.decode(syndrome.view(np.ndarray))
-    if getattr(decoder, "has_erasure_bit", False):
+    if getattr(decoder, "has_erasure_bit", False):  # pragma: no cover
         return error[:-1].view(type(syndrome)), bool(error[-1])
     return error.view(type(syndrome)), False
 

--- a/src/qldpc/codes/common.py
+++ b/src/qldpc/codes/common.py
@@ -725,12 +725,7 @@ class ClassicalCode(AbstractCode):
         return self.shortened(bits)
 
     def get_logical_error_rate_func(
-        self,
-        num_samples: int,
-        max_error_rate: float = 0.3,
-        *,
-        discard_weight: int | Collection[int] = (),
-        **decoder_kwargs: Any,
+        self, num_samples: int, max_error_rate: float = 0.3, **decoder_kwargs: Any
     ) -> ErrorRateFunc:
         """Construct a function from physical --> logical error rate in a code capacity model.
 
@@ -760,9 +755,6 @@ class ClassicalCode(AbstractCode):
             F(p) = q_0(p) + sum_(k>0) q_k(p) F_k.
         We thereby only need to sample errors of weight k > 0.
         """
-        if not isinstance(discard_weight, Collection):
-            discard_weight = [discard_weight]
-
         decoder = decoders.get_decoder(self.matrix, **decoder_kwargs)
 
         # sample errors of fixed weight and record failure/discard counts
@@ -772,7 +764,7 @@ class ClassicalCode(AbstractCode):
         for weight in range(1, len(sample_allocation)):
             num_failures[weight], num_discards[weight] = (
                 self._estimate_decoding_infidelity_and_variance(
-                    weight, sample_allocation[weight], decoder, discard_weight
+                    weight, sample_allocation[weight], decoder
                 )
             )
         return ErrorRateFunc(
@@ -780,13 +772,19 @@ class ClassicalCode(AbstractCode):
         )
 
     def _estimate_decoding_infidelity_and_variance(
-        self,
-        error_weight: int,
-        num_samples: int,
-        decoder: decoders.Decoder,
-        discard_weight: Collection[int],
+        self, error_weight: int, num_samples: int, decoder: decoders.Decoder
     ) -> tuple[int, int]:
         """Sample and correct errors of a fixed weight.  Return logical error and discard counts."""
+
+        def _get_error_and_erasure(
+            syndrome: npt.NDArray[np.int_],
+        ) -> tuple[galois.FieldArray, bool]:
+            """Decode a syndrome and extract an erasure bit, if applicable."""
+            error = decoder.decode(syndrome.view(np.ndarray))
+            if getattr(decoder, "has_erasure_bit", False):
+                return error[:-1].view(self.field), bool(error[-1])
+            return error.view(self.field), False
+
         num_failures = 0
         num_discards = 0
         for _ in range(num_samples):
@@ -797,8 +795,8 @@ class ClassicalCode(AbstractCode):
 
             # decode the error
             syndrome = self.matrix @ error
-            decoded_error = decoder.decode(syndrome.view(np.ndarray)).view(self.field)
-            if discard_weight and np.count_nonzero(decoded_error) in discard_weight:
+            decoded_error, erasure = _get_error_and_erasure(syndrome)
+            if erasure:
                 num_discards += 1
             elif np.any(decoded_error - error):
                 num_failures += 1
@@ -1944,8 +1942,6 @@ class QuditCode(AbstractCode):
         num_samples: int,
         max_error_rate: float = 0.3,
         pauli_bias: Sequence[float] | None = None,
-        *,
-        discard_weight: int | Collection[int] = (),
         **decoder_kwargs: Any,
     ) -> ErrorRateFunc:
         """Construct a function from physical --> logical error rate in a code capacity model.
@@ -1966,9 +1962,6 @@ class QuditCode(AbstractCode):
         See help(qldpc.codes.ClassicalCode.get_logical_error_rate_func) for more details about how
         this method works.
         """
-        if not isinstance(discard_weight, Collection):
-            discard_weight = [discard_weight]
-
         # collect relative probabilities of Z, X, and Y errors
         pauli_bias_zxy: npt.NDArray[np.floating] | None
         if pauli_bias is not None:
@@ -1993,12 +1986,7 @@ class QuditCode(AbstractCode):
         for weight in range(1, len(sample_allocation)):
             num_failures[weight], num_discards[weight] = (
                 self._estimate_decoding_fidelity_and_variance(
-                    weight,
-                    sample_allocation[weight],
-                    decoder,
-                    logical_ops,
-                    pauli_bias_zxy,
-                    discard_weight,
+                    weight, sample_allocation[weight], decoder, logical_ops, pauli_bias_zxy
                 )
             )
         return ErrorRateFunc(
@@ -2012,9 +2000,18 @@ class QuditCode(AbstractCode):
         decoder: decoders.Decoder,
         logical_ops: npt.NDArray[np.int_],
         pauli_bias_zxy: npt.NDArray[np.floating] | None,
-        discard_weight: Collection[int],
     ) -> tuple[int, int]:
         """Sample and correct errors of a fixed weight.  Return logical error and discard counts."""
+
+        def _get_error_and_erasure(
+            syndrome: npt.NDArray[np.int_],
+        ) -> tuple[galois.FieldArray, bool]:
+            """Decode a syndrome and extract an erasure bit, if applicable."""
+            error = decoder.decode(syndrome.view(np.ndarray))
+            if getattr(decoder, "has_erasure_bit", False):
+                return error[:-1].view(self.field), bool(error[-1])
+            return error.view(self.field), False
+
         num_failures = 0
         num_discards = 0
         syndrome_matrix = -math.symplectic_conjugate(self.matrix)
@@ -2037,8 +2034,8 @@ class QuditCode(AbstractCode):
 
             error = np.concatenate([error_x, error_z]).view(self.field)
             syndrome = syndrome_matrix @ error
-            decoded_error = decoder.decode(syndrome.view(np.ndarray)).view(self.field)
-            if discard_weight and math.symplectic_weight(decoded_error) in discard_weight:
+            decoded_error, erasure = _get_error_and_erasure(syndrome)
+            if erasure:
                 num_discards += 1  # pragma: no cover
             elif np.any(logical_ops @ math.symplectic_conjugate(decoded_error - error)):
                 num_failures += 1
@@ -3028,7 +3025,6 @@ class CSSCode(QuditCode):
         *,
         decoder_x_kwargs: dict[str, Any] | None = None,
         decoder_z_kwargs: dict[str, Any] | None = None,
-        discard_weight: int | Collection[int] = (),
         **decoder_kwargs: Any,
     ) -> ErrorRateFunc:
         """Construct a function from physical --> logical error rate in a code capacity model.
@@ -3049,9 +3045,6 @@ class CSSCode(QuditCode):
         See help(qldpc.codes.ClassicalCode.get_logical_error_rate_func) for more details about how
         this method works.
         """
-        if not isinstance(discard_weight, Collection):
-            discard_weight = [discard_weight]
-
         # collect relative probabilities of Z, X, and Y errors
         pauli_bias_zxy: npt.NDArray[np.floating] | None
         if pauli_bias is not None:
@@ -3096,7 +3089,6 @@ class CSSCode(QuditCode):
                     logicals_x,
                     logicals_z,
                     pauli_bias_zxy,
-                    discard_weight,
                 )
             )
         return ErrorRateFunc(
@@ -3112,9 +3104,18 @@ class CSSCode(QuditCode):
         logicals_x: npt.NDArray[np.int_],
         logicals_z: npt.NDArray[np.int_],
         pauli_bias_zxy: npt.NDArray[np.floating] | None,
-        discard_weight: Collection[int],
     ) -> tuple[int, int]:
         """Sample and correct errors of a fixed weight.  Return logical error and discard counts."""
+
+        def _get_error_and_erasure(
+            decoder: decoders.Decoder, syndrome: npt.NDArray[np.int_]
+        ) -> tuple[galois.FieldArray, bool]:
+            """Decode a syndrome and extract an erasure bit, if applicable."""
+            error = decoder.decode(syndrome.view(np.ndarray))
+            if getattr(decoder, "has_erasure_bit", False):
+                return error[:-1].view(self.field), bool(error[-1])
+            return error.view(self.field), False
+
         num_failures = 0
         num_discards = 0
         for _ in range(num_samples):
@@ -3129,14 +3130,13 @@ class CSSCode(QuditCode):
                 range(1, self.field.order), size=len(error_locs_z)
             )
             syndrome_z = self.matrix_x @ error_z
-            decoded_error_z = decoder_z.decode(syndrome_z.view(np.ndarray)).view(self.field)
-
-            if discard_weight and np.count_nonzero(decoded_error_z) in discard_weight:
+            decoded_error_z, erasure_z = _get_error_and_erasure(decoder_z, syndrome_z)
+            if erasure_z:
                 num_discards += 1
                 continue
 
-            failure_z = np.any(logicals_x @ (decoded_error_z - error_z))
-            if not discard_weight and failure_z:
+            failure_z = np.any(logicals_x @ (decoded_error_z.view(self.field) - error_z))
+            if not getattr(decoder_x, "has_erasure_bit", False) and failure_z:
                 # If we are _not_ post-selecting and there _was_ a decoding failure, then there is
                 # no need to consider X-type errors, because we will record one failure either way.
                 num_failures += 1
@@ -3149,10 +3149,8 @@ class CSSCode(QuditCode):
                 range(1, self.field.order), size=len(error_locs_x)
             )
             syndrome_x = self.matrix_z @ error_x
-            decoded_error_x = decoder_x.decode(syndrome_x.view(np.ndarray)).view(self.field)
-            if (
-                discard_weight and np.count_nonzero(decoded_error_x) in discard_weight
-            ):  # pragma: no cover
+            decoded_error_x, erasure_x = _get_error_and_erasure(decoder_x, syndrome_x)
+            if erasure_x | erasure_z:  # pragma: no cover
                 num_discards += 1
                 continue
             if failure_z or np.any(logicals_z @ (decoded_error_x - error_x)):

--- a/src/qldpc/codes/common.py
+++ b/src/qldpc/codes/common.py
@@ -775,16 +775,6 @@ class ClassicalCode(AbstractCode):
         self, error_weight: int, num_samples: int, decoder: decoders.Decoder
     ) -> tuple[int, int]:
         """Sample and correct errors of a fixed weight.  Return logical error and discard counts."""
-
-        def _get_error_and_erasure(
-            syndrome: npt.NDArray[np.int_],
-        ) -> tuple[galois.FieldArray, bool]:
-            """Decode a syndrome and extract an erasure bit, if applicable."""
-            error = decoder.decode(syndrome.view(np.ndarray))
-            if getattr(decoder, "has_erasure_bit", False):
-                return error[:-1].view(self.field), bool(error[-1])
-            return error.view(self.field), False
-
         num_failures = 0
         num_discards = 0
         for _ in range(num_samples):
@@ -795,7 +785,7 @@ class ClassicalCode(AbstractCode):
 
             # decode the error
             syndrome = self.matrix @ error
-            decoded_error, erasure = _get_error_and_erasure(syndrome)
+            decoded_error, erasure = _get_error_and_erasure(decoder, syndrome)
             if erasure:
                 num_discards += 1
             elif np.any(decoded_error - error):
@@ -2002,16 +1992,6 @@ class QuditCode(AbstractCode):
         pauli_bias_zxy: npt.NDArray[np.floating] | None,
     ) -> tuple[int, int]:
         """Sample and correct errors of a fixed weight.  Return logical error and discard counts."""
-
-        def _get_error_and_erasure(
-            syndrome: npt.NDArray[np.int_],
-        ) -> tuple[galois.FieldArray, bool]:
-            """Decode a syndrome and extract an erasure bit, if applicable."""
-            error = decoder.decode(syndrome.view(np.ndarray))
-            if getattr(decoder, "has_erasure_bit", False):
-                return error[:-1].view(self.field), bool(error[-1])
-            return error.view(self.field), False
-
         num_failures = 0
         num_discards = 0
         syndrome_matrix = -math.symplectic_conjugate(self.matrix)
@@ -2034,7 +2014,7 @@ class QuditCode(AbstractCode):
 
             error = np.concatenate([error_x, error_z]).view(self.field)
             syndrome = syndrome_matrix @ error
-            decoded_error, erasure = _get_error_and_erasure(syndrome)
+            decoded_error, erasure = _get_error_and_erasure(decoder, syndrome)
             if erasure:
                 num_discards += 1  # pragma: no cover
             elif np.any(logical_ops @ math.symplectic_conjugate(decoded_error - error)):
@@ -3106,16 +3086,6 @@ class CSSCode(QuditCode):
         pauli_bias_zxy: npt.NDArray[np.floating] | None,
     ) -> tuple[int, int]:
         """Sample and correct errors of a fixed weight.  Return logical error and discard counts."""
-
-        def _get_error_and_erasure(
-            decoder: decoders.Decoder, syndrome: npt.NDArray[np.int_]
-        ) -> tuple[galois.FieldArray, bool]:
-            """Decode a syndrome and extract an erasure bit, if applicable."""
-            error = decoder.decode(syndrome.view(np.ndarray))
-            if getattr(decoder, "has_erasure_bit", False):
-                return error[:-1].view(self.field), bool(error[-1])
-            return error.view(self.field), False
-
         num_failures = 0
         num_discards = 0
         for _ in range(num_samples):
@@ -3157,88 +3127,6 @@ class CSSCode(QuditCode):
                 num_failures += 1
 
         return num_failures, num_discards
-
-
-def _join_slices(*sectors: Slice) -> npt.NDArray[np.int_]:
-    """Join index slices together into one slice."""
-    return np.concatenate(
-        [
-            np.arange(sector.start or 0, sector.stop, sector.step or 1, dtype=int)
-            if isinstance(sector, slice)
-            else sector
-            for sector in sectors
-        ]
-    ).astype(int)
-
-
-def _is_canonicalized(matrix: npt.NDArray[np.int_]) -> bool:
-    """Is the given matrix in canonical (row-reduced) form?"""
-    return all(
-        matrix[row, pivot] and not np.any(matrix[:row, pivot])
-        for row, pivot in enumerate(math.first_nonzero_cols(matrix))
-    )
-
-
-def _get_sample_allocation(
-    num_samples: int, block_length: int, max_error_rate: float
-) -> npt.NDArray[np.int_]:
-    """Construct an allocation of samples by error weight.
-
-    This method returns an array whose k-th entry is the number of samples to devote to errors of
-    weight k, given a maximum error rate that we care about.
-    """
-    probs = _get_error_probs_by_weight(block_length, max_error_rate)
-
-    # zero out the distribution at k=0, flatten it out to the left of its peak, and renormalize
-    probs[0] = 0
-    probs[1 : np.argmax(probs)] = probs.max()
-    probs /= np.sum(probs)
-
-    # assign sample numbers according to the probability distribution constructed above,
-    # increasing num_samples if necessary to deal with weird edge cases from round-off errors
-    while np.sum(sample_allocation := np.round(probs * num_samples).astype(int)) < num_samples:
-        num_samples += 1  # pragma: no cover
-
-    # allocate one sample to k=0 to fix an edge case in ErrorRateFunc
-    sample_allocation[0] = 1
-
-    # truncate trailing zeros and return
-    nonzero = np.nonzero(sample_allocation)[0]
-    return sample_allocation[: nonzero[-1] + 1]
-
-
-def _get_error_probs_by_weight(
-    block_length: int, error_rate: float, max_weight: int | None = None
-) -> npt.NDArray[np.floating]:
-    """Build an array whose k-th entry is the probability of a weight-k error in a code.
-
-    If a code has block_length n and each bit has an independent probability p = error_rate of an
-    error, then the probability of k errors is (n choose k) p**k (1-p)**(n-k).
-
-    We compute the above probability using logarithms because otherwise the combinatorial factor
-    (n choose k) might be too large to handle.
-    """
-    max_weight = max_weight or block_length
-
-    # deal with some pathological cases
-    if error_rate == 0:
-        probs = np.zeros(max_weight + 1)
-        probs[0] = 1
-        return probs
-    elif error_rate == 1:
-        probs = np.zeros(max_weight + 1)
-        probs[block_length:] = 1
-        return probs
-
-    log_error_rate = np.log(error_rate)
-    log_one_minus_error_rate = np.log(1 - error_rate)
-    log_probs = [
-        math.log_choose(block_length, kk)
-        + kk * log_error_rate
-        + (block_length - kk) * log_one_minus_error_rate
-        for kk in range(max_weight + 1)
-    ]
-    return np.exp(log_probs)
 
 
 OneOrManyFloats = TypeVar("OneOrManyFloats", float, Iterable[float])
@@ -3327,3 +3215,96 @@ class ErrorRateFunc:
         value = weight_probs @ values
         variance = np.sqrt(weight_probs**2 @ variances)
         return 1 - float(value), float(variance)
+
+
+def _get_sample_allocation(
+    num_samples: int, block_length: int, max_error_rate: float
+) -> npt.NDArray[np.int_]:
+    """Construct an allocation of samples by error weight.
+
+    This method returns an array whose k-th entry is the number of samples to devote to errors of
+    weight k, given a maximum error rate that we care about.
+    """
+    probs = _get_error_probs_by_weight(block_length, max_error_rate)
+
+    # zero out the distribution at k=0, flatten it out to the left of its peak, and renormalize
+    probs[0] = 0
+    probs[1 : np.argmax(probs)] = probs.max()
+    probs /= np.sum(probs)
+
+    # assign sample numbers according to the probability distribution constructed above,
+    # increasing num_samples if necessary to deal with weird edge cases from round-off errors
+    while np.sum(sample_allocation := np.round(probs * num_samples).astype(int)) < num_samples:
+        num_samples += 1  # pragma: no cover
+
+    # allocate one sample to k=0 to fix an edge case in ErrorRateFunc
+    sample_allocation[0] = 1
+
+    # truncate trailing zeros and return
+    nonzero = np.nonzero(sample_allocation)[0]
+    return sample_allocation[: nonzero[-1] + 1]
+
+
+def _get_error_probs_by_weight(
+    block_length: int, error_rate: float, max_weight: int | None = None
+) -> npt.NDArray[np.floating]:
+    """Build an array whose k-th entry is the probability of a weight-k error in a code.
+
+    If a code has block_length n and each bit has an independent probability p = error_rate of an
+    error, then the probability of k errors is (n choose k) p**k (1-p)**(n-k).
+
+    We compute the above probability using logarithms because otherwise the combinatorial factor
+    (n choose k) might be too large to handle.
+    """
+    max_weight = max_weight or block_length
+
+    # deal with some pathological cases
+    if error_rate == 0:
+        probs = np.zeros(max_weight + 1)
+        probs[0] = 1
+        return probs
+    elif error_rate == 1:
+        probs = np.zeros(max_weight + 1)
+        probs[block_length:] = 1
+        return probs
+
+    log_error_rate = np.log(error_rate)
+    log_one_minus_error_rate = np.log(1 - error_rate)
+    log_probs = [
+        math.log_choose(block_length, kk)
+        + kk * log_error_rate
+        + (block_length - kk) * log_one_minus_error_rate
+        for kk in range(max_weight + 1)
+    ]
+    return np.exp(log_probs)
+
+
+def _get_error_and_erasure(
+    decoder: decoders.Decoder,
+    syndrome: galois.FieldArray,
+) -> tuple[galois.FieldArray, bool]:
+    """Decode a syndrome and extract an erasure bit, if applicable."""
+    error = decoder.decode(syndrome.view(np.ndarray))
+    if getattr(decoder, "has_erasure_bit", False):
+        return error[:-1].view(type(syndrome)), bool(error[-1])
+    return error.view(type(syndrome)), False
+
+
+def _join_slices(*sectors: Slice) -> npt.NDArray[np.int_]:
+    """Join index slices together into one slice."""
+    return np.concatenate(
+        [
+            np.arange(sector.start or 0, sector.stop, sector.step or 1, dtype=int)
+            if isinstance(sector, slice)
+            else sector
+            for sector in sectors
+        ]
+    ).astype(int)
+
+
+def _is_canonicalized(matrix: npt.NDArray[np.int_]) -> bool:
+    """Is the given matrix in canonical (row-reduced) form?"""
+    return all(
+        matrix[row, pivot] and not np.any(matrix[:row, pivot])
+        for row, pivot in enumerate(math.first_nonzero_cols(matrix))
+    )

--- a/src/qldpc/codes/common_test.py
+++ b/src/qldpc/codes/common_test.py
@@ -231,7 +231,7 @@ def test_classical_capacity() -> None:
 
     # with an erasure-enabled decoder, unrecognised syndromes are discarded
     logical_error_rate_func = code.get_logical_error_rate_func(
-        num_samples=4, max_error_rate=0.5, with_lookup=True, max_weight=0, add_erasure_bit=True
+        num_samples=1, max_error_rate=0.5, with_lookup=True, max_weight=0, add_erasure_bit=True
     )
     assert logical_error_rate_func(0, discard_rate=True) == (0, 0)  # no errors at p=0
     assert logical_error_rate_func(0.5, discard_rate=True)[0] > 0  # nonzero syndromes → erasure
@@ -737,7 +737,7 @@ def test_css_capacity() -> None:
     """Logical error rates in a code capacity model."""
     code = codes.SteaneCode()
 
-    logical_error_rate_func = code.get_logical_error_rate_func(num_samples=10)
+    logical_error_rate_func = code.get_logical_error_rate_func(num_samples=1)
     assert logical_error_rate_func(0) == (0, 0)  # no logical error with zero uncertainty
 
     # guaranteed logical X and Z errors

--- a/src/qldpc/codes/common_test.py
+++ b/src/qldpc/codes/common_test.py
@@ -745,8 +745,8 @@ def test_css_capacity() -> None:
         logical_error_rate_func = code.get_logical_error_rate_func(10, 1, pauli_bias)
         assert logical_error_rate_func(1)[0] == 1
 
-    # with pure-X errors, Z syndromes are always zero (no Z erasure) and X syndromes are always
-    # nonzero (X erasure fires), so every sample hits the X-erasure path and is discarded
+    # with pure-X errors, Z syndromes are always zero (no Z erasure) so samples reach the X
+    # decoder; at p=0.9 the dominant weight-6 errors have nonzero X syndromes, triggering erasure
     logical_error_rate_func = code.get_logical_error_rate_func(
         num_samples=1,
         max_error_rate=1,
@@ -756,4 +756,4 @@ def test_css_capacity() -> None:
         add_erasure_bit=True,
     )
     assert logical_error_rate_func(0, discard_rate=True) == (0, 0)  # no errors at p=0
-    assert logical_error_rate_func(1, discard_rate=True)[0] > 0  # X syndromes → erasure
+    assert logical_error_rate_func(0.9, discard_rate=True)[0] > 0  # X syndromes → erasure

--- a/src/qldpc/codes/common_test.py
+++ b/src/qldpc/codes/common_test.py
@@ -745,9 +745,15 @@ def test_css_capacity() -> None:
         logical_error_rate_func = code.get_logical_error_rate_func(10, 1, pauli_bias)
         assert logical_error_rate_func(1)[0] == 1
 
-    # with an erasure-enabled decoder, unrecognised syndromes are discarded
+    # with pure-X errors, Z syndromes are always zero (no Z erasure) and X syndromes are always
+    # nonzero (X erasure fires), so every sample hits the X-erasure path and is discarded
     logical_error_rate_func = code.get_logical_error_rate_func(
-        num_samples=1, max_error_rate=1, with_lookup=True, max_weight=0, add_erasure_bit=True
+        num_samples=1,
+        max_error_rate=1,
+        pauli_bias=(0, 1, 0),
+        with_lookup=True,
+        max_weight=0,
+        add_erasure_bit=True,
     )
     assert logical_error_rate_func(0, discard_rate=True) == (0, 0)  # no errors at p=0
-    assert logical_error_rate_func(1, discard_rate=True)[0] > 0  # all syndromes → erasure
+    assert logical_error_rate_func(1, discard_rate=True)[0] > 0  # X syndromes → erasure

--- a/src/qldpc/codes/common_test.py
+++ b/src/qldpc/codes/common_test.py
@@ -229,11 +229,12 @@ def test_classical_capacity() -> None:
     assert logical_error_rate_func(0) == (0, 0)  # no logical error with zero uncertainty
     assert logical_error_rate_func([1])[0] == 1  # guaranteed logical error
 
-    # compute discard rates
+    # with an erasure-enabled decoder, unrecognised syndromes are discarded
     logical_error_rate_func = code.get_logical_error_rate_func(
-        num_samples=4, max_error_rate=0.5, with_lookup=True, max_weight=0
+        num_samples=4, max_error_rate=0.5, with_lookup=True, max_weight=0, add_erasure_bit=True
     )
-    assert logical_error_rate_func(0, discard_rate=True) == (0, 0)
+    assert logical_error_rate_func(0, discard_rate=True) == (0, 0)  # no errors at p=0
+    assert logical_error_rate_func(0.5, discard_rate=True)[0] > 0  # nonzero syndromes → erasure
 
     # test cap on physical error rate
     logical_error_rate_func = code.get_logical_error_rate_func(num_samples=1, max_error_rate=0.5)
@@ -536,11 +537,12 @@ def test_quantum_capacity() -> None:
         logical_error_rate_func = code.get_logical_error_rate_func(10, 1, pauli_bias)
         assert logical_error_rate_func(1)[0] == 1
 
-    # compute discard rates (trivial deterministic example)
+    # with an erasure-enabled decoder, unrecognised syndromes are discarded
     logical_error_rate_func = code.get_logical_error_rate_func(
-        num_samples=1, max_error_rate=1, with_lookup=True, max_weight=1
+        num_samples=1, max_error_rate=1, with_lookup=True, max_weight=0, add_erasure_bit=True
     )
-    assert logical_error_rate_func(0, discard_rate=True) == (0, 0)
+    assert logical_error_rate_func(0, discard_rate=True) == (0, 0)  # no errors at p=0
+    assert logical_error_rate_func(1, discard_rate=True)[0] > 0  # all syndromes → erasure
 
 
 def test_qudit_to_css() -> None:
@@ -743,8 +745,9 @@ def test_css_capacity() -> None:
         logical_error_rate_func = code.get_logical_error_rate_func(10, 1, pauli_bias)
         assert logical_error_rate_func(1)[0] == 1
 
-    # compute discard rates (trivial deterministic example)
+    # with an erasure-enabled decoder, unrecognised syndromes are discarded
     logical_error_rate_func = code.get_logical_error_rate_func(
-        num_samples=1, max_error_rate=1, with_lookup=True, max_weight=1
+        num_samples=1, max_error_rate=1, with_lookup=True, max_weight=0, add_erasure_bit=True
     )
-    assert logical_error_rate_func(0, discard_rate=True) == (0, 0)
+    assert logical_error_rate_func(0, discard_rate=True) == (0, 0)  # no errors at p=0
+    assert logical_error_rate_func(1, discard_rate=True)[0] > 0  # all syndromes → erasure

--- a/src/qldpc/codes/common_test.py
+++ b/src/qldpc/codes/common_test.py
@@ -745,15 +745,29 @@ def test_css_capacity() -> None:
         logical_error_rate_func = code.get_logical_error_rate_func(10, 1, pauli_bias)
         assert logical_error_rate_func(1)[0] == 1
 
-    # with pure-X errors, Z syndromes are always zero (no Z erasure) so samples reach the X
-    # decoder; at p=0.9 the dominant weight-6 errors have nonzero X syndromes, triggering erasure
-    logical_error_rate_func = code.get_logical_error_rate_func(
+    # pauli_bias convention is (X, Y, Z); (0,0,1) = pure Z: Z syndromes are always nonzero so
+    # the Z erasure path fires deterministically for any nonzero weight
+    logical_error_rate_func_z = code.get_logical_error_rate_func(
         num_samples=1,
         max_error_rate=1,
-        pauli_bias=(0, 1, 0),
+        pauli_bias=(0, 0, 1),
         with_lookup=True,
         max_weight=0,
         add_erasure_bit=True,
     )
-    assert logical_error_rate_func(0, discard_rate=True) == (0, 0)  # no errors at p=0
-    assert logical_error_rate_func(0.9, discard_rate=True)[0] > 0  # X syndromes → erasure
+    assert logical_error_rate_func_z(0, discard_rate=True) == (0, 0)  # no errors at p=0
+    assert logical_error_rate_func_z(0.9, discard_rate=True)[0] > 0  # Z syndromes → erasure
+
+    # (1,0,0) = pure X: Z syndromes are always zero so samples reach the X decoder; weight-6
+    # X errors have syndrome = the missing qubit's column in matrix_z (always nonzero), triggering
+    # X erasure deterministically
+    logical_error_rate_func_x = code.get_logical_error_rate_func(
+        num_samples=1,
+        max_error_rate=1,
+        pauli_bias=(1, 0, 0),
+        with_lookup=True,
+        max_weight=0,
+        add_erasure_bit=True,
+    )
+    assert logical_error_rate_func_x(0, discard_rate=True) == (0, 0)  # no errors at p=0
+    assert logical_error_rate_func_x(0.9, discard_rate=True)[0] > 0  # X syndromes → erasure

--- a/src/qldpc/codes/common_test.py
+++ b/src/qldpc/codes/common_test.py
@@ -745,8 +745,8 @@ def test_css_capacity() -> None:
         logical_error_rate_func = code.get_logical_error_rate_func(10, 1, pauli_bias)
         assert logical_error_rate_func(1)[0] == 1
 
-    # pauli_bias convention is (X, Y, Z); (0,0,1) = pure Z: Z syndromes are always nonzero so
-    # the Z erasure path fires deterministically for any nonzero weight
+    # pauli_bias convention is (X, Y, Z); (0, 0, 1) = pure Z
+    # if the max_weight for lookup is 0, any Z syndrome triggers erasure
     logical_error_rate_func_z = code.get_logical_error_rate_func(
         num_samples=1,
         max_error_rate=1,
@@ -756,11 +756,9 @@ def test_css_capacity() -> None:
         add_erasure_bit=True,
     )
     assert logical_error_rate_func_z(0, discard_rate=True) == (0, 0)  # no errors at p=0
-    assert logical_error_rate_func_z(0.9, discard_rate=True)[0] > 0  # Z syndromes → erasure
+    assert logical_error_rate_func_z(0.5, discard_rate=True)[0] > 0  # Z syndromes → erasure
 
-    # (1,0,0) = pure X: Z syndromes are always zero so samples reach the X decoder; weight-6
-    # X errors have syndrome = the missing qubit's column in matrix_z (always nonzero), triggering
-    # X erasure deterministically
+    # (1 ,0, 0) = pure X: Z syndromes are always zero so samples reach the X decoder
     logical_error_rate_func_x = code.get_logical_error_rate_func(
         num_samples=1,
         max_error_rate=1,
@@ -770,4 +768,4 @@ def test_css_capacity() -> None:
         add_erasure_bit=True,
     )
     assert logical_error_rate_func_x(0, discard_rate=True) == (0, 0)  # no errors at p=0
-    assert logical_error_rate_func_x(0.9, discard_rate=True)[0] > 0  # X syndromes → erasure
+    assert logical_error_rate_func_x(0.5, discard_rate=True)[0] > 0  # X syndromes → erasure

--- a/src/qldpc/codes/common_test.py
+++ b/src/qldpc/codes/common_test.py
@@ -231,13 +231,12 @@ def test_classical_capacity() -> None:
 
     # compute discard rates
     logical_error_rate_func = code.get_logical_error_rate_func(
-        num_samples=4, max_error_rate=0.5, with_lookup=True, max_weight=1
+        num_samples=4, max_error_rate=0.5, with_lookup=True, max_weight=0
     )
     assert logical_error_rate_func(0, discard_rate=True) == (0, 0)
-    assert logical_error_rate_func(0.5, discard_rate=True) == (0.5, 0)
 
     # test cap on physical error rate
-    logical_error_rate_func = code.get_logical_error_rate_func(num_samples=10, max_error_rate=0.5)
+    logical_error_rate_func = code.get_logical_error_rate_func(num_samples=1, max_error_rate=0.5)
     with pytest.raises(ValueError, match="error rates greater than"):
         logical_error_rate_func(1)
 

--- a/src/qldpc/codes/common_test.py
+++ b/src/qldpc/codes/common_test.py
@@ -231,7 +231,7 @@ def test_classical_capacity() -> None:
 
     # compute discard rates
     logical_error_rate_func = code.get_logical_error_rate_func(
-        num_samples=4, max_error_rate=0.5, discard_weight=1
+        num_samples=4, max_error_rate=0.5, with_lookup=True, max_weight=1
     )
     assert logical_error_rate_func(0, discard_rate=True) == (0, 0)
     assert logical_error_rate_func(0.5, discard_rate=True) == (0.5, 0)
@@ -539,7 +539,7 @@ def test_quantum_capacity() -> None:
 
     # compute discard rates (trivial deterministic example)
     logical_error_rate_func = code.get_logical_error_rate_func(
-        num_samples=1, max_error_rate=1, discard_weight=1
+        num_samples=1, max_error_rate=1, with_lookup=True, max_weight=1
     )
     assert logical_error_rate_func(0, discard_rate=True) == (0, 0)
 
@@ -746,6 +746,6 @@ def test_css_capacity() -> None:
 
     # compute discard rates (trivial deterministic example)
     logical_error_rate_func = code.get_logical_error_rate_func(
-        num_samples=1, max_error_rate=1, discard_weight=1
+        num_samples=1, max_error_rate=1, with_lookup=True, max_weight=1
     )
     assert logical_error_rate_func(0, discard_rate=True) == (0, 0)

--- a/src/qldpc/decoders/custom.py
+++ b/src/qldpc/decoders/custom.py
@@ -220,18 +220,22 @@ class LookupDecoder(Decoder):
     decreasing weight.  For each error ee, it computes the corresponding syndrome ss, and assigns
     syndrome ss the "correction" ee, overriding any previously assigned correction if present.
 
-    If provided a penalty_func that maps an error to a real number (i.e., a penalty), the decoder
-    only assigns correction ee to syndrome ss if (a) ss has no assigned correction, or (b) the
-    penalty of ee is <= the penalty of the correction currently assigned to ss.
+    If initialized with symplectic=True, this decoder treats the provided parity check matrix as that
+    of a QuditCode, with the first and last half of the columns denoting, respectively, the X and Z
+    support of a stabilizer.  Decoded errors are likewise vectors that indicate their X and Z
+    support by the first and second half of their entries.
+
+    If initialized with add_erasure_bit=True, this decoder appends a bit to all decoded errors.  If
+    asked to decode a syndrome that was not observed when constructing the lookup table, the erasure
+    bit is set to 1.  The erasure bit is set to 0 otherwise.
 
     If provided an error_channel of independent probabilities for each "error mechanism" (associated
     with one column of the parity check matrix), construct a penalty_func that penalizes unlikely
     errors.
 
-    If initialized with symplectic=True, this decoder treats the provided parity check matrix as that
-    of a QuditCode, with the first and last half of the columns denoting, respectively, the X and Z
-    support of a stabilizer.  Decoded errors are likewise vectors that indicate their X and Z
-    support by the first and second half of their entries.
+    If provided a penalty_func that maps an error to a real number (i.e., a penalty), the decoder
+    only assigns correction ee to syndrome ss if (a) ss has no assigned correction, or (b) the
+    penalty of ee is <= the penalty of the correction currently assigned to ss.
     """
 
     def __init__(

--- a/src/qldpc/decoders/custom.py
+++ b/src/qldpc/decoders/custom.py
@@ -240,6 +240,7 @@ class LookupDecoder(Decoder):
         max_weight: int,
         *,
         symplectic: bool = False,
+        add_erasure_bit: bool = False,
         error_channel: npt.NDArray[np.floating] | Sequence[float] | None = None,
         penalty_func: Callable[[npt.NDArray[np.int_] | Sequence[int]], float] | None = None,
     ) -> None:
@@ -259,6 +260,9 @@ class LookupDecoder(Decoder):
                 "Cannot specify both an error_channel and a penalty_func"
             )
 
+        def _maybe_add_erasure_bit(error: npt.NDArray[np.int_]) -> npt.NDArray[np.int_]:
+            return np.hstack([error, [0]]) if add_erasure_bit else error
+
         penalty_func = penalty_func or (
             self.build_penalty_func(error_channel) if error_channel is not None else None
         )
@@ -269,10 +273,15 @@ class LookupDecoder(Decoder):
         error_weights: dict[tuple[int, ...], float] = {}
         for error, syndrome in LookupDecoder.iter_errors_and_syndromes(pcm, max_weight, symplectic):
             if penalty_func is None:
-                self.syndrome_to_correction[syndrome] = error
+                self.syndrome_to_correction[syndrome] = _maybe_add_erasure_bit(error)
             elif (error_weight := penalty_func(error)) <= error_weights.get(syndrome, np.inf):
                 error_weights[syndrome] = error_weight
-                self.syndrome_to_correction[syndrome] = error
+                self.syndrome_to_correction[syndrome] = _maybe_add_erasure_bit(error)
+
+        self.has_erasure_bit = add_erasure_bit
+        self.default_correction = np.zeros(self.shape[1], dtype=int)
+        if add_erasure_bit:
+            self.default_correction = np.hstack([self.default_correction, [1]])
 
     @staticmethod
     def iter_errors_and_syndromes(
@@ -303,7 +312,7 @@ class LookupDecoder(Decoder):
     def decode(self, syndrome: npt.NDArray[np.int_]) -> npt.NDArray[np.int_]:
         """Decode an error syndrome and return an inferred error."""
         return self.syndrome_to_correction.get(
-            tuple(syndrome.view(np.ndarray)), np.zeros(self.shape[1], dtype=int)
+            tuple(syndrome.view(np.ndarray)), self.default_correction
         ).copy()
 
     @staticmethod
@@ -339,6 +348,7 @@ class WeightedLookupDecoder(LookupDecoder):
         max_weight: int,
         *,
         symplectic: bool = False,
+        add_erasure_bit: bool = False,
     ) -> None:
         pcm = (
             DetectorErrorModelArrays(pcm_or_dem).detector_flip_matrix
@@ -346,12 +356,20 @@ class WeightedLookupDecoder(LookupDecoder):
             else pcm_or_dem
         )
 
+        def _maybe_add_erasure_bit(error: npt.NDArray[np.int_]) -> npt.NDArray[np.int_]:
+            return np.hstack([error, [0]]) if add_erasure_bit else error
+
         self.shape: tuple[int, ...] = pcm.shape
         self.syndrome_to_candidates: dict[tuple[int, ...], list[npt.NDArray[np.int_]]] = (
             collections.defaultdict(list)
         )
         for error, syndrome in LookupDecoder.iter_errors_and_syndromes(pcm, max_weight, symplectic):
-            self.syndrome_to_candidates[syndrome].append(error)
+            self.syndrome_to_candidates[syndrome].append(_maybe_add_erasure_bit(error))
+
+        self.has_erasure_bit = add_erasure_bit
+        self.default_correction = np.zeros(self.shape[1], dtype=int)
+        if add_erasure_bit:
+            self.default_correction = np.hstack([self.default_correction, [1]])
 
     def decode(
         self,
@@ -362,7 +380,7 @@ class WeightedLookupDecoder(LookupDecoder):
     ) -> npt.NDArray[np.int_]:
         """Decode an error syndrome and return an inferred error."""
         errors = self.syndrome_to_candidates.get(
-            tuple(syndrome.view(np.ndarray)), [np.zeros(self.shape[1], dtype=int)]
+            tuple(syndrome.view(np.ndarray)), [self.default_correction]
         )
         return (min(errors, key=penalty_func) if penalty_func is not None else errors[-1]).copy()
 

--- a/src/qldpc/decoders/custom_test.py
+++ b/src/qldpc/decoders/custom_test.py
@@ -177,15 +177,22 @@ def test_quantum_decoding(pytestconfig: pytest.Config) -> None:
     decoder = decoders.LookupDecoder(
         code.matrix,
         symplectic=True,
+        add_erasure_bit=True,
         max_weight=2,
         penalty_func=lambda vec: int(np.count_nonzero(vec)),
     )
     decoded_error = decoder.decode(syndrome).view(code.field)
-    assert np.array_equal(syndrome, code.matrix @ math.symplectic_conjugate(decoded_error))
+    assert decoded_error[-1] == 0
+    assert np.array_equal(syndrome, code.matrix @ math.symplectic_conjugate(decoded_error[:-1]))
+    assert decoder.decode(np.ones_like(syndrome))[-1] == 1
 
-    decoder = decoders.WeightedLookupDecoder(code.matrix, symplectic=True, max_weight=2)
+    decoder = decoders.WeightedLookupDecoder(
+        code.matrix, symplectic=True, add_erasure_bit=True, max_weight=2
+    )
     decoded_error = decoder.decode(syndrome).view(code.field)
-    assert np.array_equal(syndrome, code.matrix @ math.symplectic_conjugate(decoded_error))
+    assert decoded_error[-1] == 0
+    assert np.array_equal(syndrome, code.matrix @ math.symplectic_conjugate(decoded_error[:-1]))
+    assert decoder.decode(np.ones_like(syndrome))[-1] == 1
 
 
 def test_penalty_func() -> None:

--- a/src/qldpc/decoders/dems.py
+++ b/src/qldpc/decoders/dems.py
@@ -230,22 +230,17 @@ class DetectorErrorModelArrays:
         but flips one newly added observable.  The erasure bit thereby allows decoders to indicate
         erasure by flipping the erasure bit.
         """
-        detector_flip_matrix = scipy.sparse.hstack(
-            [self.detector_flip_matrix, scipy.sparse.csc_matrix((self.num_detectors, bits))],
-            format="csc",
-        )
+        detector_flip_blocks = [
+            self.detector_flip_matrix,
+            scipy.sparse.csc_matrix((self.num_detectors, bits)),
+        ]
+        detector_flip_matrix = scipy.sparse.bmat(detector_flip_blocks, format="csc")
 
-        observable_flip_matrix = self.observable_flip_matrix
-        observable_flip_matrix = scipy.sparse.hstack(
-            [observable_flip_matrix, scipy.sparse.csc_matrix((self.num_observables, bits))],
-            format="csc",
-        )
-        observable_flip_matrix = scipy.sparse.vstack(
-            [observable_flip_matrix, scipy.sparse.csc_matrix((bits, self.num_errors + bits))],
-            format="csc",
-        )
-        for bit_index in range(-1, -bits - 1, -1):
-            observable_flip_matrix[bit_index, bit_index] = 1
+        observable_flip_blocks = [
+            [self.observable_flip_matrix, None],
+            [None, scipy.sparse.eye(bits, dtype=int, format="csc")],
+        ]
+        observable_flip_matrix = scipy.sparse.bmat(observable_flip_blocks, format="csc")
 
         detector_flip_matrix.eliminate_zeros()
         observable_flip_matrix.eliminate_zeros()

--- a/src/qldpc/decoders/dems.py
+++ b/src/qldpc/decoders/dems.py
@@ -230,11 +230,11 @@ class DetectorErrorModelArrays:
         but flips one newly added observable.  The erasure bit thereby allows decoders to indicate
         erasure by flipping the erasure bit.
         """
-        detector_flip_blocks = [
+        detector_flip_stack = [
             self.detector_flip_matrix,
             scipy.sparse.csc_matrix((self.num_detectors, bits)),
         ]
-        detector_flip_matrix = scipy.sparse.bmat(detector_flip_blocks, format="csc")
+        detector_flip_matrix = scipy.sparse.hstack(detector_flip_stack, format="csc")
 
         observable_flip_blocks = [
             [self.observable_flip_matrix, None],

--- a/src/qldpc/decoders/dems.py
+++ b/src/qldpc/decoders/dems.py
@@ -231,17 +231,17 @@ class DetectorErrorModelArrays:
         erasure by flipping the erasure bit.
         """
         detector_flip_matrix = scipy.sparse.hstack(
-            [self.detector_flip_matrix, scipy.sparce.csc_matrix((self.num_detectors, bits))],
+            [self.detector_flip_matrix, scipy.sparse.csc_matrix((self.num_detectors, bits))],
             format="csc",
         )
 
         observable_flip_matrix = self.observable_flip_matrix
         observable_flip_matrix = scipy.sparse.hstack(
-            [observable_flip_matrix, scipy.sparce.csc_matrix((self.num_observables, bits))],
+            [observable_flip_matrix, scipy.sparse.csc_matrix((self.num_observables, bits))],
             format="csc",
         )
         observable_flip_matrix = scipy.sparse.vstack(
-            [observable_flip_matrix, scipy.sparce.csc_matrix((bits, self.num_errors + bits))],
+            [observable_flip_matrix, scipy.sparse.csc_matrix((bits, self.num_errors + bits))],
             format="csc",
         )
         for bit_index in range(-1, -bits - 1, -1):

--- a/src/qldpc/decoders/dems.py
+++ b/src/qldpc/decoders/dems.py
@@ -242,8 +242,6 @@ class DetectorErrorModelArrays:
         ]
         observable_flip_matrix = scipy.sparse.bmat(observable_flip_blocks, format="csc")
 
-        detector_flip_matrix.eliminate_zeros()
-        observable_flip_matrix.eliminate_zeros()
         return DetectorErrorModelArrays.from_arrays(
             detector_flip_matrix,
             observable_flip_matrix,

--- a/src/qldpc/decoders/dems.py
+++ b/src/qldpc/decoders/dems.py
@@ -223,6 +223,38 @@ class DetectorErrorModelArrays:
             self.error_probs[errors_to_keep],
         )
 
+    def with_erasure_bit(self, num: int = 1) -> DetectorErrorModelArrays:
+        """Construct the DetectorErrorModelArrays obtained by adding erasure bits to the DEM.
+
+        Each erasure bit is essentially a zero-probability error mechanism that flips no detectors,
+        but flips one newly added observable.  The erasure bit thereby allows decoders to indicate
+        erasure by flipping the erasure bit.
+        """
+        detector_flip_matrix = scipy.sparse.hstack(
+            [self.detector_flip_matrix, scipy.sparce.csc_matrix((self.num_detectors, num))],
+            format="csc",
+        )
+
+        observable_flip_matrix = self.observable_flip_matrix
+        observable_flip_matrix = scipy.sparse.hstack(
+            [observable_flip_matrix, scipy.sparce.csc_matrix((self.num_observables, num))],
+            format="csc",
+        )
+        observable_flip_matrix = scipy.sparse.vstack(
+            [observable_flip_matrix, scipy.sparce.csc_matrix((num, self.num_errors + num))],
+            format="csc",
+        )
+        for bit_index in range(-1, -num - 1, -1):
+            observable_flip_matrix[bit_index, bit_index] = 1
+
+        detector_flip_matrix.eliminate_zeros()
+        observable_flip_matrix.eliminate_zeros()
+        return DetectorErrorModelArrays.from_arrays(
+            detector_flip_matrix,
+            observable_flip_matrix,
+            np.hstack([self.error_probs, [0] * num]),
+        )
+
 
 def _values_that_occur_an_odd_number_of_times(items: Collection[int]) -> frozenset[int]:
     """Subset of items that occur an odd number of times."""

--- a/src/qldpc/decoders/dems.py
+++ b/src/qldpc/decoders/dems.py
@@ -223,7 +223,7 @@ class DetectorErrorModelArrays:
             self.error_probs[errors_to_keep],
         )
 
-    def with_erasure_bit(self, num: int = 1) -> DetectorErrorModelArrays:
+    def with_erasure(self, bits: int = 1) -> DetectorErrorModelArrays:
         """Construct the DetectorErrorModelArrays obtained by adding erasure bits to the DEM.
 
         Each erasure bit is essentially a zero-probability error mechanism that flips no detectors,
@@ -231,20 +231,20 @@ class DetectorErrorModelArrays:
         erasure by flipping the erasure bit.
         """
         detector_flip_matrix = scipy.sparse.hstack(
-            [self.detector_flip_matrix, scipy.sparce.csc_matrix((self.num_detectors, num))],
+            [self.detector_flip_matrix, scipy.sparce.csc_matrix((self.num_detectors, bits))],
             format="csc",
         )
 
         observable_flip_matrix = self.observable_flip_matrix
         observable_flip_matrix = scipy.sparse.hstack(
-            [observable_flip_matrix, scipy.sparce.csc_matrix((self.num_observables, num))],
+            [observable_flip_matrix, scipy.sparce.csc_matrix((self.num_observables, bits))],
             format="csc",
         )
         observable_flip_matrix = scipy.sparse.vstack(
-            [observable_flip_matrix, scipy.sparce.csc_matrix((num, self.num_errors + num))],
+            [observable_flip_matrix, scipy.sparce.csc_matrix((bits, self.num_errors + bits))],
             format="csc",
         )
-        for bit_index in range(-1, -num - 1, -1):
+        for bit_index in range(-1, -bits - 1, -1):
             observable_flip_matrix[bit_index, bit_index] = 1
 
         detector_flip_matrix.eliminate_zeros()
@@ -252,7 +252,7 @@ class DetectorErrorModelArrays:
         return DetectorErrorModelArrays.from_arrays(
             detector_flip_matrix,
             observable_flip_matrix,
-            np.hstack([self.error_probs, [0] * num]),
+            np.hstack([self.error_probs, [0] * bits]),
         )
 
 

--- a/src/qldpc/decoders/dems_test.py
+++ b/src/qldpc/decoders/dems_test.py
@@ -113,6 +113,51 @@ def test_simplify() -> None:
     assert simplified_dem == dem_arrays.simplified().to_detector_error_model()
 
 
+def test_with_erasure() -> None:
+    """Add erasure bits to a DetectorErrorModelArrays."""
+    dem = stim.DetectorErrorModel("""
+        error(0.1) D0
+        error(0.2) D1 L0
+    """)
+    dem_arrays = decoders.DetectorErrorModelArrays(dem)
+    erasure_arrays = dem_arrays.with_erasure()
+
+    # one new error mechanism and one new observable; detectors unchanged
+    assert erasure_arrays.num_errors == dem_arrays.num_errors + 1
+    assert erasure_arrays.num_observables == dem_arrays.num_observables + 1
+    assert erasure_arrays.num_detectors == dem_arrays.num_detectors
+
+    # erasure mechanism flips no detectors and has zero probability
+    assert erasure_arrays.detector_flip_matrix[:, -1].nnz == 0
+    assert erasure_arrays.error_probs[-1] == 0
+
+    # erasure mechanism flips only the new erasure observable, not the original ones
+    assert erasure_arrays.observable_flip_matrix[:-1, -1].nnz == 0
+    assert erasure_arrays.observable_flip_matrix[-1, -1] == 1
+
+    # original errors do not flip the new erasure observable
+    assert erasure_arrays.observable_flip_matrix[-1, :-1].nnz == 0
+
+    # original detector/observable matrices and error probs are preserved
+    assert np.array_equal(
+        erasure_arrays.detector_flip_matrix[:, :-1].todense(),
+        dem_arrays.detector_flip_matrix.todense(),
+    )
+    assert np.array_equal(
+        erasure_arrays.observable_flip_matrix[:-1, :-1].todense(),
+        dem_arrays.observable_flip_matrix.todense(),
+    )
+    assert np.array_equal(erasure_arrays.error_probs[:-1], dem_arrays.error_probs)
+
+    # with bits=2, the bottom-right block of observable_flip_matrix is a 2×2 identity
+    erasure_arrays_2 = dem_arrays.with_erasure(bits=2)
+    assert erasure_arrays_2.num_errors == dem_arrays.num_errors + 2
+    assert erasure_arrays_2.num_observables == dem_arrays.num_observables + 2
+    assert np.array_equal(
+        erasure_arrays_2.observable_flip_matrix[-2:, -2:].todense(), np.eye(2, dtype=int)
+    )
+
+
 def test_post_selection() -> None:
     """Post select on some detectors."""
     dem = stim.DetectorErrorModel("""

--- a/src/qldpc/decoders/sinter.py
+++ b/src/qldpc/decoders/sinter.py
@@ -313,7 +313,7 @@ class SubgraphDecoder(SinterDecoder):
         """
         dem_arrays = DetectorErrorModelArrays(dem, simplify=simplify)
         subgraph_observables = (
-            [list(range(dem.num_observables))] * self.num_subgraphs
+            [list(range(dem.num_observables)) for _ in range(self.num_subgraphs)]
             if self.subgraph_observables is None
             else self.subgraph_observables
         )

--- a/src/qldpc/decoders/sinter.py
+++ b/src/qldpc/decoders/sinter.py
@@ -315,7 +315,7 @@ class SubgraphDecoder(SinterDecoder):
         subgraph_observables = (
             [list(range(dem.num_observables)) for _ in range(self.num_subgraphs)]
             if self.subgraph_observables is None
-            else self.subgraph_observables
+            else [list(obs) for obs in self.subgraph_observables]
         )
         num_observables = dem.num_observables
 

--- a/src/qldpc/decoders/sinter.py
+++ b/src/qldpc/decoders/sinter.py
@@ -508,7 +508,7 @@ class SequentialWindowDecoder(SinterDecoder):
             window_decoder = self.get_configured_decoder(window_dem_arrays)
             if getattr(window_decoder, "has_erasure_bit", False):
                 raise NotImplementedError(
-                    f"{type(self)} does not yet suport erasure decoding.\nIf you would like to see "
+                    f"{type(self)} does not yet support erasure decoding.\nIf you would like to see "
                     "this feature, please file an issue at https://github.com/qLDPCOrg/qLDPC/issues"
                 )
 

--- a/src/qldpc/decoders/sinter.py
+++ b/src/qldpc/decoders/sinter.py
@@ -90,7 +90,7 @@ class SinterDecoder(Decoder, sinter.Decoder):
         dem_arrays = DetectorErrorModelArrays(dem, simplify=simplify)
         decoder = self.get_configured_decoder(dem_arrays)
         if getattr(decoder, "has_erasure_bit", False):
-            dem_arrays = dem_arrays.with_erasure_bit()
+            dem_arrays = dem_arrays.with_erasure()
         return CompiledSinterDecoder(dem_arrays, decoder)
 
     def get_configured_decoder(self, dem_arrays: DetectorErrorModelArrays) -> Decoder:

--- a/src/qldpc/decoders/sinter.py
+++ b/src/qldpc/decoders/sinter.py
@@ -338,9 +338,9 @@ class SubgraphDecoder(SinterDecoder):
             subgraph_decoder = SinterDecoder.compile_decoder_for_dem(self, subgraph_dem)
             subgraph_decoders.append(subgraph_decoder)
 
-        if getattr(subgraph_decoder.decoder, "has_erasure_bit", False):
-            subgraph_observables[ss].append(num_observables)
-            num_observables += 1
+            if getattr(subgraph_decoder.decoder, "has_erasure_bit", False):
+                subgraph_observables[ss].append(num_observables)
+                num_observables += 1
 
         return CompiledSubgraphDecoder(
             self.subgraph_detectors,

--- a/src/qldpc/decoders/sinter.py
+++ b/src/qldpc/decoders/sinter.py
@@ -86,6 +86,7 @@ class SinterDecoder(Decoder, sinter.Decoder):
         """Creates a decoder preconfigured for the given detector error model.
 
         See help(sinter.Decoder) for additional information.
+        # add erasure bits, if necessary
         """
         dem_arrays = DetectorErrorModelArrays(dem, simplify=simplify)
         decoder = self.get_configured_decoder(dem_arrays)
@@ -292,9 +293,9 @@ class SubgraphDecoder(SinterDecoder):
                 f" number of observable sets ({num_observable_sets})"
             )
 
-        self.subgraph_detectors = list(map(list, subgraph_detectors))
+        self.subgraph_detectors = [sorted(dets) for dets in subgraph_detectors]
         self.subgraph_observables = (
-            None if subgraph_observables is None else list(map(list, subgraph_observables))
+            None if subgraph_observables is None else [sorted(obs) for obs in subgraph_observables]
         )
 
         SinterDecoder.__init__(
@@ -313,14 +314,17 @@ class SubgraphDecoder(SinterDecoder):
         """
         dem_arrays = DetectorErrorModelArrays(dem, simplify=simplify)
         subgraph_observables = (
-            [slice(None)] * self.num_subgraphs
+            [list(range(dem.num_observables))] * self.num_subgraphs
             if self.subgraph_observables is None
             else self.subgraph_observables
         )
+        num_observables = dem.num_observables
 
         # build a decoder for each subgraph
         subgraph_decoders = []
-        for detectors, observables in zip(self.subgraph_detectors, subgraph_observables):
+        for ss, (detectors, observables) in enumerate(
+            zip(self.subgraph_detectors, subgraph_observables)
+        ):
             # identify the error mechanisms that flip these detectors
             errors = dem_arrays.detector_flip_matrix[detectors].getnnz(axis=0) != 0
 
@@ -335,12 +339,16 @@ class SubgraphDecoder(SinterDecoder):
             subgraph_decoder = SinterDecoder.compile_decoder_for_dem(self, subgraph_dem)
             subgraph_decoders.append(subgraph_decoder)
 
+        if getattr(subgraph_decoder.decoder, "has_erasure_bit", False):
+            subgraph_observables[ss].append(num_observables)
+            num_observables += 1
+
         return CompiledSubgraphDecoder(
             self.subgraph_detectors,
             subgraph_observables,
             subgraph_decoders,
             dem.num_detectors,
-            dem.num_observables,
+            num_observables,
         )
 
 
@@ -512,6 +520,13 @@ class SequentialWindowDecoder(SinterDecoder):
 
             # update the history of errors that are addressed by preceding windows
             addressed_errors |= c_errors
+
+        # add erasure bits, if necessary
+        num_erasure_bits = sum(
+            getattr(decoder, "has_erasure_bit", False) for decoder in window_decoders
+        )
+        if num_erasure_bits:
+            dem_arrays = dem_arrays.with_erasure_bit(num_erasure_bits)
 
         return CompiledSequentialWindowDecoder(
             dem_arrays, window_detectors, window_errors, window_decoders

--- a/src/qldpc/decoders/sinter.py
+++ b/src/qldpc/decoders/sinter.py
@@ -86,7 +86,6 @@ class SinterDecoder(Decoder, sinter.Decoder):
         """Creates a decoder preconfigured for the given detector error model.
 
         See help(sinter.Decoder) for additional information.
-        # add erasure bits, if necessary
         """
         dem_arrays = DetectorErrorModelArrays(dem, simplify=simplify)
         decoder = self.get_configured_decoder(dem_arrays)
@@ -525,13 +524,6 @@ class SequentialWindowDecoder(SinterDecoder):
 
             # update the history of errors that are addressed by preceding windows
             addressed_errors |= c_errors
-
-        # add erasure bits, if necessary
-        num_erasure_bits = sum(
-            getattr(decoder, "has_erasure_bit", False) for decoder in window_decoders
-        )
-        if num_erasure_bits:
-            dem_arrays = dem_arrays.with_erasure_bit(num_erasure_bits)
 
         return CompiledSequentialWindowDecoder(
             dem_arrays, window_detectors, window_errors, window_decoders

--- a/src/qldpc/decoders/sinter.py
+++ b/src/qldpc/decoders/sinter.py
@@ -507,6 +507,11 @@ class SequentialWindowDecoder(SinterDecoder):
                 dem_arrays.error_probs[d_errors],
             )
             window_decoder = self.get_configured_decoder(window_dem_arrays)
+            if getattr(window_decoder, "has_erasure_bit", False):
+                raise NotImplementedError(
+                    f"{type(self)} does not yet suport erasure decoding.\nIf you would like to see "
+                    "this feature, please file an issue at https://github.com/qLDPCOrg/qLDPC/issues"
+                )
 
             # identify errors in the commit region
             c_errors = dem_arrays.detector_flip_matrix[c_detectors].getnnz(axis=0) != 0
@@ -607,11 +612,12 @@ class CompiledSequentialWindowDecoder(CompiledSinterDecoder):
             ) % 2
 
             # decode this syndrome and update the net error appropriately
-            net_error[:, errors] = (
+            decoded_error = (
                 decoder.decode_batch(syndromes)
                 if hasattr(decoder, "decode_batch")
                 else np.array([decoder.decode(syndrome) for syndrome in syndromes])
-            )[:, error_locs]
+            )
+            net_error[:, errors] = decoded_error[:, error_locs]
 
         return net_error
 

--- a/src/qldpc/decoders/sinter.py
+++ b/src/qldpc/decoders/sinter.py
@@ -89,6 +89,8 @@ class SinterDecoder(Decoder, sinter.Decoder):
         """
         dem_arrays = DetectorErrorModelArrays(dem, simplify=simplify)
         decoder = self.get_configured_decoder(dem_arrays)
+        if getattr(decoder, "has_erasure_bit", False):
+            dem_arrays = dem_arrays.with_erasure_bit()
         return CompiledSinterDecoder(dem_arrays, decoder)
 
     def get_configured_decoder(self, dem_arrays: DetectorErrorModelArrays) -> Decoder:

--- a/src/qldpc/decoders/sinter_test.py
+++ b/src/qldpc/decoders/sinter_test.py
@@ -98,6 +98,75 @@ def test_subgraph_decoding() -> None:
         decoders.SubgraphDecoder([[0], [1], [2]], [[0]])
 
 
+def test_sinter_decoder_with_erasure() -> None:
+    """compile_decoder_for_dem expands the DEM with an erasure observable when has_erasure_bit."""
+    dem = stim.DetectorErrorModel("""
+        error(0.1) D0
+        error(0.1) D1 L0
+    """)
+    decoder = decoders.SinterDecoder(with_lookup=True, max_weight=1, add_erasure_bit=True)
+    compiled = decoder.compile_decoder_for_dem(dem)
+
+    # one extra observable for the erasure bit
+    assert compiled.dem_arrays.num_observables == dem.num_observables + 1
+
+    # known syndromes: correct observables, erasure bit = 0
+    shots = np.array([[1, 0], [0, 1]], dtype=np.uint8)
+    result = compiled.decode_shots(shots)
+    assert result.shape == (2, dem.num_observables + 1)
+    assert np.array_equal(result[:, :-1], [[0], [1]])  # L0: not flipped by D0, flipped by D1
+    assert np.all(result[:, -1] == 0)
+
+    # unknown syndrome (no weight-1 error explains both D0 and D1): erasure bit = 1
+    assert compiled.decode_shots(np.array([[1, 1]], dtype=np.uint8))[0, -1] == 1
+
+
+def test_subgraph_decoder_with_erasure() -> None:
+    """SubgraphDecoder appends one erasure observable per subgraph that has_erasure_bit."""
+    # error 0 flips both D0 and D1 (so D0-alone is an unknown syndrome for subgraph 0)
+    dem = stim.DetectorErrorModel("""
+        error(0.1) D0 D1 L0
+        error(0.1) D2 L1
+    """)
+    decoder = decoders.SubgraphDecoder(
+        [[0, 1], [2]], with_lookup=True, max_weight=1, add_erasure_bit=True
+    )
+    compiled = decoder.compile_decoder_for_dem(dem)
+
+    # two original observables plus one erasure observable per subgraph
+    assert compiled.num_observables == dem.num_observables + 2
+
+    # known syndromes: correct logical observables, both erasure bits = 0
+    shots = np.array([[1, 1, 0], [0, 0, 1], [0, 0, 0]], dtype=np.uint8)
+    result = compiled.decode_shots(shots)
+    assert result.shape == (3, dem.num_observables + 2)
+    assert np.array_equal(result[:, :2], [[1, 0], [0, 1], [0, 0]])  # L0, L1
+    assert np.all(result[:, 2:] == 0)
+
+    # D0 alone is not explained by any weight-1 error in subgraph 0: erasure_0 fires, erasure_1 does not
+    unknown_result = compiled.decode_shots(np.array([[1, 0, 0]], dtype=np.uint8))
+    assert unknown_result[0, 2] == 1  # erasure for subgraph 0
+    assert unknown_result[0, 3] == 0  # no erasure for subgraph 1
+
+    # compile_decoder_for_dem must not mutate self.subgraph_observables: second compile is identical
+    compiled_2 = decoder.compile_decoder_for_dem(dem)
+    assert compiled_2.num_observables == compiled.num_observables
+    assert np.array_equal(compiled_2.decode_shots(shots), result)
+
+
+def test_sequential_window_decoder_erasure_not_implemented() -> None:
+    """SequentialWindowDecoder raises NotImplementedError when has_erasure_bit is set."""
+    dem = stim.DetectorErrorModel("""
+        error(0.1) D0 L0
+        error(0.1) D1 L1
+    """)
+    decoder = decoders.SequentialWindowDecoder(
+        [[0], [1]], with_lookup=True, max_weight=1, add_erasure_bit=True
+    )
+    with pytest.raises(NotImplementedError, match="erasure"):
+        decoder.compile_decoder_for_dem(dem)
+
+
 def test_sequential_decoding() -> None:
     """Decode segments sequentially."""
     # construct a simple detector error model and sample from it

--- a/src/qldpc/decoders/sinter_test.py
+++ b/src/qldpc/decoders/sinter_test.py
@@ -98,6 +98,44 @@ def test_subgraph_decoding() -> None:
         decoders.SubgraphDecoder([[0], [1], [2]], [[0]])
 
 
+def test_sequential_decoding() -> None:
+    """Decode segments sequentially."""
+    # construct a simple detector error model and sample from it
+    dem = stim.DetectorErrorModel("""
+        detector(0) D0
+        detector(1) D1
+        detector(2) D2
+        error(0.1) D0 D1 L0
+        error(0.1) D1 D2 L1
+        error(0.1) D2 L2
+    """)
+    sampler = dem.compile_sampler()
+    det_data, obs_data, err_data = sampler.sample(100)
+
+    # build a monolithic decoder, compile, and predict observable flips
+    decoder_1 = decoders.SinterDecoder(with_lookup=True, max_weight=3)
+    compiled_decoder_1 = decoder_1.compile_decoder_for_dem(dem)
+    predicted_flips_1 = compiled_decoder_1.decode_shots_bit_packed(
+        compiled_decoder_1.packbits(det_data)
+    )
+
+    # build a sequential decoder, compile, and predict observable flips
+    decoder_2 = decoders.SequentialWindowDecoder([[0], [1], [2]], with_lookup=True, max_weight=1)
+    compiled_decoder_2 = decoder_2.compile_decoder_for_dem(dem)
+    predicted_flips_2 = compiled_decoder_2.decode_shots_bit_packed(
+        compiled_decoder_2.packbits(det_data)
+    )
+    assert np.array_equal(predicted_flips_1, predicted_flips_2)
+
+    # build an equivalent sliding window decoder, compile, and predict observable flips
+    decoder_2 = decoders.SlidingWindowDecoder(1, 1, with_lookup=True, max_weight=1)
+    compiled_decoder_2 = decoder_2.compile_decoder_for_dem(dem)
+    predicted_flips_2 = compiled_decoder_2.decode_shots_bit_packed(
+        compiled_decoder_2.packbits(det_data)
+    )
+    assert np.array_equal(predicted_flips_1, predicted_flips_2)
+
+
 def test_sinter_decoder_with_erasure() -> None:
     """compile_decoder_for_dem expands the DEM with an erasure observable when has_erasure_bit."""
     dem = stim.DetectorErrorModel("""
@@ -143,15 +181,11 @@ def test_subgraph_decoder_with_erasure() -> None:
     assert np.array_equal(result[:, :2], [[1, 0], [0, 1], [0, 0]])  # L0, L1
     assert np.all(result[:, 2:] == 0)
 
-    # D0 alone is not explained by any weight-1 error in subgraph 0: erasure_0 fires, erasure_1 does not
+    # D0 alone is not explained by any weight-1 error in subgraph 0
+    # erasure_0 fires, erasure_1 does not
     unknown_result = compiled.decode_shots(np.array([[1, 0, 0]], dtype=np.uint8))
     assert unknown_result[0, 2] == 1  # erasure for subgraph 0
     assert unknown_result[0, 3] == 0  # no erasure for subgraph 1
-
-    # compile_decoder_for_dem must not mutate self.subgraph_observables: second compile is identical
-    compiled_2 = decoder.compile_decoder_for_dem(dem)
-    assert compiled_2.num_observables == compiled.num_observables
-    assert np.array_equal(compiled_2.decode_shots(shots), result)
 
 
 def test_sequential_window_decoder_erasure_not_implemented() -> None:
@@ -165,41 +199,3 @@ def test_sequential_window_decoder_erasure_not_implemented() -> None:
     )
     with pytest.raises(NotImplementedError, match="erasure"):
         decoder.compile_decoder_for_dem(dem)
-
-
-def test_sequential_decoding() -> None:
-    """Decode segments sequentially."""
-    # construct a simple detector error model and sample from it
-    dem = stim.DetectorErrorModel("""
-        detector(0) D0
-        detector(1) D1
-        detector(2) D2
-        error(0.1) D0 D1 L0
-        error(0.1) D1 D2 L1
-        error(0.1) D2 L2
-    """)
-    sampler = dem.compile_sampler()
-    det_data, obs_data, err_data = sampler.sample(100)
-
-    # build a monolithic decoder, compile, and predict observable flips
-    decoder_1 = decoders.SinterDecoder(with_lookup=True, max_weight=3)
-    compiled_decoder_1 = decoder_1.compile_decoder_for_dem(dem)
-    predicted_flips_1 = compiled_decoder_1.decode_shots_bit_packed(
-        compiled_decoder_1.packbits(det_data)
-    )
-
-    # build a sequential decoder, compile, and predict observable flips
-    decoder_2 = decoders.SequentialWindowDecoder([[0], [1], [2]], with_lookup=True, max_weight=1)
-    compiled_decoder_2 = decoder_2.compile_decoder_for_dem(dem)
-    predicted_flips_2 = compiled_decoder_2.decode_shots_bit_packed(
-        compiled_decoder_2.packbits(det_data)
-    )
-    assert np.array_equal(predicted_flips_1, predicted_flips_2)
-
-    # build an equivalent sliding window decoder, compile, and predict observable flips
-    decoder_2 = decoders.SlidingWindowDecoder(1, 1, with_lookup=True, max_weight=1)
-    compiled_decoder_2 = decoder_2.compile_decoder_for_dem(dem)
-    predicted_flips_2 = compiled_decoder_2.decode_shots_bit_packed(
-        compiled_decoder_2.packbits(det_data)
-    )
-    assert np.array_equal(predicted_flips_1, predicted_flips_2)


### PR DESCRIPTION
Also use this capability in code capacity calculations, replacing the short-lived `discard_weight(s)` argument