### PR TITLE
Add `abstract.linalg`

### DIFF
--- a/examples/scripts/find_bbcode_layouts.py
+++ b/examples/scripts/find_bbcode_layouts.py
@@ -148,7 +148,7 @@ def get_layout_search_space(
     - a relative shift (between L and R) of the qubit plaquettes of the BBCode.
     """
     # identify the sets of lattice vectors that are used to relabel qubit plaquettes
-    vectors: list[tuple[int, int]] = list(np.ndindex(code.orders))  # type:ignore[arg-type]
+    vectors: list[tuple[int, int]] = list(np.ndindex(code.orders))
     vector_pairs = itertools.combinations(vectors, 2)
     lattice_vectors = [
         (vec_a, vec_b) if code.get_order(vec_a) >= code.get_order(vec_b) else (vec_b, vec_a)

--- a/src/qldpc/abstract/__init__.py
+++ b/src/qldpc/abstract/__init__.py
@@ -16,13 +16,18 @@ from .groups import (
     TrivialGroup,
     get_coefficient_and_exponents,
 )
+from .linalg import (
+    block_diag,
+    get_howell_dual,
+    kron,
+    matmul,
+)
 from .rings import (
     Element,
     GroupRing,
     Protograph,
     RingArray,
     RingMember,
-    kron,
 )
 from .wedderburn_artin import (
     WedderburnArtinComponentTransformer,
@@ -46,6 +51,10 @@ __all__ = [
     "SymmetricGroup",
     "TrivialGroup",
     "get_coefficient_and_exponents",
+    "block_diag",
+    "get_howell_dual",
+    "kron",
+    "matmul",
     "Element",
     "GroupRing",
     "Protograph",
@@ -53,5 +62,4 @@ __all__ = [
     "RingMember",
     "WedderburnArtinComponentTransformer",
     "WedderburnArtinTransformer",
-    "kron",
 ]

--- a/src/qldpc/abstract/groups.py
+++ b/src/qldpc/abstract/groups.py
@@ -5,8 +5,8 @@ a subgroup of the symmetric group.  Group members subclass the SymPy Permutation
 
 !!! WARNINGS !!!
 
-First and foremost, this module does not promise to be performant.  If you need to do heavy
-numerical abstract algebra, you're probably better served by GAP or MAGMA (or maybe SageMath).
+This module does not promise to be performant.  If you need to do heavy numerical abstract algebra,
+you're probably better served by GAP or MAGMA (or maybe SageMath).
 
 This module only supports representations of group members by orthogonal matrices over finite
 fields.  The restriction to orthogonal representations allows identifying the "transpose" of a group

--- a/src/qldpc/abstract/linalg.py
+++ b/src/qldpc/abstract/linalg.py
@@ -1,0 +1,183 @@
+"""Module for linear algebra with matrices over rings and bimodules
+
+!!! WARNINGS !!!
+
+This module does not promise to be performant.  If you need to do heavy numerical abstract algebra,
+you're probably better served by GAP or MAGMA (or maybe SageMath).
+
+
+Copyright 2023 The qLDPC Authors and Infleqtion Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from __future__ import annotations
+
+import functools
+from typing import TYPE_CHECKING
+
+import numpy as np
+import numpy.typing as npt
+import scipy.linalg
+
+from qldpc import math
+
+from .rings import Group, GroupMember, GroupRing, RingArray
+
+if TYPE_CHECKING:
+    from .wedderburn_artin import WedderburnArtinTransformer
+
+
+def matmul(
+    matrix_a: RingArray | npt.NDArray[np.int_],
+    matrix_b: RingArray | npt.NDArray[np.int_],
+    *,
+    right: bool = False,
+) -> RingArray:
+    """Multiply two matrices over a ring.
+
+    This method exists to handle two different cases:
+    1. 'right is False' (default): Ordinary matrix multiplication, or simply 'matrix_a @ matrix_b'.
+    2. 'right is True': matrix multiplication with a reversed order of multiplication in the ring.
+    """
+    ring = _get_ring(matrix_a, matrix_b)
+    if (
+        matrix_a.ndim != matrix_b.ndim
+        or matrix_a.ndim < 2
+        or (inner_dim := matrix_a.shape[-1]) != matrix_b.shape[-2]
+    ):
+        raise ValueError(
+            f"Incompatible matrix shapes for abstract.matmul: {matrix_a.shape}, {matrix_b.shape}"
+        )
+
+    if ring.is_commutative or not right:
+        return (matrix_a @ matrix_b).view(RingArray)
+
+    final_shape = (*matrix_a.shape[:-1], matrix_b.shape[-1])
+    matrix = RingArray.build(np.zeros(final_shape, dtype=int), ring)
+    for idx in np.ndindex(final_shape):
+        head, ii, jj = idx[:-2], idx[-2], idx[-1]
+        matrix[idx] = sum(
+            matrix_b[(*head, kk, jj)] * matrix_a[(*head, ii, kk)] for kk in range(inner_dim)
+        )
+    return matrix
+
+
+def kron(
+    matrix_a: RingArray | npt.NDArray[np.int_], matrix_b: RingArray | npt.NDArray[np.int_]
+) -> RingArray:
+    """Take the Kronecker product of two matrices over a ring.
+
+    If the base ring R is commutative, this is the ordinary Kronecker product.
+    Otherwise, matrix entries of the Kronecker product live in the bimodule of R.
+    See get_bimodule for additional information.
+    """
+    ring = _get_ring(matrix_a, matrix_b)
+
+    if not ring.is_commutative:
+        bimodule = get_bimodule(ring)
+        sector_size = ring.group.identity.size
+        swap_sectors = GroupMember(
+            list(range(sector_size, 2 * sector_size)) + list(range(sector_size))
+        )
+        matrix_a = RingArray.build(matrix_a, bimodule)
+        matrix_b = swap_sectors * ~RingArray.build(matrix_b, bimodule) * swap_sectors
+
+    return np.kron(matrix_a, matrix_b).view(RingArray)
+
+
+@functools.cache
+def get_bimodule(ring: GroupRing) -> GroupRing:
+    """Map a group algebra F[G] to its induced bimodule F[G ⨂ G].
+
+    Elements r ⨂ s ∈ F[G ⨂ G] of the bimodule act on elements of the base ring as
+        (r ⨂ s)(t) = r·t·s.
+    When lifting a RingArray matrix over a bimodule, the "left" entries of G ⨂ G get lifted to an
+    ordinary representation, while the "right" entries get lifted to an anti-representation.
+    """
+    size = ring.group.identity.size
+
+    def lift(member: GroupMember) -> npt.NDArray[np.int_]:
+        part_l = GroupMember(member.array_form[:size])
+        part_r = GroupMember([val - size for val in member.array_form[size:]])
+        return ring.group.lift(part_l) @ ring.group.lift(~part_r, right=True)
+
+    bimodule_group = Group(ring.group.to_sympy() * ring.group.to_sympy(), lift=lift)
+    return GroupRing(bimodule_group, ring.field.order)
+
+
+def block_diag(
+    matrix_a: RingArray | npt.NDArray[np.int_], matrix_b: RingArray | npt.NDArray[np.int_]
+) -> RingArray:
+    """Stack the two matrices into a block-diagonal matrix."""
+    ring = _get_ring(matrix_a, matrix_b)
+    matrix_ab = scipy.linalg.block_diag(matrix_a, matrix_b)
+    return RingArray.build(matrix_ab, ring)
+
+
+def get_howell_dual(
+    matrix_hnf: RingArray,
+    *,
+    transformer: WedderburnArtinTransformer | None = None,
+    right: bool = False,
+) -> RingArray:
+    """Build the "dual" of a matrix in Howell normal form.
+
+    The dual matrix provides a pseudoinverse of matrix_hnf in the following sense: if
+        D = matrix_hnf @ dual_matrix.T,
+    then
+    1. D is diagonal,
+    2. D @ matrix_hnf = matrix_hnf,
+    3. D.T @ dual_matrix = dual_matrix, and
+    4. D = transformer.transpose_array(D).
+
+    Note that we have two different notions of a transpose at play:
+    1. D.T...
+        (a) swaps the matrix indices of D, and
+        (b) takes group members g -> ~g = g**-1, which transposes their regular representation.
+    2. transformer.transpose_array(D)...
+        (a) swaps the matrix indices of D (identically to D.T), and
+        (b) for each entry of D, transposes its matrix representation within each Wedderburn-Artin
+            component of the ring.
+
+    WARNING: This method assumes--and does not verify--that matrix_hnf is in Howell normal form.
+    """
+    ring = matrix_hnf.ring
+    transformer = transformer = transformer or ring.get_transformer()
+    dual_matrix = np.zeros(matrix_hnf.shape, dtype=object)
+    for row, col in enumerate(math.first_nonzero_cols(matrix_hnf)):
+        pivot = matrix_hnf[row, col].copy()
+        if ring.is_commutative:
+            new_matrix_entry = pivot
+        else:
+            new_matrix_entry = ring.zero
+            for component_transformer in transformer.transformers:
+                if np.any(component := component_transformer.project(pivot)):
+                    field = component_transformer.extended_field
+                    diags = np.diag(np.diag(component)).view(field)
+                    new_matrix_entry += component_transformer.embed(diags).T
+        dual_matrix[row, col] = new_matrix_entry
+    return RingArray.build(dual_matrix, ring)
+
+
+def _get_ring(
+    matrix_a: RingArray | npt.NDArray[np.int_], matrix_b: RingArray | npt.NDArray[np.int_]
+) -> GroupRing:
+    """Identify the ring that at least one of the matrices is over."""
+    ring_a = matrix_a.ring if isinstance(matrix_a, RingArray) else None
+    ring_b = matrix_b.ring if isinstance(matrix_b, RingArray) else None
+    if ring_a is None and ring_b is None:
+        raise ValueError("At least one of the provided matrices must be a RingArray")
+    if ring_a is not None and ring_b is not None and ring_a != ring_b:
+        raise ValueError("The provided matrices are over different rings")
+    return ring_a if ring_a is not None else ring_b  # type:ignore[return-value]

--- a/src/qldpc/abstract/linalg_test.py
+++ b/src/qldpc/abstract/linalg_test.py
@@ -1,0 +1,122 @@
+"""Unit tests for linalg.py
+
+Copyright 2023 The qLDPC Authors and Infleqtion Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from qldpc import abstract
+
+
+def test_basics(rows: int = 2, cols: int = 3) -> None:
+    """Basic linear algebra over commutative rings."""
+    ring = abstract.GroupRing(abstract.CyclicGroup(3), field=2)
+    values_a = [[ring.group.random() for _ in range(cols)] for _ in range(rows)]
+    values_b = [[ring.group.random() for _ in range(cols)] for _ in range(rows)]
+    matrix_a = abstract.RingArray.build(values_a, ring)
+    matrix_b = abstract.RingArray.build(values_b, ring)
+
+    # matrix multiplication and the Kronecker product work as expected
+    assert np.array_equal(
+        abstract.matmul(matrix_a, matrix_b.T),
+        matrix_a @ matrix_b.T,
+    )
+    assert np.array_equal(
+        abstract.kron(matrix_a, matrix_b),
+        np.kron(matrix_a, matrix_b).view(abstract.RingArray),
+    )
+
+    # block_diag works as expected
+    matrix_ab = abstract.block_diag(matrix_a, matrix_b)
+    assert np.array_equal(matrix_ab[: matrix_a.shape[0], : matrix_a.shape[1]], matrix_a)
+    assert np.array_equal(matrix_ab[matrix_a.shape[0] :, matrix_a.shape[1] :], matrix_b)
+    assert not np.any(matrix_ab[: matrix_a.shape[0], matrix_a.shape[1] :])
+    assert not np.any(matrix_ab[matrix_a.shape[0] :, : matrix_a.shape[1]])
+
+    # we can still use these methods if only one of them is a RingArray
+    assert np.array_equal(abstract.matmul(np.eye(matrix_a.shape[0], dtype=int), matrix_a), matrix_a)
+    assert np.array_equal(abstract.matmul(matrix_a, np.eye(matrix_a.shape[1], dtype=int)), matrix_a)
+
+    # ... but we need at least one of them to be a RingArray
+    with pytest.raises(ValueError, match="At least one .* RingArray"):
+        abstract.kron(np.eye(1, dtype=int), np.eye(1, dtype=int))
+
+    # matrix dimensions must be compatible for matrix multiplication
+    with pytest.raises(ValueError, match="Incompatible matrix shapes"):
+        abstract.matmul(matrix_a, matrix_b)
+
+    # we can't multiply matrices over different rings
+    other_ring = abstract.GroupRing(ring.group, field=ring.field.order + 1)
+    other_matrix = abstract.RingArray.build(np.eye(matrix_a.shape[0], dtype=int), other_ring)
+    with pytest.raises(ValueError, match="different rings"):
+        abstract.matmul(other_matrix, matrix_a)
+
+
+def test_matmul_and_kron_interplay(ring: abstract.GroupRing, rows: int = 2, cols: int = 3) -> None:
+    """Matrix multiplication and the Kronecker product work together as expected."""
+    values_a = [[ring.group.random() for _ in range(cols)] for _ in range(rows)]
+    values_b = [[ring.group.random() for _ in range(cols)] for _ in range(rows)]
+    values_c = [[ring.group.random() for _ in range(cols)] for _ in range(rows)]
+    values_d = [[ring.group.random() for _ in range(cols)] for _ in range(rows)]
+    matrix_a = abstract.RingArray.build(values_a, ring)
+    matrix_b = abstract.RingArray.build(values_b, ring)
+    matrix_c = abstract.RingArray.build(values_c, ring).transpose()
+    matrix_d = abstract.RingArray.build(values_d, ring).transpose()
+
+    # (A ⨂ B) @ (C ⨂ D)
+    matrix_ab = abstract.kron(matrix_a, matrix_b)
+    matrix_cd = abstract.kron(matrix_c, matrix_d)
+    matrix_ab_cd = abstract.matmul(matrix_ab, matrix_cd)
+
+    # build (A @ C) ⨂ (B @ D), with reversed order of ring multiplication in second tensor factor
+    matrix_ac = abstract.matmul(matrix_a, matrix_c)
+    matrix_bd = abstract.matmul(matrix_b, matrix_d, right=True)
+    matrix_ac_bd = abstract.kron(matrix_ac, matrix_bd)
+    assert np.array_equal(matrix_ab_cd, matrix_ac_bd)
+
+    if not ring.is_commutative:
+        # assert that elements of the bimodule R ⨂ R transform elements of the ring R correctly
+        val_a = matrix_a[0, 0]
+        val_b = matrix_b[0, 0]
+        val_ab = matrix_ab[0, 0]
+        random_val = abstract.RingMember.from_vector(ring.field.Random(ring.group.order), ring)
+        random_vec = random_val.to_vector()
+        assert np.array_equal(
+            val_ab.lift() @ random_vec,
+            val_a.lift() @ (val_b.lift(right=True) @ random_vec),
+        )
+
+
+@pytest.mark.parametrize("right", [False, True])
+def test_howell_dual(ring: abstract.GroupRing, right: bool, rows: int = 2, cols: int = 3) -> None:
+    """Matrices in Howell normal form have a "dual" that acts like a pseudoinverse."""
+    transformer = ring.get_transformer()
+    values = [[ring.group.random() for _ in range(cols)] for _ in range(rows)]
+    matrix = abstract.RingArray.build(values, ring)
+
+    # find a null-space matrix in Howell normal form
+    generator = matrix.null_space(right=right).howell_normal_form_semisimple(right=right)
+    assert not np.any(abstract.matmul(matrix, generator.T, right=right))
+
+    # find the "dual" of the null-space matrix, which acts like a pseudoinverse
+    dual = abstract.get_howell_dual(generator)
+    diag = abstract.matmul(generator, dual.T, right=right)
+    assert np.array_equal(diag.astype(bool), np.eye(len(diag), dtype=bool))
+    assert np.array_equal(abstract.matmul(diag, generator, right=right), generator)
+    assert np.array_equal(abstract.matmul(diag.T, dual, right=right), dual)
+    assert np.array_equal(diag, transformer.transpose_array(diag))

--- a/src/qldpc/abstract/rings.py
+++ b/src/qldpc/abstract/rings.py
@@ -2,8 +2,8 @@
 
 !!! WARNINGS !!!
 
-First and foremost, this module does not promise to be performant.  If you need to do heavy
-numerical abstract algebra, you're probably better served by GAP or MAGMA (or maybe SageMath).
+This module does not promise to be performant.  If you need to do heavy numerical abstract algebra,
+you're probably better served by GAP or MAGMA (or maybe SageMath).
 
 
 Copyright 2023 The qLDPC Authors and Infleqtion Inc.
@@ -608,65 +608,30 @@ class RingArray(npt.NDArray[np.object_]):
         """Base field of this RingArray."""
         return self.ring.field
 
-    def regular_lift(self, *, right: bool | None = None) -> galois.FieldArray:
-        """Block matrix obtained by a regular lift of each entry of this RingArray.
-
-        If this RingArray has shape (rows, cols, 2), it is treated as a bimodule: the [:, :, 0]
-        slice is lifted with the left regular representation and [:, :, 1] with the right, and the
-        two block matrices are combined by block-wise matrix multiplication.
-        """
-        assert self.ndim == 1 or self.ndim == 2 or (self.ndim == 3 and self.shape[2] == 2)
-        if self.ndim == 3:
-            assert right is None
-            rows, cols, block_size = self.shape[0], self.shape[1], self.group.order
-            tensor_shape = (rows, block_size, cols, block_size)
-            matrix_shape = (rows * block_size, cols * block_size)
-            lift_0 = self[:, :, 0].view(RingArray).regular_lift(right=False)
-            lift_1 = self[:, :, 1].view(RingArray).regular_lift(right=True)
-            blocks_0 = lift_0.reshape(tensor_shape).transpose(0, 2, 1, 3)
-            blocks_1 = lift_1.reshape(tensor_shape).transpose(0, 2, 1, 3)
-            product_blocks = blocks_0 @ blocks_1
-            return product_blocks.transpose(0, 2, 1, 3).reshape(matrix_shape)
-
+    def regular_lift(self, *, right: bool = False) -> galois.FieldArray:
+        """Block matrix obtained by a regular lift of each entry of this RingArray."""
+        assert self.ndim == 1 or self.ndim == 2
         rows = 1 if self.ndim == 1 else self.shape[0]
         cols = self.shape[-1]
         block_size = self.group.order
         if 0 in (rows, cols):
             return self.field.Zeros((rows * block_size, cols * block_size))
         blocks = [
-            [val.lift(right=right or False) for val in row]
+            [val.regular_lift(right=right) for val in row]
             for row in self.reshape(-1, self.shape[-1])
         ]
         return np.block(blocks).view(self.field)
 
-    def lift(self, *, right: bool | None = None) -> galois.FieldArray:
-        """Block matrix obtained by lifting each entry of this RingArray.
-
-        If this RingArray has shape (rows, cols, 2), it is treated as a bimodule: the [:, :, 0]
-        slice is lifted with the left regular representation and [:, :, 1] with the right, and the
-        two block matrices are combined by block-wise matrix multiplication.
-        """
-        assert self.ndim == 1 or self.ndim == 2 or (self.ndim == 3 and self.shape[2] == 2)
-        if self.ndim == 3:
-            assert right is None
-            rows, cols, block_size = self.shape[0], self.shape[1], self.group.order
-            tensor_shape = (rows, block_size, cols, block_size)
-            matrix_shape = (rows * block_size, cols * block_size)
-            lift_0 = self[:, :, 0].view(RingArray).lift(right=False)
-            lift_1 = self[:, :, 1].view(RingArray).lift(right=True)
-            blocks_0 = lift_0.reshape(tensor_shape).transpose(0, 2, 1, 3)
-            blocks_1 = lift_1.reshape(tensor_shape).transpose(0, 2, 1, 3)
-            product_blocks = blocks_0 @ blocks_1
-            return product_blocks.transpose(0, 2, 1, 3).reshape(matrix_shape)
-
+    def lift(self, *, right: bool = False) -> galois.FieldArray:
+        """Block matrix obtained by lifting each entry of this RingArray."""
+        assert self.ndim == 1 or self.ndim == 2
         rows = 1 if self.ndim == 1 else self.shape[0]
         cols = self.shape[-1]
         block_size = self.group.lift_dim
         if 0 in (rows, cols):
             return self.field.Zeros((rows * block_size, cols * block_size))
         blocks = [
-            [val.lift(right=right or False) for val in row]
-            for row in self.reshape(-1, self.shape[-1])
+            [val.lift(right=right) for val in row] for row in self.reshape(-1, self.shape[-1])
         ]
         return np.block(blocks).view(self.field)
 
@@ -679,8 +644,12 @@ class RingArray(npt.NDArray[np.object_]):
 
     @property
     def T(self) -> RingArray:
-        """Transpose of this RingArray, which also transposes every array entry."""
-        return (~self).transpose()
+        """Conjugate-transpose of a matrix over a ring.
+
+        In addition to transposing the first two indices of the array, this method "conjugates" or
+        "transposes" each array element, which takes group members g -> ~g = g**-1.
+        """
+        return (~self).transpose(1, 0, *np.arange(2, self.ndim))
 
     @staticmethod
     def build(
@@ -690,38 +659,41 @@ class RingArray(npt.NDArray[np.object_]):
         """Construct a RingArray.
 
         The constructed array is built from:
-        - an array populated by
+        1. An array populated by
             (a) ring members,
             (b) group members, or
-            (c) integers, and
-        - a ring (or group, inducing a group algebra over GF(2)).
-        Integers and group members are cast as members of the ring.
+            (c) integers.
+        2. A ring (or group, inducing a group algebra over GF(2)).
+        Integers and group members are cast into members of the ring.
         """
         array = np.asanyarray(data)
 
         # identify the base ring and group
         if ring is None:
-            rings = [value.ring for value in array.ravel() if isinstance(value, RingMember)]
+            rings = {value.ring for value in array.ravel() if isinstance(value, RingMember)}
             if not len(set(rings)) <= 1:
                 raise ValueError("Inconsistent rings provided to RingArray.build")
             if rings:
-                ring = rings[0]
+                ring = next(iter(rings))
             else:
                 field = type(array).order if isinstance(array, galois.FieldArray) else None
                 ring = GroupRing(TrivialGroup(), field)
-        group = ring.group if isinstance(ring, GroupRing) else ring
+        ring = ring if isinstance(ring, GroupRing) else GroupRing(ring)
+        one = ring.group.identity
 
         def as_ring_member(value: RingMember | GroupMember | int) -> RingMember:
             """Elevate a value to an element of the ring."""
             if isinstance(value, RingMember):
-                return value
+                _value = value.copy() * one
+                _value._ring = ring
+                return _value
             if isinstance(value, GroupMember):
-                return RingMember(ring, value)
-            return RingMember(ring, (value, group.identity))
+                return RingMember(ring, value * one)
+            return RingMember(ring, (value, one))
 
         vals = [as_ring_member(value) for value in array.ravel()]
         result = np.array(vals, dtype=object).reshape(array.shape).view(RingArray)
-        result._ring = ring if isinstance(ring, GroupRing) else GroupRing(ring)
+        result._ring = ring
         return result
 
     def to_field_array(self) -> galois.FieldArray:
@@ -779,11 +751,14 @@ class RingArray(npt.NDArray[np.object_]):
         entries_as_vecs = vector.reshape(vector.size // group.order, group.order)
         return RingArray.from_field_array(entries_as_vecs, ring)
 
-    def null_space(self) -> RingArray:
+    def null_space(self, *, right: bool = False) -> RingArray:
         """Construct a matrix of null-space row vectors for this RingArray.
 
         The transpose of the null-space matrix is annihilated by this RingArray, such that
         np.any(self @ self.null_space().T) is np.False_.
+
+        If right is True, this method constructs a null space over the opposite ring, in which the
+        order of multiplication is reversed.
 
         Due to the subtleties of defining row reduction for a matrix over a ring, this method does
         not row-reduce the matrix of null-space row vectors.  The rows of the matrix returned by
@@ -794,7 +769,7 @@ class RingArray(npt.NDArray[np.object_]):
 
         # field-valued null vectors of self.regular_lift() provide an overcomplete basis for
         # the space of ring-valued null vectors
-        null_field_vectors = self.regular_lift().null_space()
+        null_field_vectors = self.regular_lift(right=right).null_space()
 
         # collect ring-valued null row vectors (that is, transposed null column vectors)
         field_array_shape = (len(null_field_vectors), self.shape[1], self.group.order)
@@ -834,14 +809,30 @@ class RingArray(npt.NDArray[np.object_]):
         return self.howell_normal_form_semisimple()
 
     def howell_normal_form_semisimple(
-        self, transformer: WedderburnArtinTransformer | None = None
+        self, transformer: WedderburnArtinTransformer | None = None, *, right: bool = False
     ) -> RingArray:
         """Compute a Howell normal form (HNF) of a RingArray over a semisimple ring.
 
         This method first puts a RingArray into a generalized reduced row echelon form (see
-        RingArray.row_reduce), then further post-processes the rows to satisfy the Howell property.
-        Specifically, if a row r has a pivot p with a nontrivial annihilator α (meaning α != 0 and
-        α·p = 0), then the row r is replaced by (1-α)·r, and the row α·r is appended to the matrix.
+        RingArray.row_reduce), then further post-processes the rows to satisfy the Howell property,
+        whereby an element v that is...
+            - in the row span of the matrix, and
+            - has j leading zeros, meaning = (0_1, 0_2, ..., 0_j, v_{j+1}, ...),
+        can be written as a linear combinations of rows whose pivots are at position k >= j.
+
+        The Howell property is enforecd as follows: if a row r has a pivot p with a nontrivial left
+        annihilator α, meaning
+              α != 0,
+            α·p  = 0,
+            α·r != 0,
+        then the row r is replaced by (1-α)·r, and the row α·r is appended to the matrix.
+
+        If right is True, the Howell property is instead enforced for nontrivial right annihilators:
+              α != 0,
+            p·α  = 0,
+            r·α != 0,
+        for which the row r is replaced by (1-α)·r, and the row α·r is appended to the matrix.
+        The ordinary HNF and right-HNF are equal for a RingArray over a commutative ring.
 
         The HNF of a RingArray over a commutative ring is unique.  For non-commutative rings, the
         HNF is only unique up to a choice of matrix basis for simple components of the ring.
@@ -860,7 +851,7 @@ class RingArray(npt.NDArray[np.object_]):
 
         # identify and row-reduce the components of this RingArray
         matrices = [
-            _get_block_howell_form(component_transformer.project_array(self))
+            _get_block_howell_form(component_transformer.project_array(self), right=right)
             for component_transformer in transformer.transformers
         ]
 
@@ -891,7 +882,7 @@ class RingArray(npt.NDArray[np.object_]):
             """
             Let π be a projector onto the components in which the pivot is nonzero.  If π != 1, then
             (1-π) is a nontrivial annihilator of the pivot.  If, moreover, (1-π)·r is nonzero, then
-            (1-π)·r contains a "hidden" pivot in a later column.  In this caes, we in principle need
+            (1-π)·r contains a "hidden" pivot in a later column.  In this case, we in principle need
             to replace r -> π·r and add (1-π)·r as a new row to the matrix.  In practice, this
             procedure messes up the reduced row echelon form of the matrix, so we instead...
             1. In the (1-π) sector, insert a zero row at the pivot_row and shift down rows below.
@@ -1062,41 +1053,6 @@ class RingArray(npt.NDArray[np.object_]):
         )
 
 
