### PR TITLE
Identify most likely observable flips in a LookupDecoder

### DIFF
--- a/examples/logical_error_rates/7_knill_qec.ipynb
+++ b/examples/logical_error_rates/7_knill_qec.ipynb
@@ -277,7 +277,7 @@
     "        noisy_circuit,\n",
     "        sinter_decoder,\n",
     "        num_samples=10**6,\n",
-    "        flags=det_record.get_events(\"flag\"),\n",
+    "        post_select=det_record.get_events(\"flag\"),\n",
     "    )\n",
     "\n",
     "    print(logical_error_rates[pp], discard_rates[pp])"

--- a/src/qldpc/decoders/custom.py
+++ b/src/qldpc/decoders/custom.py
@@ -333,9 +333,7 @@ class LookupDecoder(Decoder):
         def _get_obs_flip(error: npt.NDArray[np.int_]) -> tuple[int, ...]:
             """Map an error to its induced observable flips."""
             if isinstance(observable_flip_matrix, galois.FieldArray):
-                field = type(observable_flip_matrix)
-                error = error.view(type(observable_flip_matrix))
-                obs_flip = observable_flip_matrix @ error.view(field)
+                obs_flip = observable_flip_matrix @ error.view(type(observable_flip_matrix))
             else:
                 obs_flip = observable_flip_matrix @ error % 2
             return tuple(obs_flip.tolist())

--- a/src/qldpc/decoders/custom.py
+++ b/src/qldpc/decoders/custom.py
@@ -278,7 +278,6 @@ class LookupDecoder(Decoder):
                 )
             dem_arrays = DetectorErrorModelArrays(pcm_or_dem, simplify=simplify)
             pcm = dem_arrays.detector_flip_matrix
-            error_channel = dem_arrays.error_probs
             if dem_arrays.num_observables > 0:
                 observable_flip_matrix = dem_arrays.observable_flip_matrix
 
@@ -329,13 +328,15 @@ class LookupDecoder(Decoder):
 
         # If we got here, we are building a lookup table that maps each syndrome to an error that
         # induces the most likely observable flips.
+        assert penalty_func is not None
 
         def _get_obs_flip(error: npt.NDArray[np.int_]) -> tuple[int, ...]:
             """Map an error to its induced observable flips."""
             if isinstance(observable_flip_matrix, galois.FieldArray):
-                obs_flip = observable_flip_matrix @ error.view(type(observable_flip_matrix))
+                error = error.view(type(observable_flip_matrix))
+                obs_flip = (observable_flip_matrix @ error).view(np.ndarray)
             else:
-                obs_flip = observable_flip_matrix @ error % 2
+                obs_flip = (observable_flip_matrix @ error).view(np.ndarray) % 2
             return tuple(obs_flip.tolist())
 
         # For each "key" = (syndrome, observable_flip) combination, identify:
@@ -357,7 +358,7 @@ class LookupDecoder(Decoder):
         # Identify the most likely observable_flip for each syndrome, and map the syndrome to the
         # most likely error with that (syndrome, observable_flip) combination.
         for syndrome, obs_flip_to_net_prob in net_probs.items():
-            most_likely_obs_flip = max(obs_flip_to_net_prob, key=obs_flip_to_net_prob.get)
+            most_likely_obs_flip = max(obs_flip_to_net_prob, key=obs_flip_to_net_prob.__getitem__)
             error = most_likely_errors[syndrome, most_likely_obs_flip]
             self.syndrome_to_error[syndrome] = _maybe_add_erasure_bit(error)
 

--- a/src/qldpc/decoders/custom.py
+++ b/src/qldpc/decoders/custom.py
@@ -245,10 +245,6 @@ class LookupDecoder(Decoder):
     error from the group with the highest total probability.  When initialized from a
     DetectorErrorModel that contains observables, the observable_flip_matrix is extracted
     automatically.
-
-    By default, if initialized with a DetectorErrorModel (DEM) this decoder merges error mechanisms
-    that have the same (syndrome, observable_flip) signature.  Simplifying can be disabled with
-    simplify=False.
     """
 
     def __init__(
@@ -261,7 +257,6 @@ class LookupDecoder(Decoder):
         error_channel: npt.NDArray[np.floating] | Sequence[float] | None = None,
         penalty_func: Callable[[npt.NDArray[np.int_] | Sequence[int]], float] | None = None,
         observable_flip_matrix: IntegerArray | None = None,
-        simplify: bool = True,
     ) -> None:
         if isinstance(pcm_or_dem, stim.DetectorErrorModel):
             # Initialize from a stim.DetectorErrorModel:
@@ -276,7 +271,7 @@ class LookupDecoder(Decoder):
                     "Cannot specify an error_channel, penalty_func, or observable_flip_matrix when"
                     " providing a stim.DetectorErrorModel to a LookupDecoder"
                 )
-            dem_arrays = DetectorErrorModelArrays(pcm_or_dem, simplify=simplify)
+            dem_arrays = DetectorErrorModelArrays(pcm_or_dem, simplify=False)
             pcm = dem_arrays.detector_flip_matrix
             error_channel = dem_arrays.error_probs
             if dem_arrays.num_observables > 0:
@@ -309,14 +304,14 @@ class LookupDecoder(Decoder):
         self.shape: tuple[int, ...] = pcm.shape
         self.has_erasure_bit = add_erasure_bit
         self.default_error_to_return = np.zeros(self.shape[1], dtype=int)
-        if add_erasure_bit:
+        if self.has_erasure_bit:
             self.default_error_to_return = np.hstack([self.default_error_to_return, [1]])
+
+        def _maybe_add_erasure_bit(error: npt.NDArray[np.int_]) -> npt.NDArray[np.int_]:
+            return np.hstack([error, [0]]) if self.has_erasure_bit else error
 
         # start working on the decoding map from syndrome -> error
         self.syndrome_to_error: dict[tuple[int, ...], npt.NDArray[np.int_]] = {}
-
-        def _maybe_add_erasure_bit(error: npt.NDArray[np.int_]) -> npt.NDArray[np.int_]:
-            return np.hstack([error, [0]]) if add_erasure_bit else error
 
         if observable_flip_matrix is None:
             # Loop over all errors in decreasing weight.  Assign each syndrome its most likely error.
@@ -333,7 +328,7 @@ class LookupDecoder(Decoder):
 
         # If we got here, we are building a lookup table that maps each syndrome to an error that
         # induces the most likely observable flips.
-        assert penalty_func is not None
+        assert penalty_func is not None  # primarily for type-checking reasons
 
         def _get_obs_flip(error: npt.NDArray[np.int_]) -> tuple[int, ...]:
             """Map an error to its induced observable flips."""

--- a/src/qldpc/decoders/custom.py
+++ b/src/qldpc/decoders/custom.py
@@ -264,6 +264,9 @@ class LookupDecoder(Decoder):
         simplify: bool = True,
     ) -> None:
         if isinstance(pcm_or_dem, stim.DetectorErrorModel):
+            # Initialize from a stim.DetectorErrorModel:
+            # 1. Forbid conflicting arguments.
+            # 2. Extract parity check matrix, error probabilities, and observables (if applicable).
             if (
                 error_channel is not None
                 or penalty_func is not None
@@ -278,7 +281,9 @@ class LookupDecoder(Decoder):
             error_channel = dem_arrays.error_probs
             if dem_arrays.num_observables > 0:
                 observable_flip_matrix = dem_arrays.observable_flip_matrix
+
         else:
+            # initialize from a parity check matrix and forbid conflicting arguments
             pcm = pcm_or_dem
             if error_channel is not None and penalty_func is not None:
                 raise ValueError(
@@ -290,22 +295,27 @@ class LookupDecoder(Decoder):
                     " stim.DetectorErrorModel, error_channel, or penalty_func"
                 )
 
+        # Construct the "penalty function" for each error.  If we have error probabilities, the
+        # penalty function is penalty_func(error) = -log(probability_of_error)
         penalty_func = penalty_func or (
             self.build_penalty_func(error_channel) if error_channel is not None else None
         )
 
-        def _maybe_add_erasure_bit(error: npt.NDArray[np.int_]) -> npt.NDArray[np.int_]:
-            return np.hstack([error, [0]]) if add_erasure_bit else error
-
+        # set some useful/necessary attributes
         self.shape: tuple[int, ...] = pcm.shape
         self.has_erasure_bit = add_erasure_bit
         self.default_error_to_return = np.zeros(self.shape[1], dtype=int)
         if add_erasure_bit:
             self.default_error_to_return = np.hstack([self.default_error_to_return, [1]])
 
+        # start working on the decoding map from syndrome -> error
         self.syndrome_to_error: dict[tuple[int, ...], npt.NDArray[np.int_]] = {}
 
+        def _maybe_add_erasure_bit(error: npt.NDArray[np.int_]) -> npt.NDArray[np.int_]:
+            return np.hstack([error, [0]]) if add_erasure_bit else error
+
         if observable_flip_matrix is None:
+            # Loop over all errors in decreasing weight.  Assign each syndrome its most likely error.
             error_penalty: dict[tuple[int, ...], float] = {}
             for error, syndrome in LookupDecoder.iter_errors_and_syndromes(
                 pcm, max_weight, symplectic
@@ -315,9 +325,13 @@ class LookupDecoder(Decoder):
                 elif (error_weight := penalty_func(error)) <= error_penalty.get(syndrome, np.inf):
                     error_penalty[syndrome] = error_weight
                     self.syndrome_to_error[syndrome] = _maybe_add_erasure_bit(error)
-            return
+            return  # we have built the syndrome_to_error map, so we have no more to do!
+
+        # If we got here, we are building a lookup table that maps each syndrome to an error that
+        # induces the most likely observable flips.
 
         def _get_obs_flip(error: npt.NDArray[np.int_]) -> tuple[int, ...]:
+            """Map an error to its induced observable flips."""
             if isinstance(observable_flip_matrix, galois.FieldArray):
                 field = type(observable_flip_matrix)
                 error = error.view(type(observable_flip_matrix))
@@ -326,19 +340,25 @@ class LookupDecoder(Decoder):
                 obs_flip = observable_flip_matrix @ error % 2
             return tuple(obs_flip.tolist())
 
+        # For each "key" = (syndrome, observable_flip) combination, keep track of:
+        # 1. The net probability of each key.
+        # 2. The most likely error for each key.
+        # 3. The probability of the most likely error for each key.
         Bitstring = tuple[int, ...]
         net_probs: dict[Bitstring, dict[Bitstring, float]] = collections.defaultdict(dict)
-        highest_probs: dict[tuple[Bitstring, Bitstring], float] = {}
         most_likely_errors: dict[tuple[Bitstring, Bitstring], npt.NDArray[np.int_]] = {}
+        most_likely_error_probs: dict[tuple[Bitstring, Bitstring], float] = {}
 
         for error, syndrome in LookupDecoder.iter_errors_and_syndromes(pcm, max_weight, symplectic):
             obs_flip = _get_obs_flip(error)
             prob = np.exp(-penalty_func(error))
             net_probs[syndrome][obs_flip] = net_probs[syndrome].get(obs_flip, 0.0) + prob
-            if prob > highest_probs.get((syndrome, obs_flip), 0.0):
-                highest_probs[syndrome, obs_flip] = prob
+            if prob > most_likely_error_probs.get((syndrome, obs_flip), 0.0):
+                most_likely_error_probs[syndrome, obs_flip] = prob
                 most_likely_errors[syndrome, obs_flip] = error
 
+        # Identify the most likely observable_flip for each syndrome, and map the syndrome to the
+        # most likely error with that (syndrome, observable_flip) combination.
         for syndrome, obs_flip_to_net_prob in net_probs.items():
             most_likely_obs_flip = max(obs_flip_to_net_prob, key=obs_flip_to_net_prob.get)
             error = most_likely_errors[syndrome, most_likely_obs_flip]

--- a/src/qldpc/decoders/custom.py
+++ b/src/qldpc/decoders/custom.py
@@ -278,6 +278,7 @@ class LookupDecoder(Decoder):
                 )
             dem_arrays = DetectorErrorModelArrays(pcm_or_dem, simplify=simplify)
             pcm = dem_arrays.detector_flip_matrix
+            error_channel = dem_arrays.error_probs
             if dem_arrays.num_observables > 0:
                 observable_flip_matrix = dem_arrays.observable_flip_matrix
 
@@ -288,7 +289,11 @@ class LookupDecoder(Decoder):
                 raise ValueError(
                     "Cannot specify both an error_channel and a penalty_func in a LookupDecoder"
                 )
-            if observable_flip_matrix is not None and penalty_func is None:
+            if (
+                observable_flip_matrix is not None
+                and penalty_func is None
+                and error_channel is None
+            ):
                 raise ValueError(
                     "Predicting observable flips with a LookupDecoder requires providing a"
                     " stim.DetectorErrorModel, error_channel, or penalty_func"

--- a/src/qldpc/decoders/custom.py
+++ b/src/qldpc/decoders/custom.py
@@ -236,6 +236,16 @@ class LookupDecoder(Decoder):
     If provided a penalty_func that maps an error to a real number (i.e., a penalty), the decoder
     only assigns correction ee to syndrome ss if (a) ss has no assigned correction, or (b) the
     penalty of ee is <= the penalty of the correction currently assigned to ss.
+
+    If provided an observable_flip_matrix (shape num_observables x num_errors) together with an
+    error_channel or penalty_func, the decoder uses MAP observable-flip decoding: for each syndrome
+    it finds the observable-flip class F with the highest total log-probability
+        log sum_{E in class(F,S)} P(E),
+    and returns the highest-probability individual error from that class.  Without error
+    probabilities the parameter has no effect.
+
+    When initialized from a DetectorErrorModel that contains observables, the observable_flip_matrix
+    is extracted automatically.
     """
 
     def __init__(
@@ -247,11 +257,14 @@ class LookupDecoder(Decoder):
         add_erasure_bit: bool = False,
         error_channel: npt.NDArray[np.floating] | Sequence[float] | None = None,
         penalty_func: Callable[[npt.NDArray[np.int_] | Sequence[int]], float] | None = None,
+        observable_flip_matrix: IntegerArray | None = None,
     ) -> None:
         if isinstance(pcm_or_dem, stim.DetectorErrorModel):
             dem_arrays = DetectorErrorModelArrays(pcm_or_dem)
             pcm = dem_arrays.detector_flip_matrix
             error_channel = dem_arrays.error_probs
