### PR TITLE
Allow passing fields to `field` arguments

### DIFF
--- a/src/qldpc/abstract/__init__.py
+++ b/src/qldpc/abstract/__init__.py
@@ -1,5 +1,5 @@
 from .groups import (
-    DEFAULT_FIELD_ORDER,
+    GF2,
     PSL,
     SL,
     AbelianGroup,
@@ -15,6 +15,7 @@ from .groups import (
     SymmetricGroup,
     TrivialGroup,
     get_coefficient_and_exponents,
+    resolve_field,
 )
 from .linalg import (
     block_diag,
@@ -35,7 +36,7 @@ from .wedderburn_artin import (
 )
 
 __all__ = [
-    "DEFAULT_FIELD_ORDER",
+    "GF2",
     "PSL",
     "SL",
     "AbelianGroup",
@@ -51,6 +52,7 @@ __all__ = [
     "SymmetricGroup",
     "TrivialGroup",
     "get_coefficient_and_exponents",
+    "resolve_field",
     "block_diag",
     "get_howell_dual",
     "kron",

--- a/src/qldpc/abstract/groups.py
+++ b/src/qldpc/abstract/groups.py
@@ -48,7 +48,16 @@ import sympy.core
 
 from qldpc import external
 
-DEFAULT_FIELD_ORDER = 2
+GF2: type[galois.FieldArray] = galois.GF(2)
+
+
+def resolve_field(field: int | type[galois.FieldArray] | None) -> type[galois.FieldArray]:
+    if field is None:
+        return GF2
+    if isinstance(field, int):
+        return galois.GF(field)
+    return field
+
 
 NestedSequence = Sequence[Union[object, Sequence["NestedSequence"]]]
 
@@ -720,10 +729,15 @@ class SpecialLinearGroup(Group):
     _dimension: int
     _field: type[galois.FieldArray]
 
-    def __init__(self, dimension: int, field: int | None = None, linear_rep: bool = True) -> None:
+    def __init__(
+        self,
+        dimension: int,
+        field: int | type[galois.FieldArray] | None = None,
+        linear_rep: bool = True,
+    ) -> None:
         self._name = f"SL({dimension},{field})"
         self._dimension = dimension
-        self._field = galois.GF(field or DEFAULT_FIELD_ORDER)
+        self._field = resolve_field(field)
 
         if linear_rep:
             # Construct a linear representation of this group, in which group elements permute
@@ -781,28 +795,30 @@ class SpecialLinearGroup(Group):
 
     @staticmethod
     def get_generating_mats(
-        dimension: int, field: int | None = None
+        dimension: int, field: int | type[galois.FieldArray] | None = None
     ) -> tuple[galois.FieldArray, galois.FieldArray]:
         """Generating matrices for the Special Linear group, based on arXiv:2201.09155."""
-        base_field = galois.GF(field or DEFAULT_FIELD_ORDER)
-        minus_one = -base_field(1)
-        gen_w = minus_one * np.diag(np.ones(dimension - 1, dtype=int), k=-1).view(base_field)
+        field = resolve_field(field)
+        minus_one = -field(1)
+        gen_w = minus_one * np.diag(np.ones(dimension - 1, dtype=int), k=-1).view(field)
         gen_w[0, -1] = 1
-        gen_x = base_field.Identity(dimension)
-        if base_field.order <= 3:
+        gen_x = field.Identity(dimension)
+        if field is GF2:
             gen_x[0, 1] = 1
         else:
-            gen_x[0, 0] = base_field.primitive_element
-            gen_x[1, 1] = base_field.primitive_element**-1
+            gen_x[0, 0] = field.primitive_element
+            gen_x[1, 1] = field.primitive_element**-1
             gen_w[0, 0] = minus_one
         return gen_x, gen_w
 
     @staticmethod
-    def iter_mats(dimension: int, field: int | None = None) -> Iterator[galois.FieldArray]:
+    def iter_mats(
+        dimension: int, field: int | type[galois.FieldArray] | None = None
+    ) -> Iterator[galois.FieldArray]:
         """Iterate over all elements of SL(dimension, field)."""
-        base_field = galois.GF(field or DEFAULT_FIELD_ORDER)
-        for vec in itertools.product(base_field.elements, repeat=dimension**2):
-            mat = np.reshape(vec, (dimension, dimension)).view(base_field)
+        field = resolve_field(field)
+        for vec in itertools.product(field.elements, repeat=dimension**2):
+            mat = np.reshape(vec, (dimension, dimension)).view(field)
             if np.linalg.det(mat) == 1:
                 yield mat
 
@@ -821,10 +837,15 @@ class ProjectiveSpecialLinearGroup(Group):
     _dimension: int
     _field: type[galois.FieldArray]
 
-    def __init__(self, dimension: int, field: int | None = None, linear_rep: bool = True) -> None:
+    def __init__(
+        self,
+        dimension: int,
+        field: int | type[galois.FieldArray] | None = None,
+        linear_rep: bool = True,
+    ) -> None:
         self._name = f"PSL({dimension},{field})"
         self._dimension = dimension
-        self._field = galois.GF(field or DEFAULT_FIELD_ORDER)
+        self._field = resolve_field(field)
 
         if linear_rep:
             # Construct a linear representation of this group, in which group elements permute
@@ -892,32 +913,33 @@ class ProjectiveSpecialLinearGroup(Group):
 
     @staticmethod
     def get_generating_mats(
-        dimension: int, field: int | None = None
+        dimension: int, field: int | type[galois.FieldArray] | None = None
     ) -> tuple[galois.FieldArray, galois.FieldArray]:
         """Generating matrices of PSL, constructed out of the generating matrices of SL."""
-        base_field = galois.GF(field or DEFAULT_FIELD_ORDER)
+        field = resolve_field(field)
         gen_x, gen_w = SpecialLinearGroup.get_generating_mats(dimension, field)
-        if base_field.order == 2:
+        if field is GF2:
             return gen_x, gen_w
         return (
-            np.kron(np.linalg.inv(gen_x), gen_x).view(base_field),
-            np.kron(np.linalg.inv(gen_w), gen_w).view(base_field),
+            np.kron(np.linalg.inv(gen_x), gen_x).view(field),
+            np.kron(np.linalg.inv(gen_w), gen_w).view(field),
         )
 
     @staticmethod
-    def iter_mats(dimension: int, field: int | None = None) -> Iterator[galois.FieldArray]:
+    def iter_mats(
+        dimension: int, field: int | type[galois.FieldArray] | None = None
+    ) -> Iterator[galois.FieldArray]:
         """Iterate over all elements of PSL(dimension, field)."""
-        field = field or DEFAULT_FIELD_ORDER
-        base_field = galois.GF(field)
-        num_roots = math.gcd(dimension, base_field.order - 1)
-        primitive_root = base_field.primitive_element ** ((base_field.order - 1) // num_roots)
+        field = resolve_field(field)
+        num_roots = math.gcd(dimension, field.order - 1)
+        primitive_root = field.primitive_element ** ((field.order - 1) // num_roots)
         roots = [primitive_root**k for k in range(dimension)]
         orbits = [
             frozenset([(root * mat).tobytes() for root in roots])
             for mat in SpecialLinearGroup.iter_mats(dimension, field)
         ]
         for orbit in set(orbits):
-            yield np.frombuffer(next(iter(orbit)), dtype=np.uint8).view(base_field)
+            yield np.frombuffer(next(iter(orbit)), dtype=np.uint8).view(field)
 
 
 SL = SpecialLinearGroup

--- a/src/qldpc/abstract/groups.py
+++ b/src/qldpc/abstract/groups.py
@@ -51,7 +51,10 @@ from qldpc import external
 GF2: type[galois.FieldArray] = galois.GF(2)
 
 
-def resolve_field(field: int | type[galois.FieldArray] | None) -> type[galois.FieldArray]:
+def resolve_field(
+    field: int | type[galois.FieldArray] | None,
+) -> type[galois.FieldArray]:  # pragma: no cover
+    """Parse a finite field argument to obtain an actual finite field."""
     if field is None:
         return GF2
     if isinstance(field, int):

--- a/src/qldpc/abstract/groups.py
+++ b/src/qldpc/abstract/groups.py
@@ -803,7 +803,7 @@ class SpecialLinearGroup(Group):
         gen_w = minus_one * np.diag(np.ones(dimension - 1, dtype=int), k=-1).view(field)
         gen_w[0, -1] = 1
         gen_x = field.Identity(dimension)
-        if field is GF2:
+        if field.order <= 3:
             gen_x[0, 1] = 1
         else:
             gen_x[0, 0] = field.primitive_element

--- a/src/qldpc/abstract/linalg.py
+++ b/src/qldpc/abstract/linalg.py
@@ -113,7 +113,7 @@ def get_bimodule(ring: GroupRing) -> GroupRing:
         return ring.group.lift(part_l) @ ring.group.lift(~part_r, right=True)
 
     bimodule_group = Group(ring.group.to_sympy() * ring.group.to_sympy(), lift=lift)
-    return GroupRing(bimodule_group, ring.field.order)
+    return GroupRing(bimodule_group, ring.field)
 
 
 def block_diag(

--- a/src/qldpc/abstract/rings.py
+++ b/src/qldpc/abstract/rings.py
@@ -41,7 +41,7 @@ import sympy.core
 import qldpc
 from qldpc import external
 
-from .groups import DEFAULT_FIELD_ORDER, AbelianGroup, CyclicGroup, Group, GroupMember, TrivialGroup
+from .groups import AbelianGroup, CyclicGroup, Group, GroupMember, TrivialGroup, resolve_field
 
 if TYPE_CHECKING:
     from .wedderburn_artin import WedderburnArtinTransformer
@@ -61,9 +61,9 @@ class GroupRing:
     _transformers: dict[int | None, WedderburnArtinTransformer]
     _idempotents: tuple[RingMember, ...] | None = None
 
-    def __init__(self, group: Group, field: int | None = None) -> None:
+    def __init__(self, group: Group, field: int | type[galois.FieldArray] | None = None) -> None:
         self._group = group
-        self._field = galois.GF(field or DEFAULT_FIELD_ORDER)
+        self._field = resolve_field(field)
         self._transformers = {}
 
     @property

--- a/src/qldpc/circuits/common.py
+++ b/src/qldpc/circuits/common.py
@@ -26,6 +26,7 @@ import numpy.typing as npt
 import stim
 
 from qldpc import codes, math
+from qldpc.abstract import GF2
 
 CircuitOrTableau = TypeVar("CircuitOrTableau", stim.Circuit, stim.Tableau)
 Params = ParamSpec("Params")
@@ -38,7 +39,7 @@ def restrict_to_qubits(
 
     @functools.wraps(func)
     def qubit_func(*args: Params.args, **kwargs: Params.kwargs) -> stim.Circuit:
-        if any(isinstance(arg, codes.QuditCode) and arg.field.order != 2 for arg in args):
+        if any(isinstance(arg, codes.QuditCode) and arg.field is not GF2 for arg in args):
             raise ValueError("Circuit methods are only supported for qubit codes")
         return func(*args, **kwargs)
 

--- a/src/qldpc/codes/classical.py
+++ b/src/qldpc/codes/classical.py
@@ -223,7 +223,7 @@ class BCHCode(ClassicalCode):
     ) -> None:
         field = resolve_field(field)
         length_in_base = np.base_repr(length, base=field.order)
-        if not length_in_base == str(field.order - 1) * len(length_in_base):
+        if length_in_base != str(field.order - 1) * len(length_in_base):
             raise ValueError(
                 f"BCH codes over GF({field.order}) are only defined for block lengths"
                 f" {field.order}**m - 1 with integer m."

--- a/src/qldpc/codes/classical.py
+++ b/src/qldpc/codes/classical.py
@@ -27,7 +27,7 @@ import numpy.typing as npt
 import sympy
 
 from qldpc import abstract
-from qldpc.abstract import DEFAULT_FIELD_ORDER
+from qldpc.abstract import GF2, resolve_field
 
 from .common import ClassicalCode
 
@@ -35,8 +35,8 @@ from .common import ClassicalCode
 class RepetitionCode(ClassicalCode):
     """Classical repetition code."""
 
-    def __init__(self, bits: int, field: int | None = None) -> None:
-        self._field = galois.GF(field or DEFAULT_FIELD_ORDER)
+    def __init__(self, bits: int, field: int | type[galois.FieldArray] | None = None) -> None:
+        self._field = resolve_field(field)
         self._matrix = self.field.Zeros((bits - 1, bits))
         for row in range(bits - 1):
             self._matrix[row, row] = 1
@@ -49,8 +49,8 @@ class RepetitionCode(ClassicalCode):
 class RingCode(ClassicalCode):
     """Classical ring code: repetition code with periodic boundary conditions."""
 
-    def __init__(self, bits: int, field: int | None = None) -> None:
-        self._field = galois.GF(field or DEFAULT_FIELD_ORDER)
+    def __init__(self, bits: int, field: int | type[galois.FieldArray] | None = None) -> None:
+        self._field = resolve_field(field)
         self._matrix = self.field.Zeros((bits, bits))
         for row in range(bits):
             self._matrix[row, row] = 1
@@ -72,7 +72,9 @@ class CyclicCode(ClassicalCode):
     The CyclicCode with polynomial 1 - x is a RingCode.
     """
 
-    def __init__(self, bits: int, poly: sympy.Basic, field: int | None = None) -> None:
+    def __init__(
+        self, bits: int, poly: sympy.Basic, field: int | type[galois.FieldArray] | None = None
+    ) -> None:
         """Construct a cyclic code from a block length and a polynomial in one variable."""
         if not isinstance(poly, sympy.Basic) or not len(poly.free_symbols) == 1:
             raise ValueError(f"{poly} is not a univariate polynomial")
@@ -92,11 +94,11 @@ class HammingCode(ClassicalCode):
     field; equivalently, from all vectors whose first nonzero element is a 1.
     """
 
-    def __init__(self, size: int, field: int | None = None) -> None:
+    def __init__(self, size: int, field: int | type[galois.FieldArray] | None = None) -> None:
         """Construct a Hamming code of a given rank."""
         self._distance = 3
-        self._field = galois.GF(field or DEFAULT_FIELD_ORDER)
-        if self.field.order == 2:
+        self._field = resolve_field(field)
+        if self.field is GF2:
             # collect all nonzero bitstrings
             bitstrings = list(itertools.product([0, 1], repeat=size))
             self._matrix = self.field(bitstrings[1:]).T
@@ -145,14 +147,16 @@ class ReedMullerCode(ClassicalCode):
     - https://feog.github.io/10-coding.pdf
     """
 
-    def __init__(self, order: int, size: int, field: int | None = None) -> None:
+    def __init__(
+        self, order: int, size: int, field: int | type[galois.FieldArray] | None = None
+    ) -> None:
         self._assert_valid_params(order, size)
         self._order = order
         self._size = size
 
         generator = ReedMullerCode.get_generator(order, size)
         self._matrix = ClassicalCode(generator, field).generator
-        self._field = galois.GF(field or DEFAULT_FIELD_ORDER)
+        self._field = resolve_field(field)
 
         self._dimension = len(generator)
         self._distance = 2 ** (size - order)
@@ -214,15 +218,17 @@ class BCHCode(ClassicalCode):
     - https://www.cs.cmu.edu/~venkatg/teaching/codingtheory/notes/notes6.pdf
     """
 
-    def __init__(self, length: int, dimension: int, field: int | None = None) -> None:
-        field = field or DEFAULT_FIELD_ORDER
-        length_in_base = np.base_repr(length, base=field)
-        if not length_in_base == str(field - 1) * len(length_in_base):
+    def __init__(
+        self, length: int, dimension: int, field: int | type[galois.FieldArray] | None = None
+    ) -> None:
+        field = resolve_field(field)
+        length_in_base = np.base_repr(length, base=field.order)
+        if not length_in_base == str(field.order - 1) * len(length_in_base):
             raise ValueError(
-                f"BCH codes over F_{field} are only defined for block lengths {field}^m - 1 with"
-                " integer m."
+                f"BCH codes over GF({field.order}) are only defined for block lengths"
+                f" {field.order}**m - 1 with integer m."
             )
-        super().__init__(galois.BCH(length, dimension, field=galois.GF(field)).H)
+        super().__init__(galois.BCH(length, dimension, field=field).H)
         self._dimension = dimension
 
 
@@ -237,18 +243,20 @@ class SimplexCode(ClassicalCode):
     - https://arxiv.org/abs/2502.07150
     """
 
-    def __init__(self, dim: int, field: int | None = None) -> None:
-        field = field or DEFAULT_FIELD_ORDER
+    def __init__(self, dim: int, field: int | type[galois.FieldArray] | None = None) -> None:
+        field = resolve_field(field)
         polynomial = SimplexCode.get_defining_polynomial(dim, field)
-        coefficients = polynomial.coefficients(size=field**dim - 1, order="asc")
+        coefficients = polynomial.coefficients(size=field.order**dim - 1, order="asc")
         matrix = np.array([np.roll(coefficients, jj) for jj in range(len(coefficients))])
         super().__init__(matrix, field=field)
 
         self._dimension = dim
-        self._distance = field ** (dim - 1) * (field - 1)
+        self._distance = field.order ** (dim - 1) * (field.order - 1)
 
     @staticmethod
-    def get_defining_polynomial(dim: int, field: int | None = None) -> galois.Poly:
+    def get_defining_polynomial(
+        dim: int, field: int | type[galois.FieldArray] | None = None
+    ) -> galois.Poly:
         """The polynomial that defines a SimplexCode of a given dimension and base field.
 
         Returns a three-term polynomial of the form h(x) = 1 + a * x**c + b * x**d, where
@@ -256,30 +264,30 @@ class SimplexCode(ClassicalCode):
         - the exponents c and d are integers, and
         - gcd(h(x), x ** (field**dim - 1) - 1) is a primitive polynomial of degree dim.
         """
-        field = field or DEFAULT_FIELD_ORDER
+        field = resolve_field(field)
 
         # first try finding a primitive three-term polynomial of degree dim
         try:
-            primitive_polys = galois.primitive_polys(order=field, degree=dim, terms=3)
+            primitive_polys = galois.primitive_polys(order=field.order, degree=dim, terms=3)
             return next(primitive_polys)
         except StopIteration:
             None
 
         # find a suitable polynomial by brute force
 
-        order = field**dim - 1
+        order = field.order**dim - 1
         mod_poly_coefficients = [0] * (order + 1)
         mod_poly_coefficients[0] = -1
         mod_poly_coefficients[-1] = 1
-        mod_poly = galois.Poly(mod_poly_coefficients, field=galois.GF(field))
+        mod_poly = galois.Poly(mod_poly_coefficients, field=field)
 
-        for aa, bb in itertools.product(range(1, field), repeat=2):
+        for aa, bb in itertools.product(range(1, field.order), repeat=2):
             for cc, dd in itertools.combinations(range(1, order + 1), 2):
                 coefficients = [0] * (order + 1)
                 coefficients[0] = 1
                 coefficients[cc] = aa
                 coefficients[dd] = bb
-                poly = galois.Poly(coefficients[::-1], field=galois.GF(field))
+                poly = galois.Poly(coefficients[::-1], field=field)
                 gcd_poly = galois.gcd(poly, mod_poly)
                 if gcd_poly.degree == dim and gcd_poly.is_primitive():
                     return poly
@@ -337,7 +345,7 @@ class TannerCode(ClassicalCode):
             checks = range(subcode.num_checks * idx, subcode.num_checks * (idx + 1))
             bits = [sink_indices[sink] for sink in self._get_sorted_neighbors(source)]
             matrix[np.ix_(checks, bits)] = subcode.matrix
-        super().__init__(matrix, subcode.field.order)
+        super().__init__(matrix, subcode.field)
 
     def _get_sorted_neighbors(self, node: object) -> Sequence[object]:
         """Sorted neighbors of the given node."""

--- a/src/qldpc/codes/classical.py
+++ b/src/qldpc/codes/classical.py
@@ -225,8 +225,8 @@ class BCHCode(ClassicalCode):
         length_in_base = np.base_repr(length, base=field.order)
         if length_in_base != str(field.order - 1) * len(length_in_base):
             raise ValueError(
-                f"BCH codes over GF({field.order}) are only defined for block lengths"
-                f" {field.order}**m - 1 with integer m."
+                f"BCH codes over F_{field.order} are only defined for block lengths"
+                f" {field.order}^m - 1 with integer m."
             )
         super().__init__(galois.BCH(length, dimension, field=field).H)
         self._dimension = dimension

--- a/src/qldpc/codes/classical_test.py
+++ b/src/qldpc/codes/classical_test.py
@@ -73,7 +73,7 @@ def test_special_codes() -> None:
 
     bits, dimension, field = 7, 4, 2
     assert codes.BCHCode(bits, dimension, field).dimension == dimension
-    with pytest.raises(ValueError, match=rf"block lengths {field}\*\*m - 1"):
+    with pytest.raises(ValueError, match=rf"block lengths {field}\^m - 1"):
         codes.BCHCode(bits - 1, dimension, field)
 
     order, size, field = 1, 3, 2

--- a/src/qldpc/codes/classical_test.py
+++ b/src/qldpc/codes/classical_test.py
@@ -73,7 +73,7 @@ def test_special_codes() -> None:
 
     bits, dimension, field = 7, 4, 2
     assert codes.BCHCode(bits, dimension, field).dimension == dimension
-    with pytest.raises(ValueError, match=rf"block lengths {field}**m - 1"):
+    with pytest.raises(ValueError, match=rf"block lengths {field}\*\*m - 1"):
         codes.BCHCode(bits - 1, dimension, field)
 
     order, size, field = 1, 3, 2

--- a/src/qldpc/codes/classical_test.py
+++ b/src/qldpc/codes/classical_test.py
@@ -73,7 +73,7 @@ def test_special_codes() -> None:
 
     bits, dimension, field = 7, 4, 2
     assert codes.BCHCode(bits, dimension, field).dimension == dimension
-    with pytest.raises(ValueError, match=rf"block lengths {field}\^m - 1"):
+    with pytest.raises(ValueError, match=rf"block lengths {field}**m - 1"):
         codes.BCHCode(bits - 1, dimension, field)
 
     order, size, field = 1, 3, 2

--- a/src/qldpc/codes/common.py
+++ b/src/qldpc/codes/common.py
@@ -2010,10 +2010,14 @@ class QuditCode(AbstractCode):
             # decode errors
             error_locs_x = error_locations[error_paulis > 1]
             error_x = np.zeros(len(self), dtype=int)
-            error_x[error_locs_x] = np.random.choice(self.field.values[1:], size=len(error_locs_x))
+            error_x[error_locs_x] = np.random.choice(
+                range(1, self.field.order), size=len(error_locs_x)
+            )
             error_locs_z = error_locations[(error_paulis % 2).astype(bool)]
             error_z = np.zeros(len(self), dtype=int)
-            error_z[error_locs_z] = np.random.choice(self.field.values[1:], size=len(error_locs_z))
+            error_z[error_locs_z] = np.random.choice(
+                range(1, self.field.order), size=len(error_locs_z)
+            )
 
             error = np.concatenate([error_x, error_z]).view(self.field)
             syndrome = syndrome_matrix @ error
@@ -3099,7 +3103,9 @@ class CSSCode(QuditCode):
             # decode Z-type errors
             error_locs_z = error_locations[(error_paulis % 2).astype(bool)]
             error_z = self.field.Zeros(len(self))
-            error_z[error_locs_z] = np.random.choice(self.field.values[1:], size=len(error_locs_z))
+            error_z[error_locs_z] = np.random.choice(
+                range(1, self.field.order), size=len(error_locs_z)
+            )
             syndrome_z = self.matrix_x @ error_z
             decoded_error_z, erasure = _get_error_and_erasure(decoder_z, syndrome_z)
             if erasure:
@@ -3116,7 +3122,9 @@ class CSSCode(QuditCode):
             # decode X-type errors
             error_locs_x = error_locations[error_paulis > 1]
             error_x = self.field.Zeros(len(self))
-            error_x[error_locs_x] = np.random.choice(self.field.values[1:], size=len(error_locs_x))
+            error_x[error_locs_x] = np.random.choice(
+                range(1, self.field.order), size=len(error_locs_x)
+            )
             syndrome_x = self.matrix_z @ error_x
             decoded_error_x, erasure = _get_error_and_erasure(decoder_x, syndrome_x)
             if erasure:

--- a/src/qldpc/codes/common.py
+++ b/src/qldpc/codes/common.py
@@ -36,7 +36,7 @@ import scipy.sparse
 import stim
 
 from qldpc import abstract, decoders, external, math
-from qldpc.abstract import DEFAULT_FIELD_ORDER
+from qldpc.abstract import GF2, resolve_field
 from qldpc.math import IntegerArray
 from qldpc.objects import PAULIS_XZ, Node, Pauli, PauliXZ, QuditPauli
 
@@ -88,7 +88,7 @@ class AbstractCode(abc.ABC):
     def __init__(
         self,
         matrix: AbstractCode | IntegerArray | Sequence[Sequence[int]],
-        field: int | None = None,
+        field: int | type[galois.FieldArray] | None = None,
     ) -> None:
         """Construct a code from a parity check matrix over a finite field.
 
@@ -100,20 +100,20 @@ class AbstractCode(abc.ABC):
             self._dimension = matrix._dimension
             self._distance = matrix._distance
 
-            if field is not None and field != matrix._field.order:
+            if field is not None and resolve_field(field) is not matrix._field:
                 raise ValueError(
                     f"Field argument {field} is inconsistent with the given code, which is defined"
-                    f" over F_{self._field.order}"
+                    f" over GF({self._field.order})"
                 )
 
             self._is_canonicalized = matrix._is_canonicalized
 
         elif isinstance(matrix, galois.FieldArray):
-            self._field = galois.GF(field) if field else type(matrix)
+            self._field = resolve_field(field) if field is not None else type(matrix)
             self._matrix = matrix.view(self._field)
 
         else:
-            self._field = galois.GF(field or DEFAULT_FIELD_ORDER)
+            self._field = resolve_field(field)
             self._matrix = np.asanyarray(
                 matrix.todense() if scipy.sparse.issparse(matrix) else matrix,  # type:ignore[union-attr]
             ).view(self.field)
@@ -229,7 +229,7 @@ class ClassicalCode(AbstractCode):
     def __init__(
         self,
         matrix: AbstractCode | IntegerArray | Sequence[Sequence[int]],
-        field: int | None = None,
+        field: int | type[galois.FieldArray] | None = None,
     ) -> None:
         """Construct a classical code from a parity check matrix over a finite field."""
         super().__init__(matrix, field)
@@ -248,7 +248,7 @@ class ClassicalCode(AbstractCode):
     def __str__(self) -> str:
         """Human-readable representation of this code."""
         text = ""
-        if self.field.order == 2:
+        if self.field is GF2:
             text += f"{self.name} on {len(self)} bits"
         else:
             text += f"{self.name} on {len(self)} symbols over {self.field_name}"
@@ -268,7 +268,7 @@ class ClassicalCode(AbstractCode):
             return self
         matrix_rref = self.matrix.row_reduce()
         matrix_rref = matrix_rref[np.any(matrix_rref, axis=1), :]
-        code = ClassicalCode(matrix_rref, self.field.order)
+        code = ClassicalCode(matrix_rref, self.field)
         code._dimension = len(self) - len(matrix_rref)
         code._distance = self._distance
         code._is_canonicalized = True
@@ -310,7 +310,7 @@ class ClassicalCode(AbstractCode):
             node_c = Node(index=int(row), is_data=False)
             node_d = Node(index=int(col), is_data=True)
             graph.add_edge(node_c, node_d, val=matrix[row][col])
-        graph.field = galois.GF(getattr(type(matrix), "order", DEFAULT_FIELD_ORDER))
+        setattr(graph, "field", type(matrix) if isinstance(matrix, galois.FieldArray) else GF2)
         return graph
 
     @staticmethod
@@ -318,7 +318,7 @@ class ClassicalCode(AbstractCode):
         """Convert a Tanner graph into a parity check matrix."""
         num_bits = sum(node.is_data for node in graph.nodes())
         num_checks = len(graph.nodes()) - num_bits
-        field = getattr(graph, "field", galois.GF(DEFAULT_FIELD_ORDER))
+        field = getattr(graph, "field", GF2)
         matrix = field.Zeros((num_checks, num_bits))
         for node_c, node_b, data in graph.edges(data=True):
             matrix[node_c.index, node_b.index] = data.get("val", 1)
@@ -466,7 +466,7 @@ class ClassicalCode(AbstractCode):
             return known_distance
 
         # we do not know the exact distance, so compute it
-        if self.field.order == 2 and vector is None:
+        if self.field is GF2 and vector is None:
             distance = get_distance_classical(self.generator, cutoff=cutoff)
             if cutoff <= 1:
                 self._distance = int(distance)
@@ -574,25 +574,30 @@ class ClassicalCode(AbstractCode):
 
     @staticmethod
     def random(
-        bits: int, checks: int, field: int | None = None, *, seed: int | None = None
+        bits: int,
+        checks: int,
+        field: int | type[galois.FieldArray] | None = None,
+        *,
+        seed: int | None = None,
     ) -> ClassicalCode:
         """Construct a random linear code with the given number of bits and checks.
 
         Reject any code with trivial checks or unchecked bits, identified by an all-zero row or
         column in the code's parity check matrix.
         """
-        code_field = galois.GF(field or DEFAULT_FIELD_ORDER)
+        field = resolve_field(field)
 
         def nontrivial(matrix: galois.FieldArray) -> bool:
             """Return True iff all rows and columns are nonzero."""
             return all(np.any(row) for row in matrix) and all(np.any(col) for col in matrix.T)
 
-        matrix = get_random_array(code_field, (checks, bits), satisfy=nontrivial, seed=seed)
+        matrix = get_random_array(field, (checks, bits), satisfy=nontrivial, seed=seed)
         return ClassicalCode(matrix)
 
     @staticmethod
     def from_generator(
-        generator: npt.NDArray[np.int_] | Sequence[Sequence[int]], field: int | None = None
+        generator: npt.NDArray[np.int_] | Sequence[Sequence[int]],
+        field: int | type[galois.FieldArray] | None = None,
     ) -> ClassicalCode:
         """Construct a ClassicalCode from a generator matrix."""
         return ~ClassicalCode(generator, field)
@@ -629,7 +634,7 @@ class ClassicalCode(AbstractCode):
         code_str = f"CheckMatCode({matrix_str}, GF({self.field.order}))"
 
         # try GAP/GAUAVA's AutomorphismGroup method
-        if self.field.order == 2:
+        if self.field is GF2:
             try:
                 return abstract.Group.from_name(
                     f"AutomorphismGroup({code_str})", warning_to_raise_if_calling_gap=warning
@@ -682,7 +687,7 @@ class ClassicalCode(AbstractCode):
             if nonzero_rows.size:
                 pivot_row, rows_to_reduce = nonzero_rows[0], nonzero_rows[1:]
                 if rows_to_reduce.size:
-                    if self.field.order == 2:
+                    if self.field is GF2:
                         new_matrix[rows_to_reduce] -= new_matrix[pivot_row]
                     else:
                         prefactors = new_matrix[rows_to_reduce, bit] / new_matrix[pivot_row, bit]
@@ -780,7 +785,7 @@ class ClassicalCode(AbstractCode):
             # construct an error
             error_locations = random.sample(range(len(self)), error_weight)
             error = self.field.Zeros(len(self))
-            error[error_locations] = np.random.choice(range(1, self.field.order), size=error_weight)
+            error[error_locations] = np.random.choice(self.field.elements[1:], size=error_weight)
 
             # decode the error
             syndrome = self.matrix @ error
@@ -836,7 +841,7 @@ class QuditCode(AbstractCode):
     def __init__(
         self,
         matrix: AbstractCode | IntegerArray | Sequence[Sequence[int]],
-        field: int | None = None,
+        field: int | type[galois.FieldArray] | None = None,
         *,
         is_subsystem_code: bool | None = None,
     ) -> None:
@@ -864,7 +869,7 @@ class QuditCode(AbstractCode):
     def __str__(self) -> str:
         """Human-readable representation of this code."""
         text = f"{self.name} on {len(self)}"
-        if self.field.order == 2:
+        if self.field is GF2:
             text += " qubits"
         else:
             text += f" qudits over {self.field_name}"
@@ -887,7 +892,7 @@ class QuditCode(AbstractCode):
             return self
         matrix_rref = self.matrix.row_reduce()
         matrix_rref = matrix_rref[np.any(matrix_rref, axis=1), :]
-        code = QuditCode(matrix_rref, self.field.order, is_subsystem_code=self._is_subsystem_code)
+        code = QuditCode(matrix_rref, self.field, is_subsystem_code=self._is_subsystem_code)
         if not self._is_subsystem_code:
             code._dimension = len(code) - len(matrix_rref)
         code._distance = self._distance
@@ -905,12 +910,12 @@ class QuditCode(AbstractCode):
 
         # initialize graph with nodes
         graph = nx.DiGraph()
-        graph.field = galois.GF(getattr(type(matrix), "order", DEFAULT_FIELD_ORDER))
+        setattr(graph, "field", type(matrix) if isinstance(matrix, galois.FieldArray) else GF2)
         for qudit in range(matrix.shape[-1]):
             graph.add_node(Node(index=qudit, is_data=True))
 
         # add edges
-        _Pauli = Pauli if graph.field.order == 2 else QuditPauli
+        _Pauli = Pauli if graph.field is GF2 else QuditPauli
         for row, xz, col in zip(*np.nonzero(matrix)):
             node_check = Node(index=int(row), is_data=False)
             node_qudit = Node(index=int(col), is_data=True)
@@ -931,7 +936,7 @@ class QuditCode(AbstractCode):
         matrix = np.zeros((num_checks, 2, num_qudits), dtype=int)
         for node_check, node_qudit, data in graph.edges(data=True):
             matrix[node_check.index, :, node_qudit.index] = data.get(Pauli).value
-        field = getattr(graph, "field", galois.GF(DEFAULT_FIELD_ORDER))
+        field = getattr(graph, "field", GF2)
         return field(matrix.reshape(num_checks, 2 * num_qudits))
 
     def maybe_to_css(self) -> QuditCode:
@@ -994,7 +999,7 @@ class QuditCode(AbstractCode):
 
     def get_strings(self) -> list[str]:
         """Parity checks checks of this code, represented by strings."""
-        _Pauli = Pauli if self.field.order == 2 else QuditPauli
+        _Pauli = Pauli if self.field is GF2 else QuditPauli
 
         matrix = self.matrix.reshape(self.num_checks, 2, self.num_qudits)
         checks = []
@@ -1009,7 +1014,9 @@ class QuditCode(AbstractCode):
         return checks
 
     @staticmethod
-    def from_strings(checks: Sequence[str], field: int | None = None) -> QuditCode:
+    def from_strings(
+        checks: Sequence[str], field: int | type[galois.FieldArray] | None = None
+    ) -> QuditCode:
         """Construct a QuditCode from the provided parity checks.
 
         Strings such as "Z_YX" and "Z I Y X" are both recognized, but a string like "ZI Y X" is not.
@@ -1018,8 +1025,8 @@ class QuditCode(AbstractCode):
         the Galois field GF(field), such as "Z(1) _ Y(3) X(2)".  In this case "Y(a)" is an alias
         for "X(a)*Z(a)", and strings such as "Z(1) _ X(1)*Z(3) X(2)" are also valid.
         """
-        field = field or DEFAULT_FIELD_ORDER
-        operator: type[Pauli] | type[QuditPauli] = Pauli if field == 2 else QuditPauli
+        field = resolve_field(field)
+        operator: type[Pauli] | type[QuditPauli] = Pauli if field is GF2 else QuditPauli
 
         def parse_check(check: str) -> list[str]:
             check = check.replace("_", "I")
@@ -1062,7 +1069,7 @@ class QuditCode(AbstractCode):
     @property
     def num_qubits(self) -> int:
         """Number of data qubits in this code."""
-        if not self.field.order == 2:
+        if self.field is not GF2:
             raise ValueError(
                 "You asked for the number of qubits in this code, but this code is built out of "
                 rf"{self.field.order}-dimensional qudits.\nTry calling {type(self)}.num_qudits."
@@ -1648,7 +1655,7 @@ class QuditCode(AbstractCode):
         if self.is_subsystem_code:
             stabilizers = np.vstack([stabilizers, self.get_gauge_ops()]).view(self.field)
 
-        if self.field.order == 2:
+        if self.field is GF2:
             distance = get_distance_quantum(
                 logical_ops, stabilizers, cutoff=cutoff, homogeneous=False
             )
@@ -1754,7 +1761,7 @@ class QuditCode(AbstractCode):
                 the original code, throwing an error if the original logical operators are invalid
                 for the deformed code.  Default: False.
         """
-        if not self.field.order == 2:
+        if self.field is not GF2:
             raise ValueError("Code deformation is only supported for qubit codes")
 
         # convert the physical circuit into a tableau
@@ -2003,14 +2010,10 @@ class QuditCode(AbstractCode):
             # decode errors
             error_locs_x = error_locations[error_paulis > 1]
             error_x = np.zeros(len(self), dtype=int)
-            error_x[error_locs_x] = np.random.choice(
-                range(1, self.field.order), size=len(error_locs_x)
-            )
+            error_x[error_locs_x] = np.random.choice(self.field.values[1:], size=len(error_locs_x))
             error_locs_z = error_locations[(error_paulis % 2).astype(bool)]
             error_z = np.zeros(len(self), dtype=int)
-            error_z[error_locs_z] = np.random.choice(
-                range(1, self.field.order), size=len(error_locs_z)
-            )
+            error_z[error_locs_z] = np.random.choice(self.field.values[1:], size=len(error_locs_z))
 
             error = np.concatenate([error_x, error_z]).view(self.field)
             syndrome = syndrome_matrix @ error
@@ -2054,7 +2057,7 @@ class CSSCode(QuditCode):
         self,
         code_x: ClassicalCode | npt.NDArray[np.int_] | Sequence[Sequence[int]],
         code_z: ClassicalCode | npt.NDArray[np.int_] | Sequence[Sequence[int]],
-        field: int | None = None,
+        field: int | type[galois.FieldArray] | None = None,
         *,
         is_subsystem_code: bool | None = None,
         promise_equal_distance_xz: bool = False,  # do X and Z logicals have equal minimum weight?
@@ -2081,7 +2084,7 @@ class CSSCode(QuditCode):
     def __str__(self) -> str:
         """Human-readable representation of this code."""
         text = ""
-        if self.field.order == 2:
+        if self.field is GF2:
             text += f"{self.name} on {len(self)} qubits"
         else:
             text += f"{self.name} on {len(self)} qudits over {self.field_name}"
@@ -2093,7 +2096,7 @@ class CSSCode(QuditCode):
     def classical(
         code: ClassicalCode | npt.NDArray[np.int_] | Sequence[Sequence[int]],
         pauli: PauliXZ,
-        field: int | None = None,
+        field: int | type[galois.FieldArray] | None = None,
     ) -> CSSCode:
         """Construct a CSSCode of only X-type or Z-type stabilizers."""
         assert pauli in PAULIS_XZ
@@ -2634,7 +2637,7 @@ class CSSCode(QuditCode):
         if self.is_subsystem_code:
             stabilizers = np.vstack([stabilizers, self.get_gauge_ops(pauli)]).view(self.field)
 
-        if self.field.order == 2:
+        if self.field is GF2:
             distance = get_distance_quantum(
                 logical_ops, stabilizers, cutoff=cutoff, homogeneous=True
             )
@@ -3096,9 +3099,7 @@ class CSSCode(QuditCode):
             # decode Z-type errors
             error_locs_z = error_locations[(error_paulis % 2).astype(bool)]
             error_z = self.field.Zeros(len(self))
-            error_z[error_locs_z] = np.random.choice(
-                range(1, self.field.order), size=len(error_locs_z)
-            )
+            error_z[error_locs_z] = np.random.choice(self.field.values[1:], size=len(error_locs_z))
             syndrome_z = self.matrix_x @ error_z
             decoded_error_z, erasure = _get_error_and_erasure(decoder_z, syndrome_z)
             if erasure:
@@ -3115,9 +3116,7 @@ class CSSCode(QuditCode):
             # decode X-type errors
             error_locs_x = error_locations[error_paulis > 1]
             error_x = self.field.Zeros(len(self))
-            error_x[error_locs_x] = np.random.choice(
-                range(1, self.field.order), size=len(error_locs_x)
-            )
+            error_x[error_locs_x] = np.random.choice(self.field.values[1:], size=len(error_locs_x))
             syndrome_x = self.matrix_z @ error_x
             decoded_error_x, erasure = _get_error_and_erasure(decoder_x, syndrome_x)
             if erasure:

--- a/src/qldpc/codes/common.py
+++ b/src/qldpc/codes/common.py
@@ -103,7 +103,7 @@ class AbstractCode(abc.ABC):
             if field is not None and resolve_field(field) is not matrix._field:
                 raise ValueError(
                     f"Field argument {field} is inconsistent with the given code, which is defined"
-                    f" over GF({self._field.order})"
+                    f" over F_{self._field.order}"
                 )
 
             self._is_canonicalized = matrix._is_canonicalized

--- a/src/qldpc/codes/quantum.py
+++ b/src/qldpc/codes/quantum.py
@@ -36,7 +36,7 @@ from sympy.matrices.normalforms import hermite_normal_form
 
 import qldpc
 from qldpc import abstract
-from qldpc.abstract import DEFAULT_FIELD_ORDER
+from qldpc.abstract import GF2, resolve_field
 from qldpc.objects import CayleyComplex, ChainComplex, Node, Pauli, PauliXZ, QuditPauli
 
 from .classical import (
@@ -60,8 +60,8 @@ class FiveQuditCode(QuditCode):
     - https://errorcorrectionzoo.org/c/galois_5_1_3
     """
 
-    def __init__(self, field: int | None = None) -> None:
-        code_field = galois.GF(field or DEFAULT_FIELD_ORDER)
+    def __init__(self, field: int | type[galois.FieldArray] | None = None) -> None:
+        field = resolve_field(field)
         matrix = [
             [1, 0, 0, -1, 0, 0, 1, -1, 0, 0],
             [0, 1, 0, 0, -1, 0, 0, 1, -1, 0],
@@ -69,7 +69,7 @@ class FiveQuditCode(QuditCode):
             [0, -1, 0, 1, 0, -1, 0, 0, 0, 1],
         ]
         super().__init__(
-            code_field(1) * np.array(matrix, dtype=int),
+            field(1) * np.array(matrix, dtype=int),
             is_subsystem_code=False,
         )
         self._dimension = 1
@@ -94,12 +94,18 @@ class QuantumHammingCode(CSSCode):
     - https://errorcorrectionzoo.org/c/quantum_hamming_css
     """
 
-    def __init__(self, size: int, field: int | None = None, *, set_logicals: bool = True) -> None:
+    def __init__(
+        self,
+        size: int,
+        field: int | type[galois.FieldArray] | None = None,
+        *,
+        set_logicals: bool = True,
+    ) -> None:
         code = HammingCode(size, field)
         super().__init__(code, code, is_subsystem_code=False)
         self._distance_x = self._distance_z = 3
 
-        if size == 4 and set_logicals and self.field.order == 2:
+        if size == 4 and set_logicals and self.field is GF2:
             """
             Make a "nice" choice of logical operators for the [15, 7, 3] quantum Hamming code.
             Pinning all but the last logical qubit to |0> results in the TetrahedralCode.
@@ -312,7 +318,7 @@ class TBCode(CSSCode):
         self,
         matrix_a: npt.NDArray[np.int_] | Sequence[Sequence[int]],
         matrix_b: npt.NDArray[np.int_] | Sequence[Sequence[int]],
-        field: int | None = None,
+        field: int | type[galois.FieldArray] | None = None,
         *,
         promise_equal_distance_xz: bool = False,
         skip_validation: bool = False,
@@ -380,7 +386,7 @@ class QCCode(TBCode):
         orders: Sequence[int] | dict[sympy.Symbol, int],
         poly_a: sympy.Basic,
         poly_b: sympy.Basic,
-        field: int | None = None,
+        field: int | type[galois.FieldArray] | None = None,
     ) -> None:
         """Construct a generalized bicycle code."""
         self.poly_a = sympy.Poly(poly_a)
@@ -578,7 +584,7 @@ class BBCode(QCCode):
         orders: Sequence[int] | dict[sympy.Symbol, int],
         poly_a: sympy.Basic,
         poly_b: sympy.Basic,
-        field: int | None = None,
+        field: int | type[galois.FieldArray] | None = None,
     ) -> None:
         """Construct a bivariate bicycle code."""
         symbols = sympy.Poly(poly_a).free_symbols | sympy.Poly(poly_b).free_symbols
@@ -592,7 +598,7 @@ class BBCode(QCCode):
     def __str__(self) -> str:
         """Human-readable representation of this code."""
         text = ""
-        if self.field.order == 2:
+        if self.field is GF2:
             text += f"{self.name} on {self.num_qubits} qubits"
         else:
             text += f"{self.name} on {self.num_qudits} qudits over {self.field_name}"
@@ -894,7 +900,7 @@ class HGPCode(CSSCode):
         self,
         code_a: ClassicalCode | npt.NDArray[np.int_] | Sequence[Sequence[int]],
         code_b: ClassicalCode | npt.NDArray[np.int_] | Sequence[Sequence[int]] | None = None,
-        field: int | None = None,
+        field: int | type[galois.FieldArray] | None = None,
         *,
         set_logicals: bool = True,
     ) -> None:
@@ -916,7 +922,7 @@ class HGPCode(CSSCode):
             code_b = code_a
         self.code_a = ClassicalCode(code_a, field)
         self.code_b = ClassicalCode(code_b, field)
-        field = self.code_a.field.order
+        field = self.code_a.field
 
         # use a matrix-based hypergraph product to identify X-sector and Z-sector parity checks
         matrix_x, matrix_z = HGPCode.get_matrix_product(self.code_a.matrix, self.code_b.matrix)
@@ -1018,8 +1024,8 @@ class HGPCode(CSSCode):
     def get_graph_product(graph_a: nx.DiGraph, graph_b: nx.DiGraph) -> nx.DiGraph:
         """Hypergraph product of two Tanner graphs."""
         graph = nx.DiGraph()
-        field = getattr(graph_a, "field", galois.GF(DEFAULT_FIELD_ORDER))
-        _Pauli = Pauli if field.order == 2 else QuditPauli
+        field = getattr(graph_a, "field", GF2)
+        _Pauli = Pauli if field is GF2 else QuditPauli
 
         # start with a cartesian products of the input graphs
         graph_product = nx.cartesian_product(graph_a, graph_b)
@@ -1166,7 +1172,7 @@ class CHGPCode(HGPCode):
         dims: tuple[int, int] | int,
         poly_a: sympy.Basic,
         poly_b: sympy.Basic | None = None,
-        field: int | None = None,
+        field: int | type[galois.FieldArray] | None = None,
     ) -> None:
         """Construct a CHGPCode from two classical block lengths and two univariate polynomials.
 
@@ -1190,7 +1196,9 @@ class CRCode(HGPCode):
     - https://arxiv.org/pdf/2511.09683v2 (Definition 3)
     """
 
-    def __init__(self, bits: int, poly: sympy.Basic, field: int | None = None) -> None:
+    def __init__(
+        self, bits: int, poly: sympy.Basic, field: int | type[galois.FieldArray] | None = None
+    ) -> None:
         """Construct a CRCode from the block length and univariate polynomial of a CyclicCode.
 
         The block length of the RingCode used in the hypergraph product is set to the distance of
@@ -1223,7 +1231,7 @@ class SHPCode(CSSCode):
         self,
         code_a: ClassicalCode | npt.NDArray[np.int_] | Sequence[Sequence[int]],
         code_b: ClassicalCode | npt.NDArray[np.int_] | Sequence[Sequence[int]] | None = None,
-        field: int | None = None,
+        field: int | type[galois.FieldArray] | None = None,
         *,
         set_logicals: bool = True,
     ) -> None:
@@ -1232,19 +1240,19 @@ class SHPCode(CSSCode):
             code_b = code_a
         self.code_a = ClassicalCode(code_a, field)
         self.code_b = ClassicalCode(code_b, field)
-        code_field = self.code_a.field
+        field = self.code_a.field
 
         matrix_x, matrix_z = SHPCode.get_matrix_product(self.code_a.matrix, self.code_b.matrix)
         super().__init__(
             matrix_x.view(np.ndarray).astype(int),
             matrix_z.view(np.ndarray).astype(int),
-            code_field.order,
+            field,
             is_subsystem_code=True,
         )
 
         stab_ops_x = np.kron(self.code_a.matrix, self.code_b.generator)
         stab_ops_z = np.kron(-self.code_a.generator, self.code_b.matrix)
-        self._stabilizer_ops = scipy.linalg.block_diag(stab_ops_x, stab_ops_z).view(code_field)
+        self._stabilizer_ops = scipy.linalg.block_diag(stab_ops_x, stab_ops_z).view(field)
 
         if set_logicals:
             logical_ops_xz = SHPCode.get_canonical_logical_line_ops(
@@ -1365,7 +1373,7 @@ class LPCode(CSSCode):
         self.matrix_b = abstract.RingArray(matrix_b)
 
         ring = self.matrix_a.ring
-        field = ring.field.order
+        field = ring.field
 
         # identify X-sector and Z-sector parity checks
         matrix_x, matrix_z = HGPCode.get_matrix_product(self.matrix_a, self.matrix_b)
@@ -1509,7 +1517,7 @@ class SLPCode(CSSCode):
         self.matrix_b = abstract.RingArray(matrix_b)
 
         ring = self.matrix_a.ring
-        field = ring.field.order
+        field = ring.field
 
         # identify X-sector and Z-sector parity checks
         matrix_x, matrix_z = SHPCode.get_matrix_product(self.matrix_a, self.matrix_b)
@@ -1608,7 +1616,7 @@ class QTCode(CSSCode):
         subset_b: Collection[abstract.GroupMember],
         code_a: ClassicalCode | npt.NDArray[np.int_] | Sequence[Sequence[int]],
         code_b: ClassicalCode | npt.NDArray[np.int_] | Sequence[Sequence[int]] | None = None,
-        field: int | None = None,
+        field: int | type[galois.FieldArray] | None = None,
         *,
         bipartite: bool = False,
     ) -> None:
@@ -1716,7 +1724,7 @@ class QTCode(CSSCode):
         group: abstract.Group,
         code_a: ClassicalCode | npt.NDArray[np.int_] | Sequence[Sequence[int]],
         code_b: ClassicalCode | npt.NDArray[np.int_] | Sequence[Sequence[int]] | None = None,
-        field: int | None = None,
+        field: int | type[galois.FieldArray] | None = None,
         *,
         bipartite: bool = False,
         one_subset: bool = False,
@@ -1815,7 +1823,7 @@ class SurfaceCode(CSSCode):
         self,
         rows: int,
         cols: int | None = None,
-        field: int | None = None,
+        field: int | type[galois.FieldArray] | None = None,
         *,
         rotated: bool = True,
     ) -> None:
@@ -1849,9 +1857,9 @@ class SurfaceCode(CSSCode):
             ]
 
             # invert Z-type Pauli on every other qubit
-            code_field = galois.GF(field or DEFAULT_FIELD_ORDER)
-            if code_field.order > 2:
-                matrix_z = matrix_z.view(code_field)
+            field = resolve_field(field)
+            if field is not GF2:
+                matrix_z = matrix_z.view(field)
                 matrix_z[:, self.bias_tailoring_qubits] *= -1
 
         super().__init__(matrix_x, matrix_z, field=field, promise_equal_distance_xz=rows == cols)
@@ -2015,7 +2023,7 @@ class ToricCode(CSSCode):
         self,
         rows: int,
         cols: int | None = None,
-        field: int | None = None,
+        field: int | type[galois.FieldArray] | None = None,
         *,
         rotated: bool = True,
     ) -> None:
@@ -2055,9 +2063,9 @@ class ToricCode(CSSCode):
             ]
 
             # invert Z-type Pauli on every other qubit
-            code_field = galois.GF(field or DEFAULT_FIELD_ORDER)
-            if code_field.order > 2:
-                matrix_z = matrix_z.view(code_field)
+            field = resolve_field(field)
+            if field is not GF2:
+                matrix_z = matrix_z.view(field)
                 matrix_z[:, self.bias_tailoring_qubits] *= -1
 
             if rows == cols == 2 and rotated:
@@ -2154,7 +2162,7 @@ class GeneralizedSurfaceCode(CSSCode):
         self,
         size: int,
         dim: int,
-        field: int | None = None,
+        field: int | type[galois.FieldArray] | None = None,
         *,
         periodic: bool = False,
     ) -> None:
@@ -2209,12 +2217,12 @@ class T4Code(CSSCode):
     def __init__(
         self,
         matrix: npt.NDArray[np.int_] | Sequence[Sequence[int]],
-        field: int | None = None,
+        field: int | type[galois.FieldArray] | None = None,
         *,
         skip_validation: bool = False,
     ) -> None:
         """Construct a T4Code from a 4x4 integer matrix whose rows generate a 4d lattice."""
-        self._field = galois.GF(field or DEFAULT_FIELD_ORDER)
+        self._field = resolve_field(field)
 
         self.lattice_basis = hermite_normal_form(sympy.Matrix(matrix).T).T[::-1, ::-1]
         self.num_vertices = self.lattice_basis.det()
@@ -2345,7 +2353,7 @@ class BaconShorCode(SHPCode):
         self,
         rows: int,
         cols: int | None = None,
-        field: int | None = None,
+        field: int | type[galois.FieldArray] | None = None,
         *,
         set_logicals: bool = True,
     ) -> None:
@@ -2374,7 +2382,7 @@ class SHYPSCode(SHPCode):
         self,
         dim_x: int,
         dim_z: int | None = None,
-        field: int | None = None,
+        field: int | type[galois.FieldArray] | None = None,
         *,
         set_logicals: bool = True,
     ) -> None:

--- a/src/qldpc/decoders/custom.py
+++ b/src/qldpc/decoders/custom.py
@@ -32,7 +32,7 @@ import scipy.sparse
 import stim
 
 from qldpc import codes, math
-from qldpc.abstract import DEFAULT_FIELD_ORDER
+from qldpc.abstract import GF2
 from qldpc.math import IntegerArray
 from qldpc.objects import Node
 
@@ -642,7 +642,7 @@ class GUFDecoder(Decoder):
             solutions = candidate_solutions[np.where(candidate_solutions[:, -1])]
 
         # convert solutions [y,c] --> [y/c,1] --> y
-        if self.code.field.order == 2:
+        if self.code.field is GF2:
             converted_solutions = solutions[:, :-1]
         else:
             converted_solutions = solutions[:, :-1] / solutions[:, -1][:, None]
@@ -785,11 +785,7 @@ class DirectDecoder(Decoder):
     @staticmethod
     def from_indirect(decoder: Decoder, matrix: IntegerArray) -> DirectDecoder:
         """Instantiate a DirectDecoder from an indirect decoder and a parity check matrix."""
-        field = (
-            type(matrix)
-            if isinstance(matrix, galois.FieldArray)
-            else galois.GF(DEFAULT_FIELD_ORDER)
-        )
+        field = type(matrix) if isinstance(matrix, galois.FieldArray) else GF2
         field_matrix = matrix.view(field)
 
         def decode_func(candidate_word: npt.NDArray[np.int_]) -> npt.NDArray[np.int_]:

--- a/src/qldpc/decoders/custom_test.py
+++ b/src/qldpc/decoders/custom_test.py
@@ -217,7 +217,7 @@ def test_quantum_decoding(pytestconfig: pytest.Config) -> None:
     np.random.seed(pytestconfig.getoption("randomly_seed"))
 
     code = codes.SurfaceCode(4, field=3)
-    local_errors = tuple(itertools.product(range(code.field.order), repeat=2))[1:]
+    local_errors = tuple(itertools.product(code.field.elements, repeat=2))[1:]
     qubit_a, qubit_b = np.random.choice(range(len(code)), size=2, replace=False)
     pauli_a, pauli_b = random.choices(local_errors, k=2)
     error = code.field.Zeros(2 * len(code))

--- a/src/qldpc/objects.py
+++ b/src/qldpc/objects.py
@@ -30,7 +30,7 @@ import numpy as np
 import numpy.typing as npt
 
 from qldpc import abstract
-from qldpc.abstract import DEFAULT_FIELD_ORDER
+from qldpc.abstract import GF2, resolve_field
 
 
 class Pauli(enum.Enum):
@@ -390,7 +390,7 @@ class ChainComplex:
     def __init__(
         self,
         ops: Sequence[npt.NDArray[np.int_] | abstract.RingArray],
-        field: int | None = None,
+        field: int | type[galois.FieldArray] | None = None,
         *,
         skip_validation: bool = False,
     ) -> None:
@@ -402,7 +402,7 @@ class ChainComplex:
             raise ValueError("Invalid or inconsistent operator types provided for a ChainComplex")
 
         # identify the base field and/or ring for the boundary operators of this chain complex
-        fields = set([galois.GF(field)]) if field is not None else set()
+        fields = {resolve_field(field)} if field is not None else set()
         rings = set()
         for op in ops:
             if isinstance(op, abstract.RingArray):
@@ -412,7 +412,7 @@ class ChainComplex:
                 fields.add(type(op))
         if len(fields) > 1 or len(rings) > 1:
             raise ValueError("Inconsistent base fields or rings provided to a chain complex")
-        self._field = fields.pop() if fields else galois.GF(DEFAULT_FIELD_ORDER)
+        self._field = fields.pop() if fields else GF2
         self._ring = rings.pop() if rings else None
 
         # identify the boundary operators of this chain complex
@@ -475,7 +475,7 @@ class ChainComplex:
     def tensor_product(
         chain_a: ChainComplex | npt.NDArray[np.int_] | abstract.RingArray,
         chain_b: ChainComplex | npt.NDArray[np.int_] | abstract.RingArray,
-        field: int | None = None,
+        field: int | type[galois.FieldArray] | None = None,
     ) -> ChainComplex:
         """Tensor product of two chain complexes.
 


### PR DESCRIPTION
That is, `field: int | None` arguments are now `field: int | type[galois.FieldArray] | None`