-def kron(
-    matrix_a: RingArray | npt.NDArray[np.int_], matrix_b: RingArray | npt.NDArray[np.int_]
-) -> RingArray:
-    """Take the ring-Kronecker (tensor) product of two RingArray matrices.
-
-    If the base ring is commutative, this is the ordinary Kronecker product.  Otherwise, the
-    matrix entries of the Kronecker product live in the bimodule of the ring, and have the form
-    r ⨂ s ~ (r, s).  In this case, the output matrix has a new axis whose index takes two values.
-    When lifting a RingArray matrix over a bimodule, the "left" entries in matrix[:, :, 0] get
-    lifted with the regular representation, while the "right" entries in matrix[:, :, 1] get lifted
-    to their representation in the opposite ring (see RingMember.regular_lift).
-    """
-    if isinstance(matrix_a, RingArray):
-        ring = matrix_a.ring
-        assert not isinstance(matrix_b, RingArray) or matrix_b.ring is ring
-    elif isinstance(matrix_b, RingArray):  # pragma: no cover
-        ring = matrix_b.ring
-        assert not isinstance(matrix_a, RingArray) or matrix_a.ring is ring
-    else:
-        raise ValueError("abstract.kron requires at least one of its inputs to be a RingArray")
-
-    if ring.is_commutative:
-        matrix = np.kron(matrix_a, matrix_b).view(RingArray)
-    else:
-        rows_a, cols_a = matrix_a.shape
-        rows_b, cols_b = matrix_b.shape
-        tensor = np.empty((rows_a, rows_b, cols_a, cols_b, 2), dtype=object)
-        tensor[:, :, :, :, 0] = np.asarray(matrix_a)[:, np.newaxis, :, np.newaxis]
-        tensor[:, :, :, :, 1] = np.asarray(matrix_b)[np.newaxis, :, np.newaxis, :]
-        matrix = tensor.reshape(rows_a * rows_b, cols_a * cols_b, 2).view(RingArray)
-
-    matrix._ring = ring
-    return matrix
-
-
 class Protograph(RingArray):  # pragma: no cover
     """Deprecated alias for RingArray."""
 