+            if observable_flip_matrix is None and dem_arrays.num_observables > 0:
+                observable_flip_matrix = dem_arrays.observable_flip_matrix
             if penalty_func is not None:
                 warnings.warn(
                     "Explicitly provided penalty_func will override the error probabilities of the "
@@ -274,13 +287,46 @@ class LookupDecoder(Decoder):
         self.shape: tuple[int, ...] = pcm.shape
         self.syndrome_to_correction: dict[tuple[int, ...], npt.NDArray[np.int_]] = {}
 
-        error_weights: dict[tuple[int, ...], float] = {}
-        for error, syndrome in LookupDecoder.iter_errors_and_syndromes(pcm, max_weight, symplectic):
-            if penalty_func is None:
-                self.syndrome_to_correction[syndrome] = _maybe_add_erasure_bit(error)
-            elif (error_weight := penalty_func(error)) <= error_weights.get(syndrome, np.inf):
-                error_weights[syndrome] = error_weight
-                self.syndrome_to_correction[syndrome] = _maybe_add_erasure_bit(error)
+        if observable_flip_matrix is not None and penalty_func is not None:
+            # observable-flip decoding: group errors by (syndrome, obs_flip) class,
+            # accumulate log-sum-exp probabilities per class, pick best class per syndrome.
+            OFKey = tuple[tuple[int, ...], tuple[int, ...]]
+
+            def _obs_flip(error: npt.NDArray[np.int_]) -> tuple[int, ...]:
+                return tuple(np.asarray(observable_flip_matrix @ error, dtype=int).ravel() % 2)
+
+            class_log_probs: dict[OFKey, float] = {}
+            class_best_log_prob: dict[OFKey, float] = {}
+            class_best_error: dict[OFKey, npt.NDArray[np.int_]] = {}
+
+            for error, syndrome in LookupDecoder.iter_errors_and_syndromes(
+                pcm, max_weight, symplectic
+            ):
+                key: OFKey = (syndrome, _obs_flip(error))
+                log_prob = -penalty_func(error)
+                class_log_probs[key] = float(
+                    np.logaddexp(class_log_probs.get(key, -np.inf), log_prob)
+                )
+                if log_prob > class_best_log_prob.get(key, -np.inf):
+                    class_best_log_prob[key] = log_prob
+                    class_best_error[key] = _maybe_add_erasure_bit(error)
+
+            best_class_log_prob: dict[tuple[int, ...], float] = {}
+            for (syndrome, obs_flip), log_prob in class_log_probs.items():
+                if log_prob > best_class_log_prob.get(syndrome, -np.inf):
+                    best_class_log_prob[syndrome] = log_prob
+                    self.syndrome_to_correction[syndrome] = class_best_error[(syndrome, obs_flip)]
+
+        else:
+            error_weights: dict[tuple[int, ...], float] = {}
+            for error, syndrome in LookupDecoder.iter_errors_and_syndromes(
+                pcm, max_weight, symplectic
+            ):
+                if penalty_func is None:
+                    self.syndrome_to_correction[syndrome] = _maybe_add_erasure_bit(error)
+                elif (error_weight := penalty_func(error)) <= error_weights.get(syndrome, np.inf):
+                    error_weights[syndrome] = error_weight
+                    self.syndrome_to_correction[syndrome] = _maybe_add_erasure_bit(error)
 
         self.has_erasure_bit = add_erasure_bit
         self.default_correction = np.zeros(self.shape[1], dtype=int)

--- a/src/qldpc/decoders/custom.py
+++ b/src/qldpc/decoders/custom.py
@@ -238,11 +238,12 @@ class LookupDecoder(Decoder):
     penalty of ee is <= the penalty of the correction currently assigned to ss.
 
     If provided an observable_flip_matrix (shape num_observables x num_errors) together with an
-    error_channel or penalty_func, the decoder uses MAP observable-flip decoding: for each syndrome
-    it finds the observable-flip class F with the highest total log-probability
-        log sum_{E in class(F,S)} P(E),
-    and returns the highest-probability individual error from that class.  Without error
-    probabilities the parameter has no effect.
+    error_channel or penalty_func, the decoder picks the most likely observable flip for each
+    syndrome rather than the single most likely error.  Concretely: errors consistent with a given
+    syndrome are grouped by their observable flip value; the total probability of each group is the
+    sum of the probabilities of its member errors; the decoder returns the highest-probability
+    individual error from the group with the highest total probability.  Without error probabilities
+    the parameter has no effect.
 
     When initialized from a DetectorErrorModel that contains observables, the observable_flip_matrix
     is extracted automatically.
@@ -282,6 +283,10 @@ class LookupDecoder(Decoder):
 
         penalty_func = penalty_func or (
             self.build_penalty_func(error_channel) if error_channel is not None else None
+        )
+        assert observable_flip_matrix is None or penalty_func is not None, (
+            "observable_flip_matrix has no effect without error probabilities; "
+            "provide an error_channel or penalty_func"
         )
 
         self.shape: tuple[int, ...] = pcm.shape

--- a/src/qldpc/decoders/custom.py
+++ b/src/qldpc/decoders/custom.py
@@ -237,16 +237,18 @@ class LookupDecoder(Decoder):
     only assigns correction ee to syndrome ss if (a) ss has no assigned correction, or (b) the
     penalty of ee is <= the penalty of the correction currently assigned to ss.
 
-    If provided an observable_flip_matrix (shape num_observables x num_errors) together with an
-    error_channel or penalty_func, the decoder picks the most likely observable flip for each
-    syndrome rather than the single most likely error.  Concretely: errors consistent with a given
-    syndrome are grouped by their observable flip value; the total probability of each group is the
-    sum of the probabilities of its member errors; the decoder returns the highest-probability
-    individual error from the group with the highest total probability.  Without error probabilities
-    the parameter has no effect.
+    If provided an observable_flip_matrix (shape num_observables × num_errors), this decoder picks an
+    error that induces the most likely observable flip for each syndrome, rather than the single most
+    likely error.  Concretely: errors consistent with a given syndrome are grouped by their
+    observable flip value; the total probability of each group is (approximately) the sum of the
+    probabilities of its member errors.  This decoder returns the highest-probability individual
+    error from the group with the highest total probability.  When initialized from a
+    DetectorErrorModel that contains observables, the observable_flip_matrix is extracted
+    automatically.
 
-    When initialized from a DetectorErrorModel that contains observables, the observable_flip_matrix
-    is extracted automatically.
+    By default, if initialized with a DetectorErrorModel (DEM) this decoder merges error mechanisms
+    that have the same (syndrome, observable_flip) signature.  Simplifying can be disabled with
+    simplify=False.
     """
 
     def __init__(
@@ -259,84 +261,88 @@ class LookupDecoder(Decoder):
         error_channel: npt.NDArray[np.floating] | Sequence[float] | None = None,
         penalty_func: Callable[[npt.NDArray[np.int_] | Sequence[int]], float] | None = None,
         observable_flip_matrix: IntegerArray | None = None,
+        simplify: bool = True,
     ) -> None:
         if isinstance(pcm_or_dem, stim.DetectorErrorModel):
-            dem_arrays = DetectorErrorModelArrays(pcm_or_dem)
+            if (
+                error_channel is not None
+                or penalty_func is not None
+                or observable_flip_matrix is not None
+            ):
+                raise ValueError(
+                    "Cannot specify an error_channel, penalty_func, or observable_flip_matrix when"
+                    " providing a stim.DetectorErrorModel to a LookupDecoder"
+                )
+            dem_arrays = DetectorErrorModelArrays(pcm_or_dem, simplify=simplify)
             pcm = dem_arrays.detector_flip_matrix
             error_channel = dem_arrays.error_probs
-            if observable_flip_matrix is None and dem_arrays.num_observables > 0:
+            if dem_arrays.num_observables > 0:
                 observable_flip_matrix = dem_arrays.observable_flip_matrix
-            if penalty_func is not None:
-                warnings.warn(
-                    "Explicitly provided penalty_func will override the error probabilities of the "
-                    "provided detector error model",
-                    stacklevel=2,
-                )
         else:
             pcm = pcm_or_dem
-            assert error_channel is None or penalty_func is None, (
-                "Cannot specify both an error_channel and a penalty_func"
-            )
-
-        def _maybe_add_erasure_bit(error: npt.NDArray[np.int_]) -> npt.NDArray[np.int_]:
-            return np.hstack([error, [0]]) if add_erasure_bit else error
+            if error_channel is not None and penalty_func is not None:
+                raise ValueError(
+                    "Cannot specify both an error_channel and a penalty_func in a LookupDecoder"
+                )
+            if observable_flip_matrix is not None and penalty_func is None:
+                raise ValueError(
+                    "Predicting observable flips with a LookupDecoder requires providing a"
+                    " stim.DetectorErrorModel, error_channel, or penalty_func"
+                )
 
         penalty_func = penalty_func or (
             self.build_penalty_func(error_channel) if error_channel is not None else None
         )
-        assert observable_flip_matrix is None or penalty_func is not None, (
-            "observable_flip_matrix has no effect without error probabilities; "
-            "provide an error_channel or penalty_func"
-        )
+
+        def _maybe_add_erasure_bit(error: npt.NDArray[np.int_]) -> npt.NDArray[np.int_]:
+            return np.hstack([error, [0]]) if add_erasure_bit else error
 
         self.shape: tuple[int, ...] = pcm.shape
-        self.syndrome_to_correction: dict[tuple[int, ...], npt.NDArray[np.int_]] = {}
+        self.has_erasure_bit = add_erasure_bit
+        self.default_error_to_return = np.zeros(self.shape[1], dtype=int)
+        if add_erasure_bit:
+            self.default_error_to_return = np.hstack([self.default_error_to_return, [1]])
 
-        if observable_flip_matrix is not None and penalty_func is not None:
-            # observable-flip decoding: group errors by (syndrome, obs_flip) class,
-            # accumulate log-sum-exp probabilities per class, pick best class per syndrome.
-            OFKey = tuple[tuple[int, ...], tuple[int, ...]]
+        self.syndrome_to_error: dict[tuple[int, ...], npt.NDArray[np.int_]] = {}
 
-            def _obs_flip(error: npt.NDArray[np.int_]) -> tuple[int, ...]:
-                return tuple(np.asarray(observable_flip_matrix @ error, dtype=int).ravel() % 2)
-
-            class_log_probs: dict[OFKey, float] = {}
-            class_best_log_prob: dict[OFKey, float] = {}
-            class_best_error: dict[OFKey, npt.NDArray[np.int_]] = {}
-
-            for error, syndrome in LookupDecoder.iter_errors_and_syndromes(
-                pcm, max_weight, symplectic
-            ):
-                key: OFKey = (syndrome, _obs_flip(error))
-                log_prob = -penalty_func(error)
-                class_log_probs[key] = float(
-                    np.logaddexp(class_log_probs.get(key, -np.inf), log_prob)
-                )
-                if log_prob > class_best_log_prob.get(key, -np.inf):
-                    class_best_log_prob[key] = log_prob
-                    class_best_error[key] = _maybe_add_erasure_bit(error)
-
-            best_class_log_prob: dict[tuple[int, ...], float] = {}
-            for (syndrome, obs_flip), log_prob in class_log_probs.items():
-                if log_prob > best_class_log_prob.get(syndrome, -np.inf):
-                    best_class_log_prob[syndrome] = log_prob
-                    self.syndrome_to_correction[syndrome] = class_best_error[(syndrome, obs_flip)]
-
-        else:
-            error_weights: dict[tuple[int, ...], float] = {}
+        if observable_flip_matrix is None:
+            error_penalty: dict[tuple[int, ...], float] = {}
             for error, syndrome in LookupDecoder.iter_errors_and_syndromes(
                 pcm, max_weight, symplectic
             ):
                 if penalty_func is None:
-                    self.syndrome_to_correction[syndrome] = _maybe_add_erasure_bit(error)
-                elif (error_weight := penalty_func(error)) <= error_weights.get(syndrome, np.inf):
-                    error_weights[syndrome] = error_weight
-                    self.syndrome_to_correction[syndrome] = _maybe_add_erasure_bit(error)
+                    self.syndrome_to_error[syndrome] = _maybe_add_erasure_bit(error)
+                elif (error_weight := penalty_func(error)) <= error_penalty.get(syndrome, np.inf):
+                    error_penalty[syndrome] = error_weight
+                    self.syndrome_to_error[syndrome] = _maybe_add_erasure_bit(error)
+            return
 
-        self.has_erasure_bit = add_erasure_bit
-        self.default_correction = np.zeros(self.shape[1], dtype=int)
-        if add_erasure_bit:
-            self.default_correction = np.hstack([self.default_correction, [1]])
+        def _get_obs_flip(error: npt.NDArray[np.int_]) -> tuple[int, ...]:
+            if isinstance(observable_flip_matrix, galois.FieldArray):
+                field = type(observable_flip_matrix)
+                error = error.view(type(observable_flip_matrix))
+                obs_flip = observable_flip_matrix @ error.view(field)
+            else:
+                obs_flip = observable_flip_matrix @ error % 2
+            return tuple(obs_flip.tolist())
+
+        Bitstring = tuple[int, ...]
+        net_probs: dict[Bitstring, dict[Bitstring, float]] = collections.defaultdict(dict)
+        highest_probs: dict[tuple[Bitstring, Bitstring], float] = {}
+        most_likely_errors: dict[tuple[Bitstring, Bitstring], npt.NDArray[np.int_]] = {}
+
+        for error, syndrome in LookupDecoder.iter_errors_and_syndromes(pcm, max_weight, symplectic):
+            obs_flip = _get_obs_flip(error)
+            prob = np.exp(-penalty_func(error))
+            net_probs[syndrome][obs_flip] = net_probs[syndrome].get(obs_flip, 0.0) + prob
+            if prob > highest_probs.get((syndrome, obs_flip), 0.0):
+                highest_probs[syndrome, obs_flip] = prob
+                most_likely_errors[syndrome, obs_flip] = error
+
+        for syndrome, obs_flip_to_net_prob in net_probs.items():
+            most_likely_obs_flip = max(obs_flip_to_net_prob, key=obs_flip_to_net_prob.get)
+            error = most_likely_errors[syndrome, most_likely_obs_flip]
+            self.syndrome_to_error[syndrome] = _maybe_add_erasure_bit(error)
 
     @staticmethod
     def iter_errors_and_syndromes(
@@ -366,8 +372,8 @@ class LookupDecoder(Decoder):
 
     def decode(self, syndrome: npt.NDArray[np.int_]) -> npt.NDArray[np.int_]:
         """Decode an error syndrome and return an inferred error."""
-        return self.syndrome_to_correction.get(
-            tuple(syndrome.view(np.ndarray)), self.default_correction
+        return self.syndrome_to_error.get(
+            tuple(syndrome.view(np.ndarray)), self.default_error_to_return
         ).copy()
 
     @staticmethod

--- a/src/qldpc/decoders/custom.py
+++ b/src/qldpc/decoders/custom.py
@@ -338,7 +338,7 @@ class LookupDecoder(Decoder):
                 obs_flip = observable_flip_matrix @ error % 2
             return tuple(obs_flip.tolist())
 
-        # For each "key" = (syndrome, observable_flip) combination, keep track of:
+        # For each "key" = (syndrome, observable_flip) combination, identify:
         # 1. The net probability of each key.
         # 2. The most likely error for each key.
         # 3. The probability of the most likely error for each key.
@@ -346,7 +346,6 @@ class LookupDecoder(Decoder):
         net_probs: dict[Bitstring, dict[Bitstring, float]] = collections.defaultdict(dict)
         most_likely_errors: dict[tuple[Bitstring, Bitstring], npt.NDArray[np.int_]] = {}
         most_likely_error_probs: dict[tuple[Bitstring, Bitstring], float] = {}
-
         for error, syndrome in LookupDecoder.iter_errors_and_syndromes(pcm, max_weight, symplectic):
             obs_flip = _get_obs_flip(error)
             prob = np.exp(-penalty_func(error))

--- a/src/qldpc/decoders/custom.py
+++ b/src/qldpc/decoders/custom.py
@@ -271,7 +271,7 @@ class LookupDecoder(Decoder):
                 error_channel is not None
                 or penalty_func is not None
                 or observable_flip_matrix is not None
-            ):
+            ):  # pragma: no cover
                 raise ValueError(
                     "Cannot specify an error_channel, penalty_func, or observable_flip_matrix when"
                     " providing a stim.DetectorErrorModel to a LookupDecoder"
@@ -285,7 +285,7 @@ class LookupDecoder(Decoder):
         else:
             # initialize from a parity check matrix and forbid conflicting arguments
             pcm = pcm_or_dem
-            if error_channel is not None and penalty_func is not None:
+            if error_channel is not None and penalty_func is not None:  # pragma: no cover
                 raise ValueError(
                     "Cannot specify both an error_channel and a penalty_func in a LookupDecoder"
                 )
@@ -293,7 +293,7 @@ class LookupDecoder(Decoder):
                 observable_flip_matrix is not None
                 and penalty_func is None
                 and error_channel is None
-            ):
+            ):  # pragma: no cover
                 raise ValueError(
                     "Predicting observable flips with a LookupDecoder requires providing a"
                     " stim.DetectorErrorModel, error_channel, or penalty_func"
@@ -337,7 +337,7 @@ class LookupDecoder(Decoder):
 
         def _get_obs_flip(error: npt.NDArray[np.int_]) -> tuple[int, ...]:
             """Map an error to its induced observable flips."""
-            if isinstance(observable_flip_matrix, galois.FieldArray):
+            if isinstance(observable_flip_matrix, galois.FieldArray):  # pragma: no cover
                 error = error.view(type(observable_flip_matrix))
                 obs_flip = (observable_flip_matrix @ error).view(np.ndarray)
             else:

--- a/src/qldpc/decoders/custom_test.py
+++ b/src/qldpc/decoders/custom_test.py
@@ -93,113 +93,49 @@ def test_lookup() -> None:
     assert np.array_equal(error, decoder.decode(syndrome))
 
 
-def test_lookup_observable() -> None:
-    """Lookup decoding that targets the most likely observable flip for each syndrome.
+def test_observable_lookup_decoding() -> None:
+    """Lookup decoding can identify the most likely observable flip for each syndrome."""
 
-    The decoder groups errors by their observable flip value, sums probabilities within each group,
-    and returns an error from the group with the highest total probability.  This gives a different
-    answer than simply picking the single most likely error when degenerate errors (sharing the same
-    observable flip) collectively outweigh a more probable individual error with a different flip.
-    """
-
-    def get_obs_flip(da: decoders.DetectorErrorModelArrays, error: np.ndarray) -> int:
-        return int(np.asarray(da.observable_flip_matrix @ error, dtype=int).ravel()[0] % 2)
-
-    # --- Part 1: explicit PCM ---
-    # Three mechanisms all give syndrome (1,): p=0.10 (obs_flip=0), p=0.09 (obs_flip=1),
-    # p=0.06 (obs_flip=1).  The decoder without observable awareness picks the most likely
-    # individual error (p=0.10, obs_flip=0).  The observable-aware decoder sums per class:
-    # obs_flip=0 total=0.10, obs_flip=1 total=0.09+0.06=0.15 → obs_flip=1 wins.
-    pcm = np.array([[1, 1, 1]], dtype=int)
-    obs_matrix = np.array([[0, 1, 1]], dtype=int)
-    error_channel = np.array([0.10, 0.09, 0.06])
-    syndrome = np.array([1], dtype=int)
-
-    standard = decoders.LookupDecoder(pcm, max_weight=1, error_channel=error_channel)
-    assert int((obs_matrix @ standard.decode(syndrome) % 2)[0]) == 0  # most likely error
-
-    aware = decoders.LookupDecoder(
-        pcm, max_weight=1, error_channel=error_channel, observable_flip_matrix=obs_matrix
-    )
-    assert int((obs_matrix @ aware.decode(syndrome) % 2)[0]) == 1  # most likely observable flip
-
-    # --- Part 2: same scenario via DEM + simplify=False ---
-    # simplify=False keeps the two "D0 L0" mechanisms separate, reproducing the three-mechanism PCM.
+    # toy detector error model and error syndrome
     dem = stim.DetectorErrorModel("""
         error(0.10) D0
         error(0.09) D0 L0
         error(0.06) D0 L0
     """)
-    da = decoders.DetectorErrorModelArrays(dem, simplify=False)
+    dem_arrays = decoders.DetectorErrorModelArrays(dem, simplify=False)
+    pcm, obs_matrix, error_probs = dem_arrays.get_arrays()
+    syndrome = np.array([1], dtype=int)
 
-    standard_dem = decoders.LookupDecoder(
-        da.detector_flip_matrix, max_weight=1, error_channel=da.error_probs
-    )
-    assert get_obs_flip(da, standard_dem.decode(syndrome)) == 0  # same result as Part 1
+    # given only the parity check matrix, a LookupDecoder will return the most likely error
+    decoder = decoders.LookupDecoder(pcm, max_weight=1, error_channel=error_probs)
+    assert np.array_equal(obs_matrix @ decoder.decode(syndrome), [0])
 
-    aware_dem = decoders.LookupDecoder(dem, max_weight=1, simplify=False)
-    assert get_obs_flip(da, aware_dem.decode(syndrome)) == 1  # same result as Part 1
+    # provided a DEM, the LookupDecoder will simplify and predict the most likely observable flip
+    decoder = decoders.LookupDecoder(dem, max_weight=1, simplify=False)
+    assert np.array_equal(obs_matrix @ decoder.decode(syndrome), [1])
 
-    # --- Part 3: same DEM with default simplify=True ---
-    # simplify=True merges the two "D0 L0" mechanisms into one with combined p≈0.145 > 0.10,
-    # so the merged mechanism is simply the most likely error; a standard decoder initialized
-    # from the DEM already returns the correct obs_flip=1 without explicit observable tracking.
-    da_simplified = decoders.DetectorErrorModelArrays(dem)
-    decoder_simplified = decoders.LookupDecoder(dem, max_weight=1)
-    assert get_obs_flip(da_simplified, decoder_simplified.decode(syndrome)) == 1
-
-    # --- Part 4: max_weight=2 DEM where simplification is not enough ---
-    # Five mechanisms, all with unique (detector, observable) patterns so simplify changes nothing:
-    #   error(0.05) D0 D1   — M0: syndrome (1,1), obs_flip=0
-    #   error(0.25) D0      — M1: syndrome (1,0), obs_flip=0
-    #   error(0.10) D1      — M2: syndrome (0,1), obs_flip=0
-    #   error(0.10) D0 L0   — M3: syndrome (1,0), obs_flip=1
-    #   error(0.25) D1 L0   — M4: syndrome (0,1), obs_flip=1
-    # For syndrome (1,1), the most likely individual combination is M1+M4 (P≈0.048, obs_flip=1).
-    # But summing per class: obs_flip=0 = P(M0)+P(M1+M2)+P(M3+M4) ≈ 0.055
-    #                         obs_flip=1 = P(M1+M4)+P(M3+M2)       ≈ 0.053
-    # A decoder without observable awareness returns obs_flip=1; the observable-aware decoder
-    # correctly returns obs_flip=0.
-    dem4 = stim.DetectorErrorModel("""
-        error(0.05) D0 D1
-        error(0.25) D0
-        error(0.10) D1
-        error(0.10) D0 L0
-        error(0.25) D1 L0
+    # The above example is "trivial" in the sense that simplifying the DEM is sufficient to predict
+    # the correct observable flips.  However, sometimes simplifying is not enough.  Consider the
+    # following DEM, in which each error has a unique (detector, observable) patterns, so
+    # simplifying changes nothing:
+    dem = stim.DetectorErrorModel("""
+        error(0.04) D0 D1  # E0: syndrome (1, 1), obs_flip=0
+        error(0.25) D0     # E1: syndrome (1, 0), obs_flip=0
+        error(0.10) D1     # E2: syndrome (0, 1), obs_flip=0
+        error(0.10) D0 L0  # E3: syndrome (1, 0), obs_flip=1
+        error(0.25) D1 L0  # E4: syndrome (0, 1), obs_flip=1
     """)
-    da4 = decoders.DetectorErrorModelArrays(dem4)
-    syndrome4 = np.array([1, 1], dtype=int)
+    dem_arrays = decoders.DetectorErrorModelArrays(dem)
+    pcm, obs_matrix, error_probs = dem_arrays.get_arrays()
+    syndrome = np.array([1, 1], dtype=int)
 
-    standard4 = decoders.LookupDecoder(
-        da4.detector_flip_matrix, max_weight=2, error_channel=da4.error_probs
-    )
-    assert get_obs_flip(da4, standard4.decode(syndrome4)) == 1  # most likely individual combination
+    # without knowing about observables, the most likely error is E0, with obs_flip=0
+    decoder = decoders.LookupDecoder(pcm, max_weight=2)
+    assert np.array_equal(obs_matrix @ decoder.decode(syndrome), [0])
 
-    aware4 = decoders.LookupDecoder(dem4, max_weight=2)
-    assert get_obs_flip(da4, aware4.decode(syndrome4)) == 0  # most likely observable flip
-
-    # Providing an observable_flip_matrix without error probabilities raises an error.
-    with pytest.raises(ValueError, match="stim.DetectorErrorModel, error_channel, or penalty_func"):
-        decoders.LookupDecoder(pcm, max_weight=1, observable_flip_matrix=obs_matrix)
-
-    # Providing both error_channel and penalty_func raises an error.
-    with pytest.raises(ValueError, match="both an error_channel and a penalty_func"):
-        decoders.LookupDecoder(
-            pcm, max_weight=1, error_channel=error_channel, penalty_func=lambda v: 0.0
-        )
-
-    # Providing a DEM alongside conflicting arguments raises an error.
-    with pytest.raises(ValueError, match="Cannot specify"):
-        decoders.LookupDecoder(dem4, max_weight=1, error_channel=da4.error_probs)
-
-    # The FieldArray branch: observable_flip_matrix is a galois FieldArray (quantum / non-binary use).
-    field = galois.GF(2)
-    pcm_gf2 = pcm.view(field)
-    obs_gf2 = obs_matrix.view(field)
-    aware_gf2 = decoders.LookupDecoder(
-        pcm_gf2, max_weight=1, error_channel=error_channel, observable_flip_matrix=obs_gf2
-    )
-    assert int((obs_matrix @ aware_gf2.decode(syndrome) % 2)[0]) == 1
+    # however, it is more likely that either (E1 + E4) XOR (E2 + E3) occurred, which have obs_flip=1
+    decoder = decoders.LookupDecoder(dem, max_weight=2)
+    assert np.array_equal(obs_matrix @ decoder.decode(syndrome), [1])
 
 
 def test_ilp_decoder() -> None:

--- a/src/qldpc/decoders/custom_test.py
+++ b/src/qldpc/decoders/custom_test.py
@@ -96,6 +96,59 @@ def test_lookup() -> None:
         decoders.LookupDecoder(dem, max_weight=2, penalty_func=lambda v: float(np.count_nonzero(v)))
 
 
+def test_lookup_observable() -> None:
+    """Observable-flip-aware lookup decoding (MAP obs_flip vs MAP error)."""
+    # Toy problem: 1 detector, 3 error mechanisms.
+    # Mechanism 0: flips detector only (obs_flip 0), p=0.10
+    # Mechanism 1: flips detector and observable (obs_flip 1), p=0.09
+    # Mechanism 2: flips detector and observable (obs_flip 1), p=0.06
+    # For syndrome (1,), MAP error picks mechanism 0 (highest individual p),
+    # but MAP obs_flip picks obs_flip=1 because P(F=1|S) = 0.09+0.06 = 0.15 > P(F=0|S) = 0.10.
+    pcm = np.array([[1, 1, 1]], dtype=int)
+    obs_matrix = np.array([[0, 1, 1]], dtype=int)
+    error_channel = [0.10, 0.09, 0.06]
+    syndrome = np.array([1], dtype=int)
+
+    # MAP error decoder (no observable_flip_matrix): returns mechanism-0 error → obs_flip 0
+    map_error_decoder = decoders.LookupDecoder(pcm, max_weight=1, error_channel=error_channel)
+    map_error_result = map_error_decoder.decode(syndrome)
+    assert int((obs_matrix @ map_error_result % 2)[0]) == 0
+
+    # MAP obs_flip decoder: returns an error whose obs_flip is 1
+    map_obs_decoder = decoders.LookupDecoder(
+        pcm, max_weight=1, error_channel=error_channel, observable_flip_matrix=obs_matrix
+    )
+    map_obs_result = map_obs_decoder.decode(syndrome)
+    assert int((obs_matrix @ map_obs_result % 2)[0]) == 1
+
+    # Auto-extraction from DEM: when simplify=True, mechanisms with identical detector+observable
+    # patterns are merged, so the resulting DEM has fewer mechanisms.  Check obs_flip via the
+    # DEM's own observable_flip_matrix rather than the original (3-column) obs_matrix.
+    error_channel_arr = np.array(error_channel)
+    dem = decoders.DetectorErrorModelArrays.from_arrays(pcm, obs_matrix, error_channel_arr).to_dem()
+    dem_decoder = decoders.LookupDecoder(dem, max_weight=1)
+    dem_result = dem_decoder.decode(syndrome)
+    dem_arrays = decoders.DetectorErrorModelArrays(dem)
+    obs_flip_via_dem = int(
+        np.asarray(dem_arrays.observable_flip_matrix @ dem_result, dtype=int).ravel()[0] % 2
+    )
+    assert obs_flip_via_dem == 1
+
+    # DEM with no observables: observable_flip_matrix is not auto-extracted; decoder is backward
+    # compatible.  All three mechanisms share the same detector pattern so they get merged into one.
+    dem_no_obs = decoders.DetectorErrorModelArrays.from_arrays(pcm, None, error_channel_arr).to_dem()
+    no_obs_decoder = decoders.LookupDecoder(dem_no_obs, max_weight=1)
+    assert decoders.DetectorErrorModelArrays(dem_no_obs).num_observables == 0
+    assert np.any(no_obs_decoder.decode(syndrome) != 0)
+
+    # No penalty_func: observable_flip_matrix is a no-op (can't determine "most likely" without probs)
+    decoder_no_prob = decoders.LookupDecoder(pcm, max_weight=1)
+    decoder_with_obs_no_prob = decoders.LookupDecoder(
+        pcm, max_weight=1, observable_flip_matrix=obs_matrix
+    )
+    assert np.array_equal(decoder_no_prob.decode(syndrome), decoder_with_obs_no_prob.decode(syndrome))
+
+
 def test_ilp_decoder() -> None:
     """Decode using an integer linear program."""
     matrix, error, syndrome = get_toy_problem()

--- a/src/qldpc/decoders/custom_test.py
+++ b/src/qldpc/decoders/custom_test.py
@@ -112,13 +112,18 @@ def test_observable_lookup_decoding() -> None:
     assert np.array_equal(obs_matrix @ decoder.decode(syndrome), [0])
 
     # provided a DEM, the LookupDecoder will simplify and predict the most likely observable flip
-    decoder = decoders.LookupDecoder(dem, max_weight=1, simplify=False)
+    decoder = decoders.LookupDecoder(dem, max_weight=1)
     assert np.array_equal(obs_matrix @ decoder.decode(syndrome), [1])
 
     # The above example is "trivial" in the sense that simplifying the DEM is sufficient to predict
-    # the correct observable flips.  However, sometimes simplifying is not enough.  Consider the
-    # following DEM, in which each error has a unique (detector, observable) patterns, so
-    # simplifying changes nothing:
+    # the correct observable flips....
+    dem_arrays = decoders.DetectorErrorModelArrays(dem, simplify=True)
+    pcm, obs_matrix, error_probs = dem_arrays.get_arrays()
+    decoder = decoders.LookupDecoder(pcm, max_weight=1, error_channel=error_probs)
+    assert np.array_equal(obs_matrix @ decoder.decode(syndrome), [1])
+
+    # However, sometimes simplifying is not enough.  Consider th following DEM, in which each error
+    # has a unique (detector, observable) patterns, so simplifying changes nothing:
     dem = stim.DetectorErrorModel("""
         error(0.04) D0 D1  # E0: syndrome (1, 1), obs_flip=0
         error(0.25) D0     # E1: syndrome (1, 0), obs_flip=0

--- a/src/qldpc/decoders/custom_test.py
+++ b/src/qldpc/decoders/custom_test.py
@@ -101,47 +101,105 @@ def test_lookup_observable() -> None:
     answer than simply picking the single most likely error when degenerate errors (sharing the same
     observable flip) collectively outweigh a more probable individual error with a different flip.
     """
-    # Three mechanisms all trigger detector D0, giving syndrome (1,):
-    #   error(0.10) D0     — obs_flip=0, highest individual probability
-    #   error(0.09) D0 L0  — obs_flip=1
-    #   error(0.06) D0 L0  — obs_flip=1 (same pattern as above)
-    # simplify=False keeps both D0 L0 mechanisms separate so their probabilities accumulate.
-    # (With the default simplify=True they would be merged, and both decoders would agree.)
-    # Picking the single most likely error gives obs_flip=0.
-    # Summing per observable-flip class: obs_flip=0 total=0.10, obs_flip=1 total=0.15 → obs_flip=1 wins.
+
+    def get_obs_flip(da: decoders.DetectorErrorModelArrays, error: np.ndarray) -> int:
+        return int(np.asarray(da.observable_flip_matrix @ error, dtype=int).ravel()[0] % 2)
+
+    # --- Part 1: explicit PCM ---
+    # Three mechanisms all give syndrome (1,): p=0.10 (obs_flip=0), p=0.09 (obs_flip=1),
+    # p=0.06 (obs_flip=1).  The decoder without observable awareness picks the most likely
+    # individual error (p=0.10, obs_flip=0).  The observable-aware decoder sums per class:
+    # obs_flip=0 total=0.10, obs_flip=1 total=0.09+0.06=0.15 → obs_flip=1 wins.
+    pcm = np.array([[1, 1, 1]], dtype=int)
+    obs_matrix = np.array([[0, 1, 1]], dtype=int)
+    error_channel = np.array([0.10, 0.09, 0.06])
+    syndrome = np.array([1], dtype=int)
+
+    standard = decoders.LookupDecoder(pcm, max_weight=1, error_channel=error_channel)
+    assert int((obs_matrix @ standard.decode(syndrome) % 2)[0]) == 0  # most likely error
+
+    aware = decoders.LookupDecoder(
+        pcm, max_weight=1, error_channel=error_channel, observable_flip_matrix=obs_matrix
+    )
+    assert int((obs_matrix @ aware.decode(syndrome) % 2)[0]) == 1  # most likely observable flip
+
+    # --- Part 2: same scenario via DEM + simplify=False ---
+    # simplify=False keeps the two "D0 L0" mechanisms separate, reproducing the three-mechanism PCM.
     dem = stim.DetectorErrorModel("""
         error(0.10) D0
         error(0.09) D0 L0
         error(0.06) D0 L0
     """)
-    dem_arrays = decoders.DetectorErrorModelArrays(dem, simplify=False)
-    syndrome = np.array([1], dtype=int)
+    da = decoders.DetectorErrorModelArrays(dem, simplify=False)
 
-    # Standard decoder (no observable awareness): picks the single highest-probability error → obs_flip=0.
-    standard_decoder = decoders.LookupDecoder(
-        dem_arrays.detector_flip_matrix, max_weight=1, error_channel=dem_arrays.error_probs
+    standard_dem = decoders.LookupDecoder(
+        da.detector_flip_matrix, max_weight=1, error_channel=da.error_probs
     )
-    result_std = standard_decoder.decode(syndrome)
-    assert (
-        int(np.asarray(dem_arrays.observable_flip_matrix @ result_std, dtype=int).ravel()[0] % 2)
-        == 0
-    )
+    assert get_obs_flip(da, standard_dem.decode(syndrome)) == 0  # same result as Part 1
 
-    # Observable-aware decoder: uses the full DEM (observable_flip_matrix auto-extracted) → obs_flip=1.
-    obs_decoder = decoders.LookupDecoder(dem, max_weight=1, simplify=False)
-    result_obs = obs_decoder.decode(syndrome)
-    assert (
-        int(np.asarray(dem_arrays.observable_flip_matrix @ result_obs, dtype=int).ravel()[0] % 2)
-        == 1
+    aware_dem = decoders.LookupDecoder(dem, max_weight=1, simplify=False)
+    assert get_obs_flip(da, aware_dem.decode(syndrome)) == 1  # same result as Part 1
+
+    # --- Part 3: same DEM with default simplify=True ---
+    # simplify=True merges the two "D0 L0" mechanisms into one with combined p≈0.145 > 0.10,
+    # so the merged mechanism is simply the most likely error; a standard decoder initialized
+    # from the DEM already returns the correct obs_flip=1 without explicit observable tracking.
+    da_simplified = decoders.DetectorErrorModelArrays(dem)
+    decoder_simplified = decoders.LookupDecoder(dem, max_weight=1)
+    assert get_obs_flip(da_simplified, decoder_simplified.decode(syndrome)) == 1
+
+    # --- Part 4: max_weight=2 DEM where simplification is not enough ---
+    # Five mechanisms, all with unique (detector, observable) patterns so simplify changes nothing:
+    #   error(0.05) D0 D1   — M0: syndrome (1,1), obs_flip=0
+    #   error(0.25) D0      — M1: syndrome (1,0), obs_flip=0
+    #   error(0.10) D1      — M2: syndrome (0,1), obs_flip=0
+    #   error(0.10) D0 L0   — M3: syndrome (1,0), obs_flip=1
+    #   error(0.25) D1 L0   — M4: syndrome (0,1), obs_flip=1
+    # For syndrome (1,1), the most likely individual combination is M1+M4 (P≈0.048, obs_flip=1).
+    # But summing per class: obs_flip=0 = P(M0)+P(M1+M2)+P(M3+M4) ≈ 0.055
+    #                         obs_flip=1 = P(M1+M4)+P(M3+M2)       ≈ 0.053
+    # A decoder without observable awareness returns obs_flip=1; the observable-aware decoder
+    # correctly returns obs_flip=0.
+    dem4 = stim.DetectorErrorModel("""
+        error(0.05) D0 D1
+        error(0.25) D0
+        error(0.10) D1
+        error(0.10) D0 L0
+        error(0.25) D1 L0
+    """)
+    da4 = decoders.DetectorErrorModelArrays(dem4)
+    syndrome4 = np.array([1, 1], dtype=int)
+
+    standard4 = decoders.LookupDecoder(
+        da4.detector_flip_matrix, max_weight=2, error_channel=da4.error_probs
     )
+    assert get_obs_flip(da4, standard4.decode(syndrome4)) == 1  # most likely individual combination
+
+    aware4 = decoders.LookupDecoder(dem4, max_weight=2)
+    assert get_obs_flip(da4, aware4.decode(syndrome4)) == 0  # most likely observable flip
 
     # Providing an observable_flip_matrix without error probabilities raises an error.
     with pytest.raises(ValueError, match="stim.DetectorErrorModel, error_channel, or penalty_func"):
+        decoders.LookupDecoder(pcm, max_weight=1, observable_flip_matrix=obs_matrix)
+
+    # Providing both error_channel and penalty_func raises an error.
+    with pytest.raises(ValueError, match="both an error_channel and a penalty_func"):
         decoders.LookupDecoder(
-            dem_arrays.detector_flip_matrix,
-            max_weight=1,
-            observable_flip_matrix=dem_arrays.observable_flip_matrix,
+            pcm, max_weight=1, error_channel=error_channel, penalty_func=lambda v: 0.0
         )
+
+    # Providing a DEM alongside conflicting arguments raises an error.
+    with pytest.raises(ValueError, match="Cannot specify"):
+        decoders.LookupDecoder(dem4, max_weight=1, error_channel=da4.error_probs)
+
+    # The FieldArray branch: observable_flip_matrix is a galois FieldArray (quantum / non-binary use).
+    field = galois.GF(2)
+    pcm_gf2 = pcm.view(field)
+    obs_gf2 = obs_matrix.view(field)
+    aware_gf2 = decoders.LookupDecoder(
+        pcm_gf2, max_weight=1, error_channel=error_channel, observable_flip_matrix=obs_gf2
+    )
+    assert int((obs_matrix @ aware_gf2.decode(syndrome) % 2)[0]) == 1
 
 
 def test_ilp_decoder() -> None:

--- a/src/qldpc/decoders/custom_test.py
+++ b/src/qldpc/decoders/custom_test.py
@@ -26,6 +26,7 @@ import galois
 import numpy as np
 import pytest
 import scipy.sparse
+import stim
 
 from qldpc import codes, decoders, math
 
@@ -97,56 +98,60 @@ def test_lookup() -> None:
 
 
 def test_lookup_observable() -> None:
-    """Observable-flip-aware lookup decoding (MAP obs_flip vs MAP error)."""
-    # Toy problem: 1 detector, 3 error mechanisms.
-    # Mechanism 0: flips detector only (obs_flip 0), p=0.10
-    # Mechanism 1: flips detector and observable (obs_flip 1), p=0.09
-    # Mechanism 2: flips detector and observable (obs_flip 1), p=0.06
-    # For syndrome (1,), MAP error picks mechanism 0 (highest individual p),
-    # but MAP obs_flip picks obs_flip=1 because P(F=1|S) = 0.09+0.06 = 0.15 > P(F=0|S) = 0.10.
+    """Lookup decoding that targets the most likely observable flip for each syndrome.
+
+    The decoder groups errors by their observable flip value, sums probabilities within each group,
+    and returns an error from the group with the highest total probability.  This gives a different
+    answer than simply picking the single most likely error when degenerate errors (sharing the same
+    observable flip) collectively outweigh a more probable individual error with a different flip.
+    """
+    # Primary case: DEM with observables.  The observable flip matrix is auto-extracted.
+    # Two mechanisms both trigger detector D0:
+    #   error(0.08) D0     — no observable flip (obs_flip=0)
+    #   error(0.12) D0 L0  — flips observable L0 (obs_flip=1)
+    # The second mechanism is more likely, so the decoder should predict obs_flip=1 for syndrome (1,).
+    # Note: with a DEM, simplification merges mechanisms with identical patterns, so this example
+    # has exactly one mechanism per observable-flip class.  The explicit-matrix test below shows the
+    # case where summing over multiple mechanisms per class changes the answer.
+    dem = stim.DetectorErrorModel("""
+        error(0.08) D0
+        error(0.12) D0 L0
+    """)
+    dem_arrays = decoders.DetectorErrorModelArrays(dem)
+    decoder = decoders.LookupDecoder(dem, max_weight=1)
+    syndrome = np.array([1], dtype=int)
+    obs_flip = int(
+        np.asarray(dem_arrays.observable_flip_matrix @ decoder.decode(syndrome), dtype=int).ravel()[0]
+        % 2
+    )
+    assert obs_flip == 1
+
+    # When a DEM has no observables, no observable flip matrix is set and the decoder works normally.
+    dem_no_obs = stim.DetectorErrorModel("error(0.1) D0")
+    assert np.any(decoders.LookupDecoder(dem_no_obs, max_weight=1).decode(syndrome) != 0)
+
+    # Explicit matrix path: shows the case where summing probabilities changes the answer.
+    # Three mechanisms all give syndrome (1,):
+    #   mechanism 0: obs_flip=0, p=0.10  ← highest individual probability
+    #   mechanism 1: obs_flip=1, p=0.09
+    #   mechanism 2: obs_flip=1, p=0.06
+    # Picking the single most likely error gives obs_flip=0.
+    # Summing by observable-flip class: obs_flip=0 total=0.10, obs_flip=1 total=0.15 → obs_flip=1 wins.
     pcm = np.array([[1, 1, 1]], dtype=int)
     obs_matrix = np.array([[0, 1, 1]], dtype=int)
-    error_channel = [0.10, 0.09, 0.06]
-    syndrome = np.array([1], dtype=int)
+    error_channel = np.array([0.10, 0.09, 0.06])
 
-    # MAP error decoder (no observable_flip_matrix): returns mechanism-0 error → obs_flip 0
-    map_error_decoder = decoders.LookupDecoder(pcm, max_weight=1, error_channel=error_channel)
-    map_error_result = map_error_decoder.decode(syndrome)
-    assert int((obs_matrix @ map_error_result % 2)[0]) == 0
+    standard_decoder = decoders.LookupDecoder(pcm, max_weight=1, error_channel=error_channel)
+    assert int((obs_matrix @ standard_decoder.decode(syndrome) % 2)[0]) == 0
 
-    # MAP obs_flip decoder: returns an error whose obs_flip is 1
-    map_obs_decoder = decoders.LookupDecoder(
+    obs_decoder = decoders.LookupDecoder(
         pcm, max_weight=1, error_channel=error_channel, observable_flip_matrix=obs_matrix
     )
-    map_obs_result = map_obs_decoder.decode(syndrome)
-    assert int((obs_matrix @ map_obs_result % 2)[0]) == 1
+    assert int((obs_matrix @ obs_decoder.decode(syndrome) % 2)[0]) == 1
 
-    # Auto-extraction from DEM: when simplify=True, mechanisms with identical detector+observable
-    # patterns are merged, so the resulting DEM has fewer mechanisms.  Check obs_flip via the
-    # DEM's own observable_flip_matrix rather than the original (3-column) obs_matrix.
-    error_channel_arr = np.array(error_channel)
-    dem = decoders.DetectorErrorModelArrays.from_arrays(pcm, obs_matrix, error_channel_arr).to_dem()
-    dem_decoder = decoders.LookupDecoder(dem, max_weight=1)
-    dem_result = dem_decoder.decode(syndrome)
-    dem_arrays = decoders.DetectorErrorModelArrays(dem)
-    obs_flip_via_dem = int(
-        np.asarray(dem_arrays.observable_flip_matrix @ dem_result, dtype=int).ravel()[0] % 2
-    )
-    assert obs_flip_via_dem == 1
-
-    # DEM with no observables: observable_flip_matrix is not auto-extracted; decoder is backward
-    # compatible.  All three mechanisms share the same detector pattern so they get merged into one.
-    dem_no_obs = decoders.DetectorErrorModelArrays.from_arrays(pcm, None, error_channel_arr).to_dem()
-    no_obs_decoder = decoders.LookupDecoder(dem_no_obs, max_weight=1)
-    assert decoders.DetectorErrorModelArrays(dem_no_obs).num_observables == 0
-    assert np.any(no_obs_decoder.decode(syndrome) != 0)
-
-    # No penalty_func: observable_flip_matrix is a no-op (can't determine "most likely" without probs)
-    decoder_no_prob = decoders.LookupDecoder(pcm, max_weight=1)
-    decoder_with_obs_no_prob = decoders.LookupDecoder(
-        pcm, max_weight=1, observable_flip_matrix=obs_matrix
-    )
-    assert np.array_equal(decoder_no_prob.decode(syndrome), decoder_with_obs_no_prob.decode(syndrome))
+    # Providing an observable_flip_matrix without error probabilities raises an error.
+    with pytest.raises(AssertionError, match="error_channel or penalty_func"):
+        decoders.LookupDecoder(pcm, max_weight=1, observable_flip_matrix=obs_matrix)
 
 
 def test_ilp_decoder() -> None:

--- a/src/qldpc/decoders/custom_test.py
+++ b/src/qldpc/decoders/custom_test.py
@@ -95,6 +95,7 @@ def test_lookup() -> None:
 
 def test_observable_lookup_decoding() -> None:
     """Lookup decoding can identify the most likely observable flip for each syndrome."""
+    obs_matrix: math.IntegerArray
 
     # toy detector error model and error syndrome
     dem = stim.DetectorErrorModel("""

--- a/src/qldpc/decoders/custom_test.py
+++ b/src/qldpc/decoders/custom_test.py
@@ -92,10 +92,6 @@ def test_lookup() -> None:
     decoder = decoders.get_decoder_lookup(dem, max_weight=2)
     assert np.array_equal(error, decoder.decode(syndrome))
 
-    # passing an explicit penalty_func alongside a DEM emits a warning
-    with pytest.warns(UserWarning, match="will override"):
-        decoders.LookupDecoder(dem, max_weight=2, penalty_func=lambda v: float(np.count_nonzero(v)))
-
 
 def test_lookup_observable() -> None:
     """Lookup decoding that targets the most likely observable flip for each syndrome.
@@ -105,53 +101,47 @@ def test_lookup_observable() -> None:
     answer than simply picking the single most likely error when degenerate errors (sharing the same
     observable flip) collectively outweigh a more probable individual error with a different flip.
     """
-    # Primary case: DEM with observables.  The observable flip matrix is auto-extracted.
-    # Two mechanisms both trigger detector D0:
-    #   error(0.08) D0     — no observable flip (obs_flip=0)
-    #   error(0.12) D0 L0  — flips observable L0 (obs_flip=1)
-    # The second mechanism is more likely, so the decoder should predict obs_flip=1 for syndrome (1,).
-    # Note: with a DEM, simplification merges mechanisms with identical patterns, so this example
-    # has exactly one mechanism per observable-flip class.  The explicit-matrix test below shows the
-    # case where summing over multiple mechanisms per class changes the answer.
-    dem = stim.DetectorErrorModel("""
-        error(0.08) D0
-        error(0.12) D0 L0
-    """)
-    dem_arrays = decoders.DetectorErrorModelArrays(dem)
-    decoder = decoders.LookupDecoder(dem, max_weight=1)
-    syndrome = np.array([1], dtype=int)
-    obs_flip = int(
-        np.asarray(dem_arrays.observable_flip_matrix @ decoder.decode(syndrome), dtype=int).ravel()[0]
-        % 2
-    )
-    assert obs_flip == 1
-
-    # When a DEM has no observables, no observable flip matrix is set and the decoder works normally.
-    dem_no_obs = stim.DetectorErrorModel("error(0.1) D0")
-    assert np.any(decoders.LookupDecoder(dem_no_obs, max_weight=1).decode(syndrome) != 0)
-
-    # Explicit matrix path: shows the case where summing probabilities changes the answer.
-    # Three mechanisms all give syndrome (1,):
-    #   mechanism 0: obs_flip=0, p=0.10  ← highest individual probability
-    #   mechanism 1: obs_flip=1, p=0.09
-    #   mechanism 2: obs_flip=1, p=0.06
+    # Three mechanisms all trigger detector D0, giving syndrome (1,):
+    #   error(0.10) D0     — obs_flip=0, highest individual probability
+    #   error(0.09) D0 L0  — obs_flip=1
+    #   error(0.06) D0 L0  — obs_flip=1 (same pattern as above)
+    # simplify=False keeps both D0 L0 mechanisms separate so their probabilities accumulate.
+    # (With the default simplify=True they would be merged, and both decoders would agree.)
     # Picking the single most likely error gives obs_flip=0.
-    # Summing by observable-flip class: obs_flip=0 total=0.10, obs_flip=1 total=0.15 → obs_flip=1 wins.
-    pcm = np.array([[1, 1, 1]], dtype=int)
-    obs_matrix = np.array([[0, 1, 1]], dtype=int)
-    error_channel = np.array([0.10, 0.09, 0.06])
+    # Summing per observable-flip class: obs_flip=0 total=0.10, obs_flip=1 total=0.15 → obs_flip=1 wins.
+    dem = stim.DetectorErrorModel("""
+        error(0.10) D0
+        error(0.09) D0 L0
+        error(0.06) D0 L0
+    """)
+    dem_arrays = decoders.DetectorErrorModelArrays(dem, simplify=False)
+    syndrome = np.array([1], dtype=int)
 
-    standard_decoder = decoders.LookupDecoder(pcm, max_weight=1, error_channel=error_channel)
-    assert int((obs_matrix @ standard_decoder.decode(syndrome) % 2)[0]) == 0
-
-    obs_decoder = decoders.LookupDecoder(
-        pcm, max_weight=1, error_channel=error_channel, observable_flip_matrix=obs_matrix
+    # Standard decoder (no observable awareness): picks the single highest-probability error → obs_flip=0.
+    standard_decoder = decoders.LookupDecoder(
+        dem_arrays.detector_flip_matrix, max_weight=1, error_channel=dem_arrays.error_probs
     )
-    assert int((obs_matrix @ obs_decoder.decode(syndrome) % 2)[0]) == 1
+    result_std = standard_decoder.decode(syndrome)
+    assert (
+        int(np.asarray(dem_arrays.observable_flip_matrix @ result_std, dtype=int).ravel()[0] % 2)
+        == 0
+    )
+
+    # Observable-aware decoder: uses the full DEM (observable_flip_matrix auto-extracted) → obs_flip=1.
+    obs_decoder = decoders.LookupDecoder(dem, max_weight=1, simplify=False)
+    result_obs = obs_decoder.decode(syndrome)
+    assert (
+        int(np.asarray(dem_arrays.observable_flip_matrix @ result_obs, dtype=int).ravel()[0] % 2)
+        == 1
+    )
 
     # Providing an observable_flip_matrix without error probabilities raises an error.
-    with pytest.raises(AssertionError, match="error_channel or penalty_func"):
-        decoders.LookupDecoder(pcm, max_weight=1, observable_flip_matrix=obs_matrix)
+    with pytest.raises(ValueError, match="stim.DetectorErrorModel, error_channel, or penalty_func"):
+        decoders.LookupDecoder(
+            dem_arrays.detector_flip_matrix,
+            max_weight=1,
+            observable_flip_matrix=dem_arrays.observable_flip_matrix,
+        )
 
 
 def test_ilp_decoder() -> None:

--- a/src/qldpc/decoders/dems.py
+++ b/src/qldpc/decoders/dems.py
@@ -153,6 +153,7 @@ class DetectorErrorModelArrays:
         return [
             (detectors, observables, prob)
             for (detectors, observables), prob in merged_errors.items()
+            if (detectors or observables) and prob  # drop inconsequential error mechanisms
         ]
 
     @staticmethod

--- a/src/qldpc/decoders/dems.py
+++ b/src/qldpc/decoders/dems.py
@@ -18,7 +18,6 @@ limitations under the License.
 from __future__ import annotations
 
 import collections
-import itertools
 from collections.abc import Collection
 
 import numpy as np

--- a/src/qldpc/decoders/dems.py
+++ b/src/qldpc/decoders/dems.py
@@ -146,16 +146,14 @@ class DetectorErrorModelArrays:
         errors: list[tuple[frozenset[int], frozenset[int], float]],
     ) -> list[tuple[frozenset[int], frozenset[int], float]]:
         """Merge circuit errors that flip the same detectors and observables."""
-        # organize errors by the detectors and observables that they flip
-        merged_errors = collections.defaultdict(list)
-        for detector_ids, observable_ids, probability in errors:
-            if (detector_ids or observable_ids) and probability:
-                merged_errors[detector_ids, observable_ids].append(probability)
-
-        # combine the probabilities of occurrence for equivalent error mechanisms
+        merged_errors: dict[tuple[frozenset[int], frozenset[int]], float] = {}
+        for detector_ids, observable_ids, prob in errors:
+            key = (detector_ids, observable_ids)
+            previous_prob = merged_errors.get(key, 0.0)
+            merged_errors[key] = previous_prob + prob - 2 * previous_prob * prob
         return [
-            (detectors, observables, _probability_of_an_odd_number_of_events(probabilities))
-            for (detectors, observables), probabilities in merged_errors.items()
+            (detectors, observables, prob)
+            for (detectors, observables), prob in merged_errors.items()
         ]
 
     @staticmethod
@@ -252,19 +250,3 @@ class DetectorErrorModelArrays:
 def _values_that_occur_an_odd_number_of_times(items: Collection[int]) -> frozenset[int]:
     """Subset of items that occur an odd number of times."""
     return frozenset([item for item, count in collections.Counter(items).items() if count % 2])
-
-
-def _probability_of_an_odd_number_of_events(event_probabilities: Collection[float]) -> float:
-    """Identify the probability that an odd number of (otherwise independent) events occurs."""
-    net_probability = 0.0
-    num_events = len(event_probabilities)
-    for num_events_that_occur in range(1, num_events + 1, 2):
-        for events_that_occur in itertools.combinations(range(num_events), num_events_that_occur):
-            probability_that_these_events_occur = np.prod(
-                [
-                    prob if event in events_that_occur else 1 - prob
-                    for event, prob in enumerate(event_probabilities)
-                ]
-            )
-            net_probability += float(probability_that_these_events_occur)
-    return net_probability

--- a/src/qldpc/decoders/retrieval.py
+++ b/src/qldpc/decoders/retrieval.py
@@ -194,7 +194,7 @@ def _to_ldpc_inputs(
     pcm_or_dem: IntegerArray | stim.DetectorErrorModel,
     error_rate: float,
     error_channel: npt.NDArray[np.floating] | Sequence[float] | None,
-) -> tuple[IntegerArray, npt.NDArray[np.floating] | Sequence[float]]:
+) -> tuple[IntegerArray, list[float]]:
     """Post-process the arguments to ldpc decoders."""
     if isinstance(pcm_or_dem, stim.DetectorErrorModel):
         dem_arrays = DetectorErrorModelArrays(pcm_or_dem)
@@ -203,7 +203,7 @@ def _to_ldpc_inputs(
     else:
         pcm = pcm_or_dem
         error_channel = [error_rate] * pcm.shape[1] if error_channel is None else error_channel
-    return pcm, error_channel
+    return pcm, list(error_channel)
 
 
 def get_decoder_MWPM(

--- a/src/qldpc/decoders/retrieval.py
+++ b/src/qldpc/decoders/retrieval.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 
 import inspect
 import sys
-import warnings
 from collections.abc import Sequence
 
 import galois
@@ -239,14 +238,9 @@ def get_decoder_MWPM(
     if isinstance(pcm_or_dem, stim.DetectorErrorModel):
         dem_arrays = DetectorErrorModelArrays(pcm_or_dem)
         pcm = dem_arrays.detector_flip_matrix
-        if decoder_args.get("error_probabilities") is not None:
-            warnings.warn(
-                "Explicitly provided error_probabilities will override the error probabilities of"
-                " the provided detector error model",
-                stacklevel=2,
-            )
-        else:
-            decoder_args["error_probabilities"] = dem_arrays.error_probs
+        if decoder_args.get("weights") is not None:  # pragma: no cover
+            raise ValueError("Cannot set error weights when initializing a MWPM decoder from a DEM")
+        decoder_args["weights"] = np.log((1 - dem_arrays.error_probs) / dem_arrays.error_probs)
     else:
         pcm = pcm_or_dem
 

--- a/src/qldpc/decoders/retrieval_test.py
+++ b/src/qldpc/decoders/retrieval_test.py
@@ -71,10 +71,6 @@ def test_decoding() -> None:
     assert np.array_equal(error, decoders.decode(dem, syndrome, with_MWPM=True))
     assert np.array_equal(error, decoders.decode(dem, syndrome, with_ILP=True))
 
-    # passing explicit error_probabilities alongside a DEM emits a warning
-    with pytest.warns(UserWarning, match="will override"):
-        decoders.decode(dem, syndrome, with_MWPM=True, error_probabilities=[0.1, 0.1])
-
     # add a non-graphlike error mechanism, which MWPM can ignore upon request
     matrix = np.hstack([matrix, np.ones((3, 1))])
     error = np.concatenate([error, [0]])

--- a/src/qldpc/decoders/sinter.py
+++ b/src/qldpc/decoders/sinter.py
@@ -51,6 +51,14 @@ class SinterDecoder(Decoder, sinter.Decoder):
                 custom decoder from a detector error model.
         """
         self.decoder_kwargs = decoder_kwargs
+        if (
+            "priors_arg" in decoder_kwargs or "log_likelihood_priors" in decoder_kwargs
+        ):  # pragma: no cover
+            raise ValueError(
+                "The 'priors_arg' and 'log_likelihood_priors' arguments to a SinterDecoder are"
+                " DEFUNCT and should no longer be necessary.\nIf you need these arguments restored,"
+                " please open an issue at https://github.com/qLDPCOrg/qLDPC/issues"
+            )
 
     def compile_decoder_for_dem(
         self, dem: stim.DetectorErrorModel, *, simplify: bool = True
@@ -233,7 +241,7 @@ class SubgraphDecoder(SinterDecoder):
             **decoder_kwargs: Arguments to pass to qldpc.decoders.get_decoder when compiling a
                 custom decoder from a detector error model.
         """
-        self.decoder_kwargs = decoder_kwargs
+        SinterDecoder.__init__(**decoder_kwargs)
 
         # consistency checks
         self.num_subgraphs = len(subgraph_detectors)
@@ -402,7 +410,7 @@ class SequentialWindowDecoder(SinterDecoder):
             **decoder_kwargs: Arguments to pass to qldpc.decoders.get_decoder when compiling a
                 custom decoder from a detector error model.
         """
-        self.decoder_kwargs = decoder_kwargs
+        SinterDecoder.__init__(**decoder_kwargs)
 
         assert commit_regions is None or len(detection_regions) == len(commit_regions)
         self.windows = [
@@ -614,7 +622,7 @@ class SlidingWindowDecoder(SequentialWindowDecoder):
             **decoder_kwargs: Arguments to pass to qldpc.decoders.get_decoder when compiling a
                 custom decoder from a detector error model.
         """
-        self.decoder_kwargs = decoder_kwargs
+        SinterDecoder.__init__(**decoder_kwargs)
 
         if not window_size >= stride > 0:  # pragma: no cover
             raise ValueError(

--- a/src/qldpc/decoders/sinter.py
+++ b/src/qldpc/decoders/sinter.py
@@ -241,7 +241,7 @@ class SubgraphDecoder(SinterDecoder):
             **decoder_kwargs: Arguments to pass to qldpc.decoders.get_decoder when compiling a
                 custom decoder from a detector error model.
         """
-        SinterDecoder.__init__(**decoder_kwargs)
+        SinterDecoder.__init__(self, **decoder_kwargs)
 
         # consistency checks
         self.num_subgraphs = len(subgraph_detectors)
@@ -410,7 +410,7 @@ class SequentialWindowDecoder(SinterDecoder):
             **decoder_kwargs: Arguments to pass to qldpc.decoders.get_decoder when compiling a
                 custom decoder from a detector error model.
         """
-        SinterDecoder.__init__(**decoder_kwargs)
+        SinterDecoder.__init__(self, **decoder_kwargs)
 
         assert commit_regions is None or len(detection_regions) == len(commit_regions)
         self.windows = [
@@ -622,7 +622,7 @@ class SlidingWindowDecoder(SequentialWindowDecoder):
             **decoder_kwargs: Arguments to pass to qldpc.decoders.get_decoder when compiling a
                 custom decoder from a detector error model.
         """
-        SinterDecoder.__init__(**decoder_kwargs)
+        SinterDecoder.__init__(self, **decoder_kwargs)
 
         if not window_size >= stride > 0:  # pragma: no cover
             raise ValueError(

--- a/src/qldpc/decoders/sinter.py
+++ b/src/qldpc/decoders/sinter.py
@@ -38,13 +38,7 @@ class DecoderNotCompiledError(Exception):
 class SinterDecoder(Decoder, sinter.Decoder):
     """Decoder usable by Sinter for decoding circuit errors."""
 
-    def __init__(
-        self,
-        *,
-        priors_arg: str | None = None,
-        log_likelihood_priors: bool = False,
-        **decoder_kwargs: object,
-    ) -> None:
+    def __init__(self, **decoder_kwargs: object) -> None:
         """Initialize a SinterDecoder.
 
         A SinterDecoder is used by Sinter to decode detection events from a detector error model to
@@ -53,32 +47,10 @@ class SinterDecoder(Decoder, sinter.Decoder):
         See help(sinter.Decoder) for additional information.
 
         Args:
-            priors_arg: The name of the keyword argument to which to pass the probabilities of
-                circuit error likelihoods.  This argument is only necessary for custom decoders.
-            log_likelihood_priors: If True, instead of error probabilities p, pass log-likelihoods
-                np.log((1 - p) / p) to the priors_arg.  This argument is only necessary for custom
-                decoders.  Default: False (unless additionalled passed the argument with_MWPM=True).
             **decoder_kwargs: Arguments to pass to qldpc.decoders.get_decoder when compiling a
                 custom decoder from a detector error model.
         """
-        self.priors_arg = priors_arg
-        self.log_likelihood_priors = log_likelihood_priors
         self.decoder_kwargs = decoder_kwargs
-
-        if self.priors_arg is None:
-            # address some known cases
-            if (
-                decoder_kwargs.get("with_lookup")
-                or decoder_kwargs.get("with_BP_OSD")
-                or decoder_kwargs.get("with_BP_LSD")
-                or decoder_kwargs.get("with_BF")
-            ):
-                self.priors_arg = "error_channel"
-            if decoder_kwargs.get("with_RBP"):
-                self.priors_arg = "error_priors"
-            if decoder_kwargs.get("with_MWPM"):
-                self.priors_arg = "weights"
-                self.log_likelihood_priors = True
 
     def compile_decoder_for_dem(
         self, dem: stim.DetectorErrorModel, *, simplify: bool = True
@@ -88,24 +60,10 @@ class SinterDecoder(Decoder, sinter.Decoder):
         See help(sinter.Decoder) for additional information.
         """
         dem_arrays = DetectorErrorModelArrays(dem, simplify=simplify)
-        decoder = self.get_configured_decoder(dem_arrays)
+        decoder = get_decoder(dem_arrays.to_dem(), **self.decoder_kwargs)
         if getattr(decoder, "has_erasure_bit", False):
             dem_arrays = dem_arrays.with_erasure()
         return CompiledSinterDecoder(dem_arrays, decoder)
-
-    def get_configured_decoder(self, dem_arrays: DetectorErrorModelArrays) -> Decoder:
-        """Configure a Decoder from the given DetectorErrorModelArrays."""
-        if self.priors_arg:
-            priors = dem_arrays.error_probs
-            if self.log_likelihood_priors:
-                priors = np.log((1 - priors) / priors)
-            priors_kwarg = {self.priors_arg: list(priors)}
-        else:
-            priors_kwarg = {}
-        decoder = get_decoder(
-            dem_arrays.detector_flip_matrix, **self.decoder_kwargs, **priors_kwarg
-        )
-        return decoder
 
     def decode(self, syndrome: npt.NDArray[np.int_]) -> npt.NDArray[np.int_]:
         """Decode an error syndrome and return an inferred error."""
@@ -259,9 +217,6 @@ class SubgraphDecoder(SinterDecoder):
         self,
         subgraph_detectors: Sequence[Collection[int]],
         subgraph_observables: Sequence[Collection[int]] | None = None,
-        *,
-        priors_arg: str | None = None,
-        log_likelihood_priors: bool = False,
         **decoder_kwargs: object,
     ) -> None:
         """Initialize a SinterDecoder that splits a detector error model into disjoint subgraphs.
@@ -275,14 +230,11 @@ class SubgraphDecoder(SinterDecoder):
             subgraph_detectors: A sequence containing one set of detectors per subgraph.
             subgraph_observables: A sequence containing one set of observables per subgraph; or None
                 to indicate that every subgraph should decode every observable.  Default: None.
-            priors_arg: The keyword argument to which to pass the probabilities of circuit error
-                likelihoods.  This argument is only necessary for custom decoders.
-            log_likelihood_priors: If True, instead of error probabilities p, pass log-likelihoods
-                np.log((1 - p) / p) to the priors_arg.  This argument is only necessary for custom
-                decoders.  Default: False (unless decoding with MWPM).
             **decoder_kwargs: Arguments to pass to qldpc.decoders.get_decoder when compiling a
                 custom decoder from a detector error model.
         """
+        self.decoder_kwargs = decoder_kwargs
+
         # consistency checks
         self.num_subgraphs = len(subgraph_detectors)
         num_observable_sets = None if subgraph_observables is None else len(subgraph_observables)
@@ -295,13 +247,6 @@ class SubgraphDecoder(SinterDecoder):
         self.subgraph_detectors = [sorted(dets) for dets in subgraph_detectors]
         self.subgraph_observables = (
             None if subgraph_observables is None else [sorted(obs) for obs in subgraph_observables]
-        )
-
-        SinterDecoder.__init__(
-            self,
-            priors_arg=priors_arg,
-            log_likelihood_priors=log_likelihood_priors,
-            **decoder_kwargs,
         )
 
     def compile_decoder_for_dem(
@@ -440,9 +385,6 @@ class SequentialWindowDecoder(SinterDecoder):
         self,
         detection_regions: Sequence[Collection[int]],
         commit_regions: Sequence[Collection[int]] | None = None,
-        *,
-        priors_arg: str | None = None,
-        log_likelihood_priors: bool = False,
         **decoder_kwargs: object,
     ) -> None:
         """Initialize a SinterDecoder that splits a detector error model into windows.
@@ -457,14 +399,11 @@ class SequentialWindowDecoder(SinterDecoder):
             commit_regions: A sequence containing a set of detectors for each window, or None, in
                 which case the commit region of each window is equal to its detection regions.
                 Default: None.
-            priors_arg: The keyword argument to which to pass the probabilities of circuit error
-                likelihoods.  This argument is only necessary for custom decoders.
-            log_likelihood_priors: If True, instead of error probabilities p, pass log-likelihoods
-                np.log((1 - p) / p) to the priors_arg.  This argument is only necessary for custom
-                decoders.  Default: False (unless decoding with MWPM).
             **decoder_kwargs: Arguments to pass to qldpc.decoders.get_decoder when compiling a
                 custom decoder from a detector error model.
         """
+        self.decoder_kwargs = decoder_kwargs
+
         assert commit_regions is None or len(detection_regions) == len(commit_regions)
         self.windows = [
             (list(d_detectors), list(c_detectors))
@@ -473,12 +412,6 @@ class SequentialWindowDecoder(SinterDecoder):
             )
             if d_detectors
         ]
-        SinterDecoder.__init__(
-            self,
-            priors_arg=priors_arg,
-            log_likelihood_priors=log_likelihood_priors,
-            **decoder_kwargs,
-        )
 
     def compile_decoder_for_dem(
         self, dem: stim.DetectorErrorModel, *, simplify: bool = True
@@ -505,7 +438,7 @@ class SequentialWindowDecoder(SinterDecoder):
                 dem_arrays.observable_flip_matrix[:, d_errors],
                 dem_arrays.error_probs[d_errors],
             )
-            window_decoder = self.get_configured_decoder(window_dem_arrays)
+            window_decoder = get_decoder(window_dem_arrays.to_dem(), **self.decoder_kwargs)
             if getattr(window_decoder, "has_erasure_bit", False):
                 raise NotImplementedError(
                     f"{type(self)} does not yet support erasure decoding.\nIf you would like to see "
@@ -655,9 +588,6 @@ class SlidingWindowDecoder(SequentialWindowDecoder):
         stride: int,
         detector_subsets: Collection[Collection[int]] | None = None,
         detector_to_time: Callable[[int], int] | None = None,
-        *,
-        priors_arg: str | None = None,
-        log_likelihood_priors: bool = False,
         **decoder_kwargs: object,
     ) -> None:
         """Initialize a SinterDecoder that splits a detector error model into temporal windows.
@@ -681,14 +611,11 @@ class SlidingWindowDecoder(SequentialWindowDecoder):
                 WARNING: if a detector_to_time mapping is not None, it will be assumed to be
                 both valid compatible with any detector error model that this decoder is later
                 compiled to with SlidingWindowDecoder.compile_decoder_for_dem.
-            priors_arg: The keyword argument to which to pass the probabilities of circuit error
-                likelihoods.  This argument is only necessary for custom decoders.
-            log_likelihood_priors: If True, instead of error probabilities p, pass log-likelihoods
-                np.log((1 - p) / p) to the priors_arg.  This argument is only necessary for custom
-                decoders.  Default: False (unless decoding with MWPM).
             **decoder_kwargs: Arguments to pass to qldpc.decoders.get_decoder when compiling a
                 custom decoder from a detector error model.
         """
+        self.decoder_kwargs = decoder_kwargs
+
         if not window_size >= stride > 0:  # pragma: no cover
             raise ValueError(
                 f"{type(self).__name__} must have window_size >= stride > 0"
@@ -699,12 +626,6 @@ class SlidingWindowDecoder(SequentialWindowDecoder):
         self.stride = stride
         self.detector_subsets = detector_subsets
         self.detector_to_time = detector_to_time
-        SinterDecoder.__init__(
-            self,
-            priors_arg=priors_arg,
-            log_likelihood_priors=log_likelihood_priors,
-            **decoder_kwargs,
-        )
 
     def compile_decoder_for_dem(
         self, dem: stim.DetectorErrorModel, *, simplify: bool = True

--- a/src/qldpc/decoders/sinter_test.py
+++ b/src/qldpc/decoders/sinter_test.py
@@ -39,13 +39,11 @@ def test_sinter_decoder() -> None:
     expected_flips = np.packbits(observable_flips, bitorder="little", axis=1)
 
     # try decoders with and without a decode_batch method
-    for decoder, priors_arg in [
-        (decoders.SinterDecoder(with_BP_OSD=True), "error_channel"),
-        (decoders.SinterDecoder(with_RBP="MinSumBPDecoderF32"), "error_priors"),
-        (decoders.SinterDecoder(with_MWPM=True), "weights"),
+    for decoder in [
+        decoders.SinterDecoder(with_BP_OSD=True),
+        decoders.SinterDecoder(with_RBP="MinSumBPDecoderF32"),
+        decoders.SinterDecoder(with_MWPM=True),
     ]:
-        assert decoder.priors_arg == priors_arg
-
         compiled_decoder = decoder.compile_decoder_for_dem(dem)
         predicted_flips = compiled_decoder.decode_shots_bit_packed(bit_packed_shots)
         assert np.array_equal(predicted_flips, expected_flips)
@@ -69,16 +67,6 @@ def test_sinter_decoder() -> None:
         compiled_decoder.decode_shots_bit_packed(bit_packed_shots),
         np.zeros_like(expected_flips),
     )
-
-
-def test_sinter_decoder_without_priors() -> None:
-    """SinterDecoder with a static decoder leaves priors_arg unset."""
-    matrix = np.eye(3, 2, dtype=int)
-    static = decoders.get_decoder_lookup(matrix, max_weight=2)
-    decoder = decoders.SinterDecoder(static_decoder=static)
-    assert decoder.priors_arg is None
-    dem = decoders.DetectorErrorModelArrays.from_arrays(matrix, None, 1e-3).to_dem()
-    decoder.compile_decoder_for_dem(dem)
 
 
 def test_subgraph_decoding() -> None:


### PR DESCRIPTION
Also make `SinterDecoder` construct an inner `Decoder` from a DEM rather than a PCM.  This allows for the automatic extraction of an `observable_flip_matrix`.