### PR TITLE
Add group lift to right-regular antirepresentation

### DIFF
--- a/src/qldpc/abstract/groups.py
+++ b/src/qldpc/abstract/groups.py
@@ -128,8 +128,8 @@ class Group:
 
     A group naturally comes equipped with a "regular lift" that maps each group member to a
     permutation matrix corresponding to the regular representation of the group.  The regular
-    representation of a group represents group members by how they act on the group itself (from the
-    left); see https://en.wikipedia.org/wiki/Regular_representation.
+    representation of a group represents group members by how they act on the group itself.
+    See https://en.wikipedia.org/wiki/Regular_representation.
 
     A group may additionally be equipped with a custom lift to an orthogonal matrix over a finite
     field, for which the group action corresponds to matrix multiplication.  If no lift is provided,
@@ -271,21 +271,26 @@ class Group:
 
     @functools.cache
     def regular_lift(self, member: GroupMember, *, right: bool = False) -> npt.NDArray[np.int_]:
-        r"""Lift a group member to its regular representation.
+        """Lift a group member to its regular representation.
 
-        The regular representation encodes group action into matrix multiplication.
-        If Vec : G -> F_2^{|G|} maps group members to standard basis vectors and g,h ∈ G, then
+        By default, this method lifts a group member to its left-regular representation.
+        Specifically, if Vec : G -> F_2^{|G|} maps group members to standard basis vectors and
+        g,h ∈ G, then
             G.regular_lift(g) @ Vec(h) = Vec(g·h).
-        If right is True, this method lifts a group member to its right-regular representation,
+
+        If right is True, this method lifts a group member to its right-regular anti-representation,
         defined by
-            G.regular_lift(g, right=True) @ Vec(h) = Vec(h·g^{-1}).
+            G.regular_lift(g, right=True) @ Vec(h) = Vec(h·g).
+        The right-regular representation of group member is then
+            G.regular_lift(g, right=True).T = G.regular_lift(~g, right=True),
+        where ~g = g**-1 is the inverse of g.
 
         See:
         - https://en.wikipedia.org/wiki/Regular_representation
         """
         matrix = np.zeros([self.order] * 2, dtype=int)
         for ii, hh in enumerate(self.generate()):
-            jj = self.index(member * hh) if not right else self.index(hh * ~member)
+            jj = self.index(hh * member) if right else self.index(member * hh)
             matrix[jj, ii] = 1
         return matrix
 
@@ -295,11 +300,25 @@ class Group:
 
         The adjoint representation captures how group members get transformed by conjugation.
         If Vec : G -> F_2^{|G|} lifts group members to standard basis vectors and g,h ∈ G, then
-            adjoint_lift(g) @ Vec(h) = Vec(g·h·g^{-1}).
+            adjoint_lift(g) @ Vec(h) = Vec(g·h·~g),
+        where ~g = g**-1 is the inverse of g.
 
         If the group is abelian, the adjoint lift of every group member is the identity matrix.
         """
-        return self.regular_lift(member) @ self.regular_lift(member, right=True)
+        return self.regular_lift(member) @ self.regular_lift(member, right=True).T
+
+    @functools.cached_property
+    def inversion_matrix(self) -> npt.NDArray[np.int_]:
+        """The matrix that maps any group member g ∈ G to its inverse ~g = g**-1.
+
+        If Vec : G -> F_2^{|G|} lifts group members to standard basis vectors and g ∈ G, then
+            G.inversion_matrix @ Vec(g) = Vec(~g),
+        where ~g = g**-1 is the inverse of g.
+        """
+        matrix = np.zeros([self.order] * 2, dtype=int)
+        for ii, gg in enumerate(self.generate()):
+            matrix[self.index(~gg), ii] = 1
+        return matrix
 
     def lift(self, member: GroupMember) -> npt.NDArray[np.int_]:
         """Lift a group member to a representation by an orthogonal matrix."""
@@ -309,18 +328,6 @@ class Group:
     def lift_dim(self) -> int:
         """Dimension of the representation for this group."""
         return self.order if self._lift is None else self.lift(self.generators[0]).shape[0]
-
-    @functools.cached_property
-    def inversion_matrix(self) -> npt.NDArray[np.int_]:
-        """The matrix that maps any group member g ∈ G to its inverse g^{-1} = g.T.
-
-        If Vec : G -> F_2^{|G|} lifts group members to standard basis vectors and g ∈ G, then
-            G.inversion_matrix @ Vec(g) = Vec(g^{-1}).
-        """
-        matrix = np.zeros([self.order] * 2, dtype=int)
-        for ii, gg in enumerate(self.generate()):
-            matrix[self.index(~gg), ii] = 1
-        return matrix
 
     @functools.cached_property
     def table(self) -> npt.NDArray[np.int_]:

--- a/src/qldpc/abstract/groups_test.py
+++ b/src/qldpc/abstract/groups_test.py
@@ -135,7 +135,7 @@ def assert_valid_lifts(group: abstract.Group) -> None:
     # the inversion matrix converts between left- and right-regular representations
     assert all(
         np.array_equal(
-            group.regular_lift(gg, right=True),
+            group.regular_lift(gg, right=True).T,
             group.inversion_matrix @ group.regular_lift(gg) @ group.inversion_matrix,
         )
         for gg in group_members

--- a/src/qldpc/abstract/rings.py
+++ b/src/qldpc/abstract/rings.py
@@ -416,25 +416,19 @@ class RingMember:
         )
 
     def regular_lift(self, *, right: bool = False) -> galois.FieldArray:
-        """Construct a matrix that encodes multiplication in the ring by matrix multiplication.
+        """Lift a ring member to its regular representation.
 
-        By default, the matrix constructed by this method represents multiplication from the left,
-        meaning that if r and s are ring members, then
+        By default, this method lifts a ring member to the regular representation induced by
+        multiplication from the left.  Specifically, if r and s are ring members, then
             r.regular_lift() @ s.to_vector() = (r * s).to_vector().
-        If right is True, then matrix multiplication corresponds to ring multiplication from the
-        right, meaning
-            r.regular_lift(right=True) @ s.to_vector() = (s * r).to_vector().
 
-        A potential point of confusion: right-multiplication in the ring should not be confused with
-        the right-regular representation of group members, which also requires taking the inverse of
-        group members.
+        If right is True, this method lifts a ring member to its regular representation in the
+        opposite ring, such that matrix multiplication corresponds to ring multiplication from the
+        right:
+            r.regular_lift(right=True) @ s.to_vector() = (s * r).to_vector().
+        See https://en.wikipedia.org/wiki/Opposite_ring.
         """
-        if not right:
-            terms = (val * self.ring.regular_lift(member) for val, member in self if val)
-        else:
-            terms = (
-                val * self.ring.regular_lift(~member, right=True) for val, member in self if val
-            )
+        terms = (val * self.ring.regular_lift(member, right=right) for val, member in self if val)
         return (
             functools.reduce(operator.add, terms)
             if bool(self)


### PR DESCRIPTION
Previously `Group.regular_lift(g, right=True)` lifted to the right-regular representation.  For consistency with `RingMember.regular_lift(r, right=True)`, which lifts to a matrix that encodes multiplication from the right (because a right-regular representation of a ring is generally not defined), the former now lifts to the right-regular **_anti_**-representation.  The right-regular representation can be recovered by `Group.regular_lift(g, right=True).T = Group.regular_lift(~g, right=True)`.

See docstrings of `Group.regular_lift` and `RingMember.regular_lift` for additional information.