@@ -1109,7 +1065,7 @@ class Protograph(RingArray):  # pragma: no cover
         return super().__getattribute__(name)
 
 
-def _get_block_howell_form(matrix: galois.FieldArray) -> galois.FieldArray:
+def _get_block_howell_form(matrix: galois.FieldArray, *, right: bool = False) -> galois.FieldArray:
     """Compute a block-Howell normal form of the provided block matrix.
 
     The provided matrix should be 4-dimensional, with matrix[i, j] storing a square block at (i, j).
@@ -1122,6 +1078,9 @@ def _get_block_howell_form(matrix: galois.FieldArray) -> galois.FieldArray:
     assert matrix.ndim == 4 and matrix.shape[-1] == matrix.shape[-2]
     field = type(matrix)
     num_block_rows, num_block_cols, size, _ = matrix.shape
+
+    if right and size > 1:
+        matrix = matrix.transpose(0, 1, 3, 2)
 
     # row-reduce as an expanded 2-D matrix and remove all-zero rows
     shape = (num_block_rows * size, num_block_cols * size)
@@ -1149,4 +1108,9 @@ def _get_block_howell_form(matrix: galois.FieldArray) -> galois.FieldArray:
 
     # re-collect into a 4-D array
     shape = (matrix.shape[0] // size, size, num_block_cols, size)
-    return matrix.reshape(shape).transpose(0, 2, 1, 3).view(field)
+    matrix = matrix.reshape(shape).transpose(0, 2, 1, 3).view(field)
+
+    if right and size > 1:
+        matrix = matrix.transpose(0, 1, 3, 2)
+
+    return matrix

--- a/src/qldpc/abstract/rings_test.py
+++ b/src/qldpc/abstract/rings_test.py
@@ -171,6 +171,14 @@ def test_ring_array(pytestconfig: pytest.Config) -> None:
         np.kron(matrix, new_matrix)
 
 
+def test_empty_lift() -> None:
+    """Lifting 0-sized RingArrays still yields arrays of the correct shape."""
+    ring = abstract.GroupRing(abstract.CyclicGroup(3), field=2)
+    empty = abstract.RingArray.build(np.zeros((0, 2), dtype=int), ring)
+    assert empty.regular_lift().shape == (0, 2 * ring.group.order)
+    assert empty.lift().shape == (0, 2 * ring.group.lift_dim)
+
+
 def test_transpose() -> None:
     """Transpose various objects."""
     group = abstract.CyclicGroup(4)
@@ -244,11 +252,18 @@ def test_ring_row_reduction(
     e3_13 = component_transformer.embed(
         component_transformer.extended_field([[0, 0, 1], [0, 0, 0], [0, 0, 0]])
     )
+    e3_31 = component_transformer.embed(
+        component_transformer.extended_field([[0, 0, 0], [0, 0, 0], [1, 0, 0]])
+    )
     e3_33 = component_transformer.embed(
         component_transformer.extended_field([[0, 0, 0], [0, 0, 0], [0, 0, 1]])
     )
     assert np.array_equal(
-        abstract.RingArray.build([[e3_13]]).howell_normal_form(),
+        abstract.RingArray.build([[e3_13]]).howell_normal_form_semisimple(),
+        abstract.RingArray.build([[e3_33]]),
+    )
+    assert np.array_equal(
+        abstract.RingArray.build([[e3_31]]).howell_normal_form_semisimple(right=True),
         abstract.RingArray.build([[e3_33]]),
     )
 
@@ -272,72 +287,21 @@ def test_ring_row_reduction(
         abstract.RingArray.build([[1, 0], [1, 1]], ring).reduced_groebner_basis()
 
 
-def test_minimal_howell_form(ring_cyclic3_gf2: abstract.GroupRing) -> None:
-    """Howell normal form merges compatible pivots to reduce the number of rows."""
+def test_howell_form(ring_cyclic3_gf2: abstract.GroupRing) -> None:
+    """The Howell normal form can add rows to a RingArray, and merges compatible pivots."""
     ring = ring_cyclic3_gf2
     a, b = ring.get_primitive_central_idempotents()
+    matrix = abstract.RingArray.build([[a, b]])
+    assert np.array_equal(
+        matrix.howell_normal_form(),
+        abstract.RingArray.build([[a, 0], [0, b]]),
+    )
+
     matrix = abstract.RingArray.build([[a, b], [0, a]])
     assert np.array_equal(
         matrix.howell_normal_form(),
         abstract.RingArray.build([[a, 0], [0, 1]]),
     )
-
-
-def test_ring_row_addition(ring_cyclic3_gf2: abstract.GroupRing) -> None:
-    """The Howell normal form can add rows to a RingArray."""
-    ring = ring_cyclic3_gf2
-    x = ring.generators[0]
-    matrix = abstract.RingArray.build([[x + 1, 1]])
-    assert np.array_equal(
-        matrix.howell_normal_form(),
-        abstract.RingArray.build([[x**2 + x, x**2 + 1], [0, x**2 + x + 1]]),
-    )
-    assert np.array_equal(
-        matrix.howell_normal_form(poly=True),
-        abstract.RingArray.build([[x + 1, 1], [0, x**2 + x + 1]]),
-    )
-
-
-def test_kron() -> None:
-    """Kronecker product of RingArrays."""
-
-    # commutative ring -> normal Kronecker product
-    ring = abstract.GroupRing(abstract.CyclicGroup(3), field=2)
-    matrix = abstract.RingArray.build(np.eye(2, dtype=int), ring)
-    result = abstract.kron(matrix, matrix)
-    assert result.shape == (matrix.shape[0] ** 2, matrix.shape[1] ** 2)
-
-    # we can still use abstract.kron if only one of the arguments is a RingArray
-    integer_matrix = np.eye(2, dtype=int)
-    result = abstract.kron(matrix, integer_matrix)
-    assert result.shape == (
-        matrix.shape[0] * integer_matrix.shape[0],
-        matrix.shape[1] * integer_matrix.shape[1],
-    )
-
-    # the Kronecker product with non-commutative rings returns an array over a bimodule
-    ring = abstract.GroupRing(abstract.DihedralGroup(3), field=2)
-    matrix = abstract.RingArray.build(np.eye(2, dtype=int), ring)
-    result = abstract.kron(matrix, matrix)
-    lifted_result = result.lift()
-    assert result.shape == (matrix.shape[0] ** 2, matrix.shape[1] ** 2, 2)
-    assert lifted_result.shape == (
-        result.shape[0] * ring.group.order,
-        result.shape[1] * ring.group.order,
-    )
-    assert np.array_equal(result.regular_lift(), lifted_result)
-
-    # kron requires at least one RingArray input
-    with pytest.raises(ValueError, match="requires at least one .* RingArray"):
-        abstract.kron(integer_matrix, integer_matrix)
-
-
-def test_ring_array_empty_lift() -> None:
-    """Lifting 0-sized RingArrays still yields arrays of the correct shape."""
-    ring = abstract.GroupRing(abstract.CyclicGroup(3), field=2)
-    empty = abstract.RingArray.build(np.zeros((0, 2), dtype=int), ring)
-    assert empty.regular_lift().shape == (0, 2 * ring.group.order)
-    assert empty.lift().shape == (0, 2 * ring.group.lift_dim)
 
 
 def test_deprecations() -> None:

--- a/src/qldpc/abstract/wedderburn_artin_test.py
+++ b/src/qldpc/abstract/wedderburn_artin_test.py
@@ -27,16 +27,6 @@ import pytest
 from qldpc import abstract
 
 
-@pytest.fixture(name="ring", scope="module", params=["cyclic3_gf4", "alternating4_gf5"])
-def rings_to_test(
-    request: pytest.FixtureRequest,
-    ring_cyclic3_gf4: abstract.GroupRing,
-    ring_alternating4_gf5: abstract.GroupRing,
-) -> abstract.GroupRing:
-    """Retrieve a ring for which we have pre-built a Wedderburn-Artin transformer."""
-    return ring_cyclic3_gf4 if request.param == "cyclic3_gf4" else ring_alternating4_gf5
-
-
 def test_wedderburn_artin_transformations(
     ring: abstract.GroupRing, pytestconfig: pytest.Config
 ) -> None:

--- a/src/qldpc/codes/quantum.py
+++ b/src/qldpc/codes/quantum.py
@@ -1407,23 +1407,23 @@ class LPCode(CSSCode):
 
         Generalizes HGPCode.get_canonical_logical_line_ops.
         """
-        generator_a = matrix_a.null_space().howell_normal_form()
-        generator_b = matrix_b.null_space().howell_normal_form()
-        generator_a_T = matrix_a.T.null_space().howell_normal_form()
-        generator_b_T = matrix_b.T.null_space().howell_normal_form()
+        generator_a = matrix_a.null_space().howell_normal_form_semisimple()
+        generator_b = matrix_b.null_space(right=True).howell_normal_form_semisimple(right=True)
+        generator_a_T = matrix_a.T.null_space().howell_normal_form_semisimple()
+        generator_b_T = matrix_b.T.null_space(right=True).howell_normal_form_semisimple(right=True)
 
-        dual_a = _get_howell_dual(generator_a)  # for which generator_a @ dual_a.T is diagonal
-        dual_b = _get_howell_dual(generator_b)
-        dual_a_T = _get_howell_dual(generator_a_T)
-        dual_b_T = _get_howell_dual(generator_b_T)
+        dual_a = abstract.get_howell_dual(generator_a)  # generator_a @ dual_a.T is diagonal
+        dual_b = abstract.get_howell_dual(generator_b, right=True)
+        dual_a_T = abstract.get_howell_dual(generator_a_T)
+        dual_b_T = abstract.get_howell_dual(generator_b_T, right=True)
 
         logical_ops_x_l = abstract.kron(dual_a, generator_b)
         logical_ops_z_l = abstract.kron(generator_a, dual_b)
         logical_ops_x_r = abstract.kron(generator_a_T, dual_b_T)
         logical_ops_z_r = abstract.kron(dual_a_T, generator_b_T)
 
-        logical_ops_x = _block_diag(logical_ops_x_l, logical_ops_x_r)
-        logical_ops_z = _block_diag(logical_ops_z_l, logical_ops_z_r)
+        logical_ops_x = abstract.block_diag(logical_ops_x_l, logical_ops_x_r)
+        logical_ops_z = abstract.block_diag(logical_ops_z_l, logical_ops_z_r)
         return logical_ops_x, logical_ops_z
 
     @staticmethod
@@ -1433,90 +1433,32 @@ class LPCode(CSSCode):
         """Lift logical operators over a ring to logical operators over the base field."""
         ring = logical_ops_x.ring
         num_columns = logical_ops_x.shape[1]
-        block_length = num_columns * ring.group.order
-
-        identity = np.eye(ring.group.order, dtype=int)
-        lifted_ops_x = ring.field.Zeros((0, block_length))
-        lifted_ops_z = ring.field.Zeros((0, block_length))
+        block_size = ring.group.lift_dim
+        num_lifted_columns = num_columns * block_size
+        identity = np.eye(block_size, dtype=int)
+        lifted_ops_x = ring.field.Zeros((0, num_lifted_columns))
+        lifted_ops_z = ring.field.Zeros((0, num_lifted_columns))
         for row, (op_x, op_z) in enumerate(zip(logical_ops_x, logical_ops_z)):
-            ops_x = op_x.lift()
-            ops_z = op_z.lift()
+            ops_x = op_x.reshape(1, *op_x.shape).lift()
+            ops_z = op_z.reshape(1, *op_z.shape).lift()
             inner_product = ops_x @ ops_z.T
             if not np.array_equal(inner_product, identity):
                 sector_rank = np.linalg.matrix_rank(inner_product)
-                basis_change = np.linalg.inv(inner_product[:sector_rank, :sector_rank]).T
-                ops_x = ops_x[:sector_rank]
-                ops_z = basis_change @ ops_z[:sector_rank]
+                if ring.is_commutative:
+                    basis_change = np.linalg.inv(inner_product[:sector_rank, :sector_rank]).T
+                    ops_x = ops_x[:sector_rank]
+                    ops_z = basis_change @ ops_z[:sector_rank]
+                else:
+                    pivot_rows = qldpc.math.first_nonzero_cols(inner_product.T.row_reduce())
+                    rows = pivot_rows[pivot_rows < block_size]
+                    cols = qldpc.math.first_nonzero_cols(inner_product[rows].row_reduce())
+                    basis_change = np.linalg.inv(inner_product[np.ix_(rows, cols)]).T
+                    ops_x = ops_x[rows]
+                    ops_z = basis_change @ ops_z[cols]
             lifted_ops_x = np.vstack([lifted_ops_x, ops_x])
             lifted_ops_z = np.vstack([lifted_ops_z, ops_z])
 
         return lifted_ops_x, lifted_ops_z
-
-
-def _get_howell_dual(
-    matrix_hnf: abstract.RingArray, transformer: abstract.WedderburnArtinTransformer | None = None
-) -> abstract.RingArray:
-    """Build the "dual" of a matrix in Howell normal form.
-
-    The dual matrix provides a pseudoinverse of matrix_hnf in the following sense: if
-        D = matrix_hnf @ dual_matrix.T,
-    then
-    1. D is diagonal,
-    2. D @ matrix_hnf = matrix_hnf,
-    3. D.T @ dual_matrix = dual_matrix, and
-    4. D = transformer.transpose_array(D).
-
-    Note that we have two different notions of a transpose at play:
-    1. D.T...
-        (a) swaps the matrix indices of D, and
-        (b) takes group members g -> ~g = g**-1, which transposes their regular representation.
-    2. transformer.transpose_array(D)...
-        (a) swaps the matrix indices of D (identically to D.T), and
-        (b) for each entry of D, transposes its matrix representation within each Wedderburn-Artin
-            component of the ring.
-
-    This method assumes--and does not verify--that matrix_hnf is in Howell normal form.
-    """
-    ring = matrix_hnf.ring
-    transformer = transformer = transformer or ring.get_transformer()
-    dual_matrix = np.zeros(matrix_hnf.shape, dtype=object)
-    for row, col in enumerate(qldpc.math.first_nonzero_cols(matrix_hnf)):
-        pivot = matrix_hnf[row, col].copy()
-        if ring.is_commutative:
-            new_matrix_entry = pivot
-        else:
-            new_matrix_entry = ring.zero
-            for component_transformer in transformer.transformers:
-                if np.any(component := component_transformer.project(pivot)):
-                    field = component_transformer.extended_field
-                    diags = np.diag(np.diag(component)).view(field)
-                    new_matrix_entry += component_transformer.embed(diags).T
-        dual_matrix[row, col] = new_matrix_entry
-    return abstract.RingArray.build(dual_matrix, ring)
-
-
-def _block_diag(matrix_a: abstract.RingArray, matrix_b: abstract.RingArray) -> abstract.RingArray:
-    """Stack the two matrices into a block-diagonal matrix.
-
-    If the two matrices have more than two dimensions, stack along the first two axes.
-    """
-    assert (
-        matrix_a.ndim == matrix_b.ndim
-        and matrix_a.ndim >= 2
-        and matrix_a.shape[2:] == matrix_b.shape[2:]
-    )
-    if matrix_a.ndim == 2:
-        matrix_ab = scipy.linalg.block_diag(matrix_a, matrix_b)
-        return abstract.RingArray.build(matrix_ab, matrix_a.ring)
-    shape = (
-        matrix_a.shape[0] + matrix_b.shape[0],
-        matrix_a.shape[1] + matrix_b.shape[1],
-        *matrix_a.shape[2:],
-    )
-    matrix_ab = abstract.RingArray.build(np.zeros(shape, dtype=int), matrix_a.ring)
-    matrix_ab[: matrix_a.shape[0], : matrix_a.shape[1]] = matrix_a
-    matrix_ab[-matrix_b.shape[0] :, -matrix_b.shape[1] :] = matrix_b
-    return matrix_ab
 
 
 class SLPCode(CSSCode):
@@ -1601,11 +1543,11 @@ class SLPCode(CSSCode):
 
         Generalizes SHPCode.get_canonical_logical_line_ops.
         """
-        generator_a = matrix_a.null_space().howell_normal_form()
-        generator_b = matrix_b.null_space().howell_normal_form()
+        generator_a = matrix_a.null_space().howell_normal_form_semisimple()
+        generator_b = matrix_b.null_space(right=True).howell_normal_form_semisimple(right=True)
 
-        dual_a = _get_howell_dual(generator_a)  # for which generator_a @ dual_a.T is diagonal
-        dual_b = _get_howell_dual(generator_b)
+        dual_a = abstract.get_howell_dual(generator_a)  # generator_a @ dual_a.T is diagonal
+        dual_b = abstract.get_howell_dual(generator_b, right=True)
 
         logical_ops_x = abstract.kron(dual_a, generator_b)
         logical_ops_z = abstract.kron(generator_a, dual_b)

--- a/src/qldpc/codes/quantum_test.py
+++ b/src/qldpc/codes/quantum_test.py
@@ -339,11 +339,11 @@ def test_trivial_lift(
     assert np.array_equal(matrix_z.lift(), code_HGP.matrix_z)
 
 
-def test_lift() -> None:
+def test_lift(ring_cyclic3_gf2: abstract.GroupRing) -> None:
     """Verify lifting in Eqs. (8) and (10) of arXiv:2202.01702v3."""
-    group = abstract.CyclicGroup(3)
-    zero = abstract.RingMember(group)
-    x0, x1, x2 = [abstract.RingMember(group, member) for member in group.generate()]
+    ring = ring_cyclic3_gf2
+    zero = abstract.RingMember(ring.group)
+    x0, x1, x2 = [abstract.RingMember(ring, member) for member in ring.group.generate()]
     base_matrix = [[x1 + x2, x0, zero], [zero, x0 + x1, x1]]
 
     ring_matrix = abstract.RingArray(base_matrix)
@@ -441,7 +441,7 @@ def test_lifted_product_codes() -> None:
         assert subsystem_rate > rate
 
 
-def test_subsystem_lifted_product_codes() -> None:
+def test_subsystem_lifted_product_codes(ring_cyclic3_gf2: abstract.GroupRing) -> None:
     """Subsystem lifted product codes in arXiv:2404.18302v1."""
 
     # example 1 on page 6 of https://arxiv.org/pdf/2404.18302v1
@@ -453,8 +453,7 @@ def test_subsystem_lifted_product_codes() -> None:
     assert code.get_code_params() == (18, 4, 2)
 
     # example 2 on page 6 of https://arxiv.org/pdf/2404.18302v1
-    group = abstract.CyclicGroup(3)
-    ring = abstract.GroupRing(group)
+    ring = ring_cyclic3_gf2
     xx = ring.generators[0]
     matrix = abstract.RingArray.build([[xx**2 + xx + 1, xx + 1, xx]])  # Eq. 23
     code = codes.SLPCode(matrix, set_logicals=True)
@@ -469,11 +468,7 @@ def test_subsystem_lifted_product_codes() -> None:
 
 
 def test_lifted_product_line_logicals(
-    pytestconfig: pytest.Config,
-    ring_cyclic3_gf2: abstract.GroupRing,
-    ring_alternating4_gf5: abstract.GroupRing,
-    rows: int = 2,
-    cols: int = 3,
+    pytestconfig: pytest.Config, ring: abstract.GroupRing, rows: int = 2, cols: int = 3
 ) -> None:
     """Canonical line operators of lifted product codes."""
     code: codes.CSSCode
@@ -481,7 +476,6 @@ def test_lifted_product_line_logicals(
     seed = pytestconfig.getoption("randomly_seed")
     sympy.core.random.seed(seed)
 
-    ring = ring_cyclic3_gf2
     values = [[ring.group.random() for _ in range(cols)] for _ in range(rows)]
     matrix = abstract.RingArray.build(values, ring)
     code = codes.LPCode(matrix, set_logicals=True)
@@ -496,7 +490,9 @@ def test_lifted_product_line_logicals(
         np.eye(code.dimension),
     )
 
-    # not all lifted product codes support canonical line operators
+
+def test_unsupported_line_logicals(rows: int = 2, cols: int = 3) -> None:
+    """We do not support line operators in lifted product codes with non-semisimple rings."""
     ring = abstract.GroupRing(abstract.CyclicGroup(2), field=2)
     values = [[ring.group.random() for _ in range(cols)] for _ in range(rows)]
     matrix = abstract.RingArray.build(values, ring)
@@ -504,38 +500,6 @@ def test_lifted_product_line_logicals(
         codes.LPCode(matrix, set_logicals=True)
     with pytest.raises(ValueError, match="not yet supported"):
         codes.SLPCode(matrix, set_logicals=True)
-
-
-def test_pending_ring_line_logical_features(
-    ring_alternating4_gf5: abstract.GroupRing, rows: int = 2, cols: int = 3
-) -> None:
-    """We do not yet support the construction of ring-logical line ops with non-commutative rings...
-
-    ... but we are working towards it, and support some necessary capabilities.
-    """
-    # _get_howell_dual works for non-commutative rings as well
-    ring = ring_alternating4_gf5
-    transformer = ring.get_transformer()
-    values = [[ring.group.random() for _ in range(cols)] for _ in range(rows)]
-    matrix = abstract.RingArray.build(values, ring)
-    generator = matrix.null_space().howell_normal_form()
-    dual = codes.quantum._get_howell_dual(generator)
-    diag = generator @ dual.T
-    assert not np.any(matrix @ generator.T)
-    assert np.array_equal(diag.astype(bool), np.eye(len(diag), dtype=bool))
-    assert np.array_equal(diag @ generator, generator)
-    assert np.array_equal(diag.T @ dual, dual)
-    assert np.array_equal(diag, transformer.transpose_array(diag))
-
-    # _block_diag handles matrices over bimodules
-    matrix = abstract.RingArray.build(np.eye(2, dtype=int), ring)
-    kron_mat = abstract.kron(matrix, matrix)
-    result = codes.quantum._block_diag(kron_mat, kron_mat)
-    assert result.shape == (kron_mat.shape[0] * 2, kron_mat.shape[1] * 2, 2)
-    assert np.array_equal(result[: kron_mat.shape[0], : kron_mat.shape[1]], kron_mat)
-    assert np.array_equal(result[kron_mat.shape[0] :, kron_mat.shape[1] :], kron_mat)
-    assert not np.any(result[: kron_mat.shape[0], kron_mat.shape[1] :])
-    assert not np.any(result[kron_mat.shape[0] :, : kron_mat.shape[1]])
 
 
 def test_quantum_tanner(pytestconfig: pytest.Config) -> None:

--- a/src/qldpc/conftest.py
+++ b/src/qldpc/conftest.py
@@ -29,3 +29,21 @@ def ring_alternating4_gf5(pytestconfig: pytest.Config) -> abstract.GroupRing:
     ring = abstract.GroupRing(abstract.AlternatingGroup(4), field=5)
     ring.get_transformer(seed=pytestconfig.getoption("randomly_seed"))
     return ring
+
+
+@pytest.fixture(name="ring", scope="session", params=["cyclic3_gf4", "alternating4_gf5"])
+def rings_to_test(
+    request: pytest.FixtureRequest,
+    ring_cyclic3_gf2: abstract.GroupRing,
+    ring_cyclic3_gf4: abstract.GroupRing,
+    ring_alternating4_gf5: abstract.GroupRing,
+) -> abstract.GroupRing:
+    """Retrieve a ring for which we have pre-built a Wedderburn-Artin transformer."""
+    match request.param:
+        case "cyclic3_gf2":
+            return ring_cyclic3_gf2
+        case "cyclic3_gf4":
+            return ring_cyclic3_gf4
+        case "alternating4_gf5":
+            return ring_alternating4_gf5
+    raise ValueError(f"Invalid fixture name: {request.param}")  # pragma: no cover


### PR DESCRIPTION
- Factor some code out of `rings.py` to `linalg.py`
- Sort out how the Kronecker product should work for non-commutative rings
- Fix construction ring-logical line operators for `LPCode` and `SLPCode` over semisimple non-commutative rings.