### PR TITLE
Add synthetic post-selection to `DetectorErrorModelArrays`

### DIFF
--- a/src/qldpc/circuits/benchmarking.py
+++ b/src/qldpc/circuits/benchmarking.py
@@ -292,11 +292,10 @@ def get_logical_error_and_discard_rate(
     Keyword args:
         post_select: The detectors in circuit_or_dem to post-select on.
         dem_to_decode: The detector error model to decode.  If post-selecting, this DEM should _not_
-            include any of the the detectors that are post-selected on.  If have a DEM that includes
-            all detectors in the circuit_or_dem, you can remove the post-selected detectors with
-                old_dem_arrays = decoders.DetectorErrorModelArrays(old_dem)
-                new_dem = old_dem_arrays.post_selected_on(post_select).simplified().to_dem()
-            If dem_to_decode is None, this method decodes with the same DEM that it samples from.
+            include any of the the detectors that are post-selected on.  If dem_to_decode is None,
+            this method builds
+                dem_arrays = decoders.DetectorErrorModelArrays(dem)
+                dem_to_decode = dem_arrays.post_selected_on(post_select).simplified().to_dem()
 
     Returns:
         A fraction of samples in which at least one observable was decoded incorrectly.

--- a/src/qldpc/circuits/benchmarking.py
+++ b/src/qldpc/circuits/benchmarking.py
@@ -293,7 +293,7 @@ def get_logical_error_and_discard_rate(
         post_select: The detectors in circuit_or_dem to post-select on.
         dem_to_decode: The detector error model to decode.  If post-selecting, this DEM should _not_
             include any of the the detectors that are post-selected on.  If have a DEM that includes
-            _all_ detectors in the circuit_or_dem, you can remove the post-selected detectors with
+            all detectors in the circuit_or_dem, you can remove the post-selected detectors with
                 old_dem_arrays = decoders.DetectorErrorModelArrays(old_dem)
                 new_dem = old_dem_arrays.post_selected_on(post_select).simplified().to_dem()
             If dem_to_decode is None, this method decodes with the same DEM that it samples from.
@@ -346,7 +346,7 @@ def get_logical_error_and_discard_rate(
         discard_rate = 1 - np.sum(shot_mask) / len(shot_mask)
 
         if dem_to_decode is None:
-            # remove irreleant error mechanisms from the DEM
+            # remove the post-selected detectors from the DEM
             dem_arrays = dem_arrays.post_selected_on(post_select).simplified()
             dem = dem_arrays.to_dem()
 

--- a/src/qldpc/decoders/dems.py
+++ b/src/qldpc/decoders/dems.py
@@ -361,7 +361,7 @@ class DetectorErrorModelArrays:
                 obs_flips = scipy.sparse.csc_matrix(
                     self.observable_flip_matrix[:, comb].sum(axis=1) % 2
                 )
-                if det_flips.nnz == 0 and obs_flips.nnz == 0:
+                if det_flips.nnz == 0 and obs_flips.nnz == 0:  # pragma: no cover
                     continue
 
                 # add the new error mechanism

--- a/src/qldpc/decoders/dems.py
+++ b/src/qldpc/decoders/dems.py
@@ -337,54 +337,18 @@ class DetectorErrorModelArrays:
         error_probs = self.error_probs[errors_to_keep]
 
         if order > 0:
-            # identify the error that are removed
-            removed_error_indices = np.where(~errors_to_keep)[0]
-            removed_det_flip_submatrix = self.detector_flip_matrix[
-                np.ix_(list(detectors), removed_error_indices.tolist())
-            ]
-            removed_det_to_removed_errors = [
-                scipy.sparse.find(row)[1] for row in removed_det_flip_submatrix
-            ]
-
-            # identify combinations of errors to add back as new error mechanisms
-            combinations_to_add = set()
-            for size in range(2, 2 * order + 1, 2):
-                for triggering_errors in removed_det_to_removed_errors:
-                    for comb in itertools.combinations(triggering_errors, r=size):
-                        if not np.any(removed_det_flip_submatrix[:, comb].sum(axis=1) % 2):
-                            combinations_to_add.add(tuple(removed_error_indices[list(comb)]))
-
-            new_errors: dict[
-                bytes, tuple[scipy.sparse.csc_matrix, scipy.sparse.csc_matrix, float]
-            ] = {}
-            for comb in combinations_to_add:
-                # detector and observable flips
-                det_flips = scipy.sparse.csc_matrix(
-                    self.detector_flip_matrix[detectors_to_keep][:, comb].sum(axis=1) % 2
+            detector_flip_matrix, observable_flip_matrix, error_probs = (
+                _get_post_selection_additions(
+                    self,
+                    detectors,
+                    detectors_to_keep,
+                    errors_to_keep,
+                    order,
+                    detector_flip_matrix,
+                    observable_flip_matrix,
+                    error_probs,
                 )
-                obs_flips = scipy.sparse.csc_matrix(
-                    self.observable_flip_matrix[:, comb].sum(axis=1) % 2
-                )
-                if det_flips.nnz == 0 and obs_flips.nnz == 0:  # pragma: no cover
-                    continue
-
-                # add the new error mechanism
-                flip_pattern = det_flips.toarray().tobytes() + obs_flips.toarray().tobytes()
-                prob = float(np.prod(self.error_probs[list(comb)]))
-                if flip_pattern in new_errors:
-                    previous_prob = new_errors[flip_pattern][2]
-                    prob = previous_prob + prob - 2 * previous_prob * prob
-                new_errors[flip_pattern] = (det_flips, obs_flips, prob)
-
-            if new_errors:
-                new_det_flips, new_obs_flips, new_probs = zip(*new_errors.values())
-                detector_flip_matrix = scipy.sparse.hstack(
-                    [detector_flip_matrix, *new_det_flips], format="csc"
-                )
-                observable_flip_matrix = scipy.sparse.hstack(
-                    [observable_flip_matrix, *new_obs_flips], format="csc"
-                )
-                error_probs = np.hstack([error_probs, new_probs])
+            )
 
         return DetectorErrorModelArrays.from_arrays(
             detector_flip_matrix,
@@ -425,3 +389,88 @@ def _values_that_occur_an_odd_number_of_times(
 ) -> frozenset[HashableType]:
     """Subset of items that occur an odd number of times."""
     return frozenset([item for item, count in collections.Counter(items).items() if count % 2])
+
+
+def _get_post_selection_additions(
+    dem_arrays: DetectorErrorModelArrays,
+    detectors: list[int],
+    detectors_to_keep: npt.NDArray[np.bool_],
+    errors_to_keep: npt.NDArray[np.bool_],
+    order: int,
+    detector_flip_matrix: scipy.sparse.csc_matrix,
+    observable_flip_matrix: scipy.sparse.csc_matrix,
+    error_probs: npt.NDArray[np.floating],
+) -> tuple[scipy.sparse.csc_matrix, scipy.sparse.csc_matrix, npt.NDArray[np.floating]]:
+    """Extend post-selected arrays by recovering combinations of individually removed errors.
+
+    Finds all combinations of up to 2*order removed errors whose net flip on the post-selected
+    detectors cancels, then appends them as new error mechanisms.
+    """
+    removed_error_indices = np.where(~errors_to_keep)[0]
+    removed_det_flip_submatrix = dem_arrays.detector_flip_matrix[
+        np.ix_(detectors, removed_error_indices.tolist())
+    ]
+    removed_det_to_removed_errors = _get_removed_det_to_removed_errors(
+        removed_det_flip_submatrix, order
+    )
+
+    combinations_to_add = set()
+    for size in range(2, 2 * order + 1, 2):
+        for triggering_errors in removed_det_to_removed_errors:
+            for comb in itertools.combinations(triggering_errors, r=size):
+                if not np.any(removed_det_flip_submatrix[:, comb].sum(axis=1) % 2):
+                    combinations_to_add.add(tuple(removed_error_indices[list(comb)]))
+
+    new_errors: dict[bytes, tuple[scipy.sparse.csc_matrix, scipy.sparse.csc_matrix, float]] = {}
+    for comb in combinations_to_add:
+        # identify detectors and observables that are flipped by this combination of errors
+        det_flips = scipy.sparse.csc_matrix(
+            dem_arrays.detector_flip_matrix[detectors_to_keep][:, comb].sum(axis=1) % 2
+        )
+        obs_flips = scipy.sparse.csc_matrix(
+            dem_arrays.observable_flip_matrix[:, comb].sum(axis=1) % 2
+        )
+        if det_flips.nnz == 0 and obs_flips.nnz == 0:
+            continue
+
+        # add this combination as a new error mechanism
+        flip_pattern = det_flips.toarray().tobytes() + obs_flips.toarray().tobytes()
+        prob = float(np.prod(dem_arrays.error_probs[list(comb)]))
+        if flip_pattern in new_errors:
+            previous_prob = new_errors[flip_pattern][2]
+            prob = previous_prob + prob - 2 * previous_prob * prob
+        new_errors[flip_pattern] = (det_flips, obs_flips, prob)
+
+    if new_errors:
+        new_det_flips, new_obs_flips, new_probs = zip(*new_errors.values())
+        detector_flip_matrix = scipy.sparse.hstack(
+            [detector_flip_matrix, *new_det_flips], format="csc"
+        )
+        observable_flip_matrix = scipy.sparse.hstack(
+            [observable_flip_matrix, *new_obs_flips], format="csc"
+        )
+        error_probs = np.hstack([error_probs, new_probs])
+
+    return detector_flip_matrix, observable_flip_matrix, error_probs
+
+
+def _get_removed_det_to_removed_errors(
+    removed_det_flip_submatrix: scipy.sparse.csc_matrix, order: int
+) -> list[list[int]]:
+    """Map each post-selected detector to the removed errors that trigger it.
+
+    For order=1 (pairs only), each error is assigned to the first detector it triggers and omitted
+    from all later detectors, since any valid pair shares the same detector flip pattern and will
+    be found exactly once.  For order>1 this optimisation is unsound, so all triggering errors are
+    returned for every detector (duplicates are filtered later via the combinations_to_add set).
+    """
+    if order == 1:
+        seen_errors: set[int] = set()
+        removed_det_to_removed_errors = []
+        for row in removed_det_flip_submatrix:
+            triggering_errors = scipy.sparse.find(row)[1]
+            unseen_triggering_errors = [err for err in triggering_errors if err not in seen_errors]
+            removed_det_to_removed_errors.append(unseen_triggering_errors)
+            seen_errors.update(triggering_errors.tolist())
+        return removed_det_to_removed_errors
+    return [scipy.sparse.find(row)[1].tolist() for row in removed_det_flip_submatrix]

--- a/src/qldpc/decoders/dems.py
+++ b/src/qldpc/decoders/dems.py
@@ -306,6 +306,10 @@ class DetectorErrorModelArrays:
         In effect, remove the given detectors and the error mechanisms that trigger them.
         If keep_detectors is True, only remove error mechanisms.
         """
+        if order < 0:  # pragma: no cover
+            raise ValueError(f"The 'order' parameter must be nonzero, not {order}")
+
+        # identify detectors to discard and errors to keep
         detectors = list(detectors)
         detectors_to_keep = np.ones(self.num_detectors, dtype=bool)
         if not keep_detectors:

--- a/src/qldpc/decoders/dems.py
+++ b/src/qldpc/decoders/dems.py
@@ -29,6 +29,9 @@ import stim
 
 HashableType = TypeVar("HashableType", bound=Hashable)
 
+ErrorTargets = tuple[frozenset[int], frozenset[int]]  # flipped detectors and observables
+CircuitError = tuple[float, frozenset[ErrorTargets]]
+
 
 class DetectorErrorModelArrays:
     """Representation of a stim.DetectorErrorModel by a collection of arrays.
@@ -50,7 +53,7 @@ class DetectorErrorModelArrays:
     detector_flip_matrix: scipy.sparse.csc_matrix  # maps errors to detector flips
     observable_flip_matrix: scipy.sparse.csc_matrix  # maps errors to observable flips
     error_probs: npt.NDArray[np.floating]  # probability of occurrence for each error
-    suggested_decompositions: dict[int, frozenset[tuple[frozenset[int], frozenset[int]]]]
+    suggested_decompositions: dict[int, frozenset[ErrorTargets]]
 
     def __init__(
         self,
@@ -96,8 +99,7 @@ class DetectorErrorModelArrays:
         detector_flip_matrix: scipy.sparse.csc_matrix | npt.NDArray[np.int_],
         observable_flip_matrix: scipy.sparse.csc_matrix | npt.NDArray[np.int_] | None,
         error_probs: npt.NDArray[np.floating] | float,
-        suggested_decompositions: dict[int, frozenset[tuple[frozenset[int], frozenset[int]]]]
-        | None = None,
+        suggested_decompositions: dict[int, frozenset[ErrorTargets]] | None = None,
     ) -> DetectorErrorModelArrays:
         """Initialize from arrays directly.
 
@@ -149,10 +151,8 @@ class DetectorErrorModelArrays:
 
     @staticmethod
     def get_circuit_errors(
-        dem: stim.DetectorErrorModel,
-        *,
-        decompose_errors: bool = False,
-    ) -> list[tuple[float, frozenset[tuple[frozenset[int], frozenset[int]]]]]:
+        dem: stim.DetectorErrorModel, *, decompose_errors: bool = False
+    ) -> list[CircuitError]:
         """Collect all circuit errors in a stim.DetectorErrorModel into a list.
 
         Each circuit error is nominally identified by:
@@ -171,7 +171,7 @@ class DetectorErrorModelArrays:
         If a detector or observable appears multiple times within one component, its occurrences
         are reduced to the original value mod 2.
         """
-        errors: list[tuple[float, frozenset[tuple[frozenset[int], frozenset[int]]]]] = []
+        errors: list[CircuitError] = []
         for instruction in dem.flattened():
             if instruction.type != "error":
                 continue
@@ -185,7 +185,7 @@ class DetectorErrorModelArrays:
                 else:
                     target_components[-1].append(target)
 
-            components: list[tuple[frozenset[int], frozenset[int]]] = []
+            components: list[ErrorTargets] = []
             for targets in target_components:
                 detectors = _values_that_occur_an_odd_number_of_times(
                     [target.val for target in targets if target.is_relative_detector_id()]
@@ -204,11 +204,9 @@ class DetectorErrorModelArrays:
         return errors
 
     @staticmethod
-    def get_merged_circuit_errors(
-        errors: list[tuple[float, frozenset[tuple[frozenset[int], frozenset[int]]]]],
-    ) -> list[tuple[float, frozenset[tuple[frozenset[int], frozenset[int]]]]]:
+    def get_merged_circuit_errors(errors: list[CircuitError]) -> list[CircuitError]:
         """Merge circuit errors that have the same targets."""
-        merged: dict[frozenset[tuple[frozenset[int], frozenset[int]]], float] = {}
+        merged: dict[frozenset[ErrorTargets], float] = {}
         for prob, targets in errors:
             previous_prob = merged.get(targets, 0.0)
             merged[targets] = previous_prob + prob - 2 * previous_prob * prob
@@ -220,9 +218,7 @@ class DetectorErrorModelArrays:
 
     @staticmethod
     def get_arrays_from_errors(
-        errors: list[tuple[float, frozenset[tuple[frozenset[int], frozenset[int]]]]],
-        num_detectors: int,
-        num_observables: int,
+        errors: list[CircuitError], num_detectors: int, num_observables: int
     ) -> tuple[scipy.sparse.csc_matrix, scipy.sparse.csc_matrix, npt.NDArray[np.floating]]:
         """Convert circuit errors into DetectorErrorModelArrays data."""
         # initialize empty arrays
@@ -354,7 +350,6 @@ class DetectorErrorModelArrays:
                         if not np.any(removed_det_flip_submatrix[:, comb].sum(axis=1) % 2):
                             combinations_to_add.add(tuple(removed_error_indices[list(comb)]))
 
-            # build new error mechanisms: detector_flips, observable_flips, probability
             new_errors: dict[
                 bytes, tuple[scipy.sparse.csc_matrix, scipy.sparse.csc_matrix, float]
             ] = {}
@@ -377,25 +372,18 @@ class DetectorErrorModelArrays:
 
                 # add the new error mechanism
                 flip_pattern = det_flips.toarray().tobytes() + obs_flips.toarray().tobytes()
-                if flip_pattern not in new_errors:
-                    new_errors[flip_pattern] = (det_flips, obs_flips, prob)
-                else:
-                    existing_prob = new_errors[flip_pattern][2]
-                    new_errors[flip_pattern] = (
-                        det_flips,
-                        obs_flips,
-                        existing_prob + prob - 2 * existing_prob * prob,
-                    )
+                if flip_pattern in new_errors:
+                    previous_prob = new_errors[flip_pattern][2]
+                    prob = previous_prob + prob - 2 * previous_prob * prob
+                new_errors[flip_pattern] = (det_flips, obs_flips, prob)
 
             if new_errors:
-                new_det = [v[0] for v in new_errors.values()]
-                new_obs = [v[1] for v in new_errors.values()]
-                new_probs = [v[2] for v in new_errors.values()]
+                new_det_flips, new_obs_flips, new_probs = zip(*new_errors.values())
                 detector_flip_matrix = scipy.sparse.hstack(
-                    [detector_flip_matrix] + new_det, format="csc"
+                    [detector_flip_matrix, *new_det_flips], format="csc"
                 )
                 observable_flip_matrix = scipy.sparse.hstack(
-                    [observable_flip_matrix] + new_obs, format="csc"
+                    [observable_flip_matrix, *new_obs_flips], format="csc"
                 )
                 error_probs = np.hstack([error_probs, new_probs])
 

--- a/src/qldpc/decoders/dems.py
+++ b/src/qldpc/decoders/dems.py
@@ -335,21 +335,71 @@ class DetectorErrorModelArrays:
 
         # build the post-selected arrays
         detector_flip_matrix = self.detector_flip_matrix[detectors_to_keep][:, errors_to_keep]
-        observable_flip_matrix = (self.observable_flip_matrix[:, errors_to_keep],)
-        error_probs = (self.error_probs[errors_to_keep],)
+        observable_flip_matrix = self.observable_flip_matrix[:, errors_to_keep]
+        error_probs = self.error_probs[errors_to_keep]
 
         if order > 0:
-            # add back error combinations that don't trigger the post-selected detectors
-            matrix = self.detector_flip_matrix[np.ix_(detectors, ~errors_to_keep)]
-            combinations_to_add = []
-            for size in range(2, 2 * order + 1, 2):
-                for row in matrix:
-                    for comb in itertools.combinations(scipy.sparse.find(row)[1], r=size):
-                        if not np.any(matrix[:, comb].sum(axis=1) % 2):
-                            combinations_to_add.append(comb)
+            # identify the error that are removed
+            removed_error_indices = np.where(~errors_to_keep)[0]
+            removed_det_flip_submatrix = self.detector_flip_matrix[
+                np.ix_(list(detectors), removed_error_indices.tolist())
+            ]
+            removed_det_to_removed_errors = [
+                scipy.sparse.find(row)[1] for row in removed_det_flip_submatrix
+            ]
 
-            print(sum(~errors_to_keep), len(combinations_to_add))
-            exit()
+            # identify combinations of errors to add back as new error mechanisms
+            combinations_to_add = set()
+            for size in range(2, 2 * order + 1, 2):
+                for triggering_errors in removed_det_to_removed_errors:
+                    for comb in itertools.combinations(triggering_errors, r=size):
+                        if not np.any(removed_det_flip_submatrix[:, comb].sum(axis=1) % 2):
+                            combinations_to_add.add(tuple(removed_error_indices[list(comb)]))
+
+            # build new error mechanisms: detector_flips, observable_flips, probability
+            new_errors: dict[
+                bytes, tuple[scipy.sparse.csc_matrix, scipy.sparse.csc_matrix, float]
+            ] = {}
+            for comb in combinations_to_add:
+                # detector and observable flips
+                det_flips = scipy.sparse.csc_matrix(
+                    self.detector_flip_matrix[detectors_to_keep][:, comb].sum(axis=1) % 2
+                )
+                obs_flips = scipy.sparse.csc_matrix(
+                    self.observable_flip_matrix[:, comb].sum(axis=1) % 2
+                )
+                if det_flips.nnz == 0 and obs_flips.nnz == 0:
+                    continue
+
+                # probability of occurrence for this joint error
+                component_probs = self.error_probs[list(comb)]
+                prob = component_probs[0]
+                for component_prob in component_probs[1:]:
+                    prob = prob + component_prob - 2 * prob * component_prob
+
+                # add the new error mechanism
+                flip_pattern = det_flips.toarray().tobytes() + obs_flips.toarray().tobytes()
+                if flip_pattern not in new_errors:
+                    new_errors[flip_pattern] = (det_flips, obs_flips, prob)
+                else:
+                    existing_prob = new_errors[flip_pattern][2]
+                    new_errors[flip_pattern] = (
+                        det_flips,
+                        obs_flips,
+                        existing_prob + prob - 2 * existing_prob * prob,
+                    )
+
+            if new_errors:
+                new_det = [v[0] for v in new_errors.values()]
+                new_obs = [v[1] for v in new_errors.values()]
+                new_probs = [v[2] for v in new_errors.values()]
+                detector_flip_matrix = scipy.sparse.hstack(
+                    [detector_flip_matrix] + new_det, format="csc"
+                )
+                observable_flip_matrix = scipy.sparse.hstack(
+                    [observable_flip_matrix] + new_obs, format="csc"
+                )
+                error_probs = np.hstack([error_probs, new_probs])
 
         return DetectorErrorModelArrays.from_arrays(
             detector_flip_matrix,

--- a/src/qldpc/decoders/dems.py
+++ b/src/qldpc/decoders/dems.py
@@ -364,14 +364,9 @@ class DetectorErrorModelArrays:
                 if det_flips.nnz == 0 and obs_flips.nnz == 0:
                     continue
 
-                # probability of occurrence for this joint error
-                component_probs = self.error_probs[list(comb)]
-                prob = component_probs[0]
-                for component_prob in component_probs[1:]:
-                    prob = prob + component_prob - 2 * prob * component_prob
-
                 # add the new error mechanism
                 flip_pattern = det_flips.toarray().tobytes() + obs_flips.toarray().tobytes()
+                prob = float(np.prod(self.error_probs[list(comb)]))
                 if flip_pattern in new_errors:
                     previous_prob = new_errors[flip_pattern][2]
                     prob = previous_prob + prob - 2 * previous_prob * prob

--- a/src/qldpc/decoders/dems.py
+++ b/src/qldpc/decoders/dems.py
@@ -466,18 +466,21 @@ def _get_post_selection_additions(
 def _get_removed_det_to_removed_errors(
     removed_det_flip_submatrix: scipy.sparse.csc_matrix, order: int
 ) -> list[list[int]]:
-    """Map each post-selected detector to the removed errors that trigger it."""
-    if order <= 2:
-        seen_errors: set[int] = set()
-        removed_det_to_removed_errors = []
-        for row in removed_det_flip_submatrix:
-            triggering_errors = scipy.sparse.find(row)[1]
-            removed_det_to_removed_errors.append(
-                [err for err in triggering_errors if err not in seen_errors]
-            )
-            seen_errors.update(triggering_errors.tolist())
-        return removed_det_to_removed_errors
-    return [scipy.sparse.find(row)[1].tolist() for row in removed_det_flip_submatrix]
+    """Map each post-selected detector to removed errors that trigger it.
+
+    More specifically, for each detector, identify errors that:
+    (1) trigger that detector, and
+    (2) do not trigger any preceding detectors.
+    """
+    seen_errors: set[int] = set()
+    removed_det_to_removed_errors = []
+    for row in removed_det_flip_submatrix:
+        triggering_errors = scipy.sparse.find(row)[1]
+        removed_det_to_removed_errors.append(
+            [err for err in triggering_errors if err not in seen_errors]
+        )
+        seen_errors.update(triggering_errors.tolist())
+    return removed_det_to_removed_errors
 
 
 def _get_pairs_grouped_by_pattern(

--- a/src/qldpc/decoders/dems.py
+++ b/src/qldpc/decoders/dems.py
@@ -306,9 +306,6 @@ class DetectorErrorModelArrays:
         In effect, remove the given detectors and the error mechanisms that trigger them.
         If keep_detectors is True, only remove error mechanisms.
         """
-        if order < 0:  # pragma: no cover
-            raise ValueError(f"The 'order' parameter must be nonzero, not {order}")
-
         # identify detectors to discard and errors to keep
         detectors = list(detectors)
         detectors_to_keep = np.ones(self.num_detectors, dtype=bool)
@@ -393,7 +390,7 @@ def _values_that_occur_an_odd_number_of_times(
 
 def _get_post_selection_additions(
     dem_arrays: DetectorErrorModelArrays,
-    detectors: list[int],
+    detectors_to_remove: list[int],
     detectors_to_keep: npt.NDArray[np.bool_],
     errors_to_keep: npt.NDArray[np.bool_],
     order: int,
@@ -406,23 +403,35 @@ def _get_post_selection_additions(
     Finds all combinations of up to 2*order removed errors whose net flip on the post-selected
     detectors cancels, then appends them as new error mechanisms.
     """
+    if not 0 <= order <= 2:
+        raise ValueError(f"The 'order' parameter must be 0, 1, or 2, not {order}")
+
     removed_error_indices = np.where(~errors_to_keep)[0]
     removed_det_flip_submatrix = dem_arrays.detector_flip_matrix[
-        np.ix_(detectors, removed_error_indices.tolist())
+        np.ix_(detectors_to_remove, removed_error_indices.tolist())
     ]
     removed_det_to_removed_errors = _get_removed_det_to_removed_errors(
         removed_det_flip_submatrix, order
     )
 
-    combinations_to_add = set()
-    for size in range(2, 2 * order + 1, 2):
-        for triggering_errors in removed_det_to_removed_errors:
-            for comb in itertools.combinations(triggering_errors, r=size):
-                if not np.any(removed_det_flip_submatrix[:, comb].sum(axis=1) % 2):
-                    combinations_to_add.add(tuple(removed_error_indices[list(comb)]))
+    # identify pairs of removed errors to add back to the DEM
+    combinations_to_add: set[frozenset[int]] = set()
+    for triggering_errors in removed_det_to_removed_errors:
+        for pair in itertools.combinations(triggering_errors, 2):
+            if not np.any(removed_det_flip_submatrix[:, pair].sum(axis=1) % 2):
+                combinations_to_add.add(frozenset(removed_error_indices[list(pair)]))
+
+    if order >= 2:
+        # identify quadruples of removed errors to add back to the DEM
+        for pairs in _get_pairs_grouped_by_pattern(removed_det_flip_submatrix).values():
+            for (e1, e2), (e3, e4) in itertools.combinations(pairs, 2):
+                indices = frozenset(removed_error_indices[[e1, e2, e3, e4]])
+                if len(indices) == 4:
+                    combinations_to_add.add(indices)
 
     new_errors: dict[bytes, tuple[scipy.sparse.csc_matrix, scipy.sparse.csc_matrix, float]] = {}
-    for comb in combinations_to_add:
+    for comb_to_add in combinations_to_add:
+        comb = sorted(comb_to_add)
         # identify detectors and observables that are flipped by this combination of errors
         det_flips = scipy.sparse.csc_matrix(
             dem_arrays.detector_flip_matrix[detectors_to_keep][:, comb].sum(axis=1) % 2
@@ -435,7 +444,7 @@ def _get_post_selection_additions(
 
         # add this combination as a new error mechanism
         flip_pattern = det_flips.toarray().tobytes() + obs_flips.toarray().tobytes()
-        prob = float(np.prod(dem_arrays.error_probs[list(comb)]))
+        prob = float(np.prod(dem_arrays.error_probs[comb]))
         if flip_pattern in new_errors:
             previous_prob = new_errors[flip_pattern][2]
             prob = previous_prob + prob - 2 * previous_prob * prob
@@ -457,20 +466,27 @@ def _get_post_selection_additions(
 def _get_removed_det_to_removed_errors(
     removed_det_flip_submatrix: scipy.sparse.csc_matrix, order: int
 ) -> list[list[int]]:
-    """Map each post-selected detector to the removed errors that trigger it.
-
-    For order=1 (pairs only), each error is assigned to the first detector it triggers and omitted
-    from all later detectors, since any valid pair shares the same detector flip pattern and will
-    be found exactly once.  For order>1 this optimisation is unsound, so all triggering errors are
-    returned for every detector (duplicates are filtered later via the combinations_to_add set).
-    """
-    if order == 1:
+    """Map each post-selected detector to the removed errors that trigger it."""
+    if order <= 2:
         seen_errors: set[int] = set()
         removed_det_to_removed_errors = []
         for row in removed_det_flip_submatrix:
             triggering_errors = scipy.sparse.find(row)[1]
-            unseen_triggering_errors = [err for err in triggering_errors if err not in seen_errors]
-            removed_det_to_removed_errors.append(unseen_triggering_errors)
+            removed_det_to_removed_errors.append(
+                [err for err in triggering_errors if err not in seen_errors]
+            )
             seen_errors.update(triggering_errors.tolist())
         return removed_det_to_removed_errors
     return [scipy.sparse.find(row)[1].tolist() for row in removed_det_flip_submatrix]
+
+
+def _get_pairs_grouped_by_pattern(
+    removed_det_flip_submatrix: scipy.sparse.csc_matrix,
+) -> dict[bytes, list[tuple[int, int]]]:
+    """Group pairs of removed-error column indices by their combined post-selected detector flips."""
+    num_errors = removed_det_flip_submatrix.shape[1]
+    flips_to_pairs: dict[bytes, list[tuple[int, int]]] = collections.defaultdict(list)
+    for pair in itertools.combinations(range(num_errors), 2):
+        flips = removed_det_flip_submatrix[:, list(pair)].sum(axis=1).toarray().ravel() % 2
+        flips_to_pairs[flips.tobytes()].append(pair)
+    return flips_to_pairs

--- a/src/qldpc/decoders/dems.py
+++ b/src/qldpc/decoders/dems.py
@@ -100,6 +100,8 @@ class DetectorErrorModelArrays:
         observable_flip_matrix: scipy.sparse.csc_matrix | npt.NDArray[np.int_] | None,
         error_probs: npt.NDArray[np.floating] | float,
         suggested_decompositions: dict[int, frozenset[ErrorTargets]] | None = None,
+        *,
+        simplify: bool = False,
     ) -> DetectorErrorModelArrays:
         """Initialize from arrays directly.
 
@@ -132,7 +134,7 @@ class DetectorErrorModelArrays:
             dem_arrays.error_probs = np.asarray(error_probs)
 
         dem_arrays.suggested_decompositions = suggested_decompositions or {}
-        return dem_arrays
+        return dem_arrays.simplified() if simplify else dem_arrays
 
     @property
     def num_errors(self) -> int:
@@ -355,6 +357,7 @@ class DetectorErrorModelArrays:
             observable_flip_matrix,
             error_probs,
             suggested_decompositions,
+            simplify=order > 0,
         )
 
     def with_erasure(self, bits: int = 1) -> DetectorErrorModelArrays:

--- a/src/qldpc/decoders/dems.py
+++ b/src/qldpc/decoders/dems.py
@@ -27,8 +27,6 @@ import numpy.typing as npt
 import scipy.sparse
 import stim
 
-from qldpc import codes
-
 HashableType = TypeVar("HashableType", bound=Hashable)
 
 

--- a/src/qldpc/decoders/dems.py
+++ b/src/qldpc/decoders/dems.py
@@ -430,7 +430,7 @@ def _get_post_selection_additions(
         obs_flips = scipy.sparse.csc_matrix(
             dem_arrays.observable_flip_matrix[:, comb].sum(axis=1) % 2
         )
-        if det_flips.nnz == 0 and obs_flips.nnz == 0:
+        if det_flips.nnz == 0 and obs_flips.nnz == 0:  # pragma: no cover
             continue
 
         # add this combination as a new error mechanism

--- a/src/qldpc/decoders/dems.py
+++ b/src/qldpc/decoders/dems.py
@@ -301,12 +301,14 @@ class DetectorErrorModelArrays:
         )
 
     def post_selected_on(
-        self, detectors: Collection[int], *, order: int = 0, keep_detectors: bool = False
+        self, detectors: Collection[int], *, keep_detectors: bool = False, order: int = 0
     ) -> DetectorErrorModelArrays:
         """Condition this detector error model on the given detectors being in 0 (untriggered).
 
-        In effect, remove the given detectors and the error mechanisms that trigger them.
-        If keep_detectors is True, only remove error mechanisms.
+        The errors that trigger the post-selected detectors are removed from the DEM.
+        The post-selected detectors are similarly removed unless keep_detectors is True.
+        If order > 0, combinations of up to 2*order removed error mechanisms are added back to the
+        DEM as synthetic error mechanisms.
         """
         if not 0 <= order <= 2:
             raise ValueError(f"The 'order' parameter must be 0, 1, or 2, not {order}")

--- a/src/qldpc/decoders/dems.py
+++ b/src/qldpc/decoders/dems.py
@@ -487,6 +487,6 @@ def _get_pairs_grouped_by_pattern(
     num_errors = removed_det_flip_submatrix.shape[1]
     flips_to_pairs: dict[bytes, list[tuple[int, int]]] = collections.defaultdict(list)
     for pair in itertools.combinations(range(num_errors), 2):
-        flips = removed_det_flip_submatrix[:, list(pair)].sum(axis=1).toarray().ravel() % 2
+        flips = removed_det_flip_submatrix[:, list(pair)].sum(axis=1).A1 % 2
         flips_to_pairs[flips.tobytes()].append(pair)
     return flips_to_pairs

--- a/src/qldpc/decoders/dems.py
+++ b/src/qldpc/decoders/dems.py
@@ -18,6 +18,7 @@ limitations under the License.
 from __future__ import annotations
 
 import collections
+import itertools
 from collections.abc import Collection, Hashable
 from typing import TypeVar
 
@@ -25,6 +26,8 @@ import numpy as np
 import numpy.typing as npt
 import scipy.sparse
 import stim
+
+from qldpc import codes
 
 HashableType = TypeVar("HashableType", bound=Hashable)
 
@@ -302,7 +305,7 @@ class DetectorErrorModelArrays:
         )
 
     def post_selected_on(
-        self, detectors: Collection[int], *, keep_detectors: bool = False
+        self, detectors: Collection[int], *, order: int = 0, keep_detectors: bool = False
     ) -> DetectorErrorModelArrays:
         """Condition this detector error model on the given detectors being in 0 (untriggered).
 
@@ -315,7 +318,7 @@ class DetectorErrorModelArrays:
             detectors_to_keep[detectors] = False
         errors_to_keep = self.detector_flip_matrix[detectors].getnnz(axis=0) == 0
 
-        new_suggested_decompositions = {}
+        suggested_decompositions = {}
         if self.suggested_decompositions:
             old_to_new_det = np.cumsum(detectors_to_keep) - 1
             old_to_new_err = np.cumsum(errors_to_keep) - 1
@@ -328,13 +331,31 @@ class DetectorErrorModelArrays:
                             int(old_to_new_det[dd]) for dd in dets if detectors_to_keep[dd]
                         )
                         new_components.add((new_dets, obs))
-                    new_suggested_decompositions[new_err_idx] = frozenset(new_components)
+                    suggested_decompositions[new_err_idx] = frozenset(new_components)
+
+        # build the post-selected arrays
+        detector_flip_matrix = self.detector_flip_matrix[detectors_to_keep][:, errors_to_keep]
+        observable_flip_matrix = (self.observable_flip_matrix[:, errors_to_keep],)
+        error_probs = (self.error_probs[errors_to_keep],)
+
+        if order > 0:
+            # add back error combinations that don't trigger the post-selected detectors
+            matrix = self.detector_flip_matrix[np.ix_(detectors, ~errors_to_keep)]
+            combinations_to_add = []
+            for size in range(2, 2 * order + 1, 2):
+                for row in matrix:
+                    for comb in itertools.combinations(scipy.sparse.find(row)[1], r=size):
+                        if not np.any(matrix[:, comb].sum(axis=1) % 2):
+                            combinations_to_add.append(comb)
+
+            print(sum(~errors_to_keep), len(combinations_to_add))
+            exit()
 
         return DetectorErrorModelArrays.from_arrays(
-            self.detector_flip_matrix[detectors_to_keep][:, errors_to_keep],
-            self.observable_flip_matrix[:, errors_to_keep],
-            self.error_probs[errors_to_keep],
-            new_suggested_decompositions,
+            detector_flip_matrix,
+            observable_flip_matrix,
+            error_probs,
+            suggested_decompositions,
         )
 
     def with_erasure(self, bits: int = 1) -> DetectorErrorModelArrays:

--- a/src/qldpc/decoders/dems.py
+++ b/src/qldpc/decoders/dems.py
@@ -306,6 +306,9 @@ class DetectorErrorModelArrays:
         In effect, remove the given detectors and the error mechanisms that trigger them.
         If keep_detectors is True, only remove error mechanisms.
         """
+        if not 0 <= order <= 2:
+            raise ValueError(f"The 'order' parameter must be 0, 1, or 2, not {order}")
+
         # identify detectors to discard and errors to keep
         detectors = list(detectors)
         detectors_to_keep = np.ones(self.num_detectors, dtype=bool)
@@ -403,16 +406,13 @@ def _get_post_selection_additions(
     Finds all combinations of up to 2*order removed errors whose net flip on the post-selected
     detectors cancels, then appends them as new error mechanisms.
     """
-    if not 0 <= order <= 2:
-        raise ValueError(f"The 'order' parameter must be 0, 1, or 2, not {order}")
+    assert 0 <= order <= 2
 
     removed_error_indices = np.where(~errors_to_keep)[0]
     removed_det_flip_submatrix = dem_arrays.detector_flip_matrix[
         np.ix_(detectors_to_remove, removed_error_indices.tolist())
     ]
-    removed_det_to_removed_errors = _get_removed_det_to_removed_errors(
-        removed_det_flip_submatrix, order
-    )
+    removed_det_to_removed_errors = _get_removed_det_to_removed_errors(removed_det_flip_submatrix)
 
     # identify pairs of removed errors to add back to the DEM
     combinations_to_add: set[frozenset[int]] = set()
@@ -464,7 +464,7 @@ def _get_post_selection_additions(
 
 
 def _get_removed_det_to_removed_errors(
-    removed_det_flip_submatrix: scipy.sparse.csc_matrix, order: int
+    removed_det_flip_submatrix: scipy.sparse.csc_matrix,
 ) -> list[list[int]]:
     """Map each post-selected detector to removed errors that trigger it.
 

--- a/src/qldpc/decoders/dems_test.py
+++ b/src/qldpc/decoders/dems_test.py
@@ -181,8 +181,8 @@ def test_post_selection() -> None:
     dem_arrays = decoders.DetectorErrorModelArrays(dem)
     assert dem_arrays.post_selected_on([0]).to_dem() == post_selected_dem
 
-    # if passed an integer order > 0, combinations of 2*order error mechanisms that do not flip the
-    # post-selected detectors are added back to the detector error model
+    # if passed an integer order=1, pairs error mechanisms that whose post-selected detector flips
+    # cancel out are added back to the detector error model
     prob = 0.1
     dem = stim.DetectorErrorModel(f"""
         detector D0
@@ -200,6 +200,29 @@ def test_post_selection() -> None:
     """)
     dem_arrays = decoders.DetectorErrorModelArrays(dem)
     assert dem_arrays.post_selected_on([0, 1], order=1).to_dem() == post_selected_dem
+
+    # setting order=2 will recover combinations of four error mechanisms
+    prob = 0.1
+    dem = stim.DetectorErrorModel(f"""
+        detector D0
+        detector D1
+        detector D2
+        logical_observable L0
+        error({prob}) D0 L0
+        error({prob}) D1 L0
+        error({prob}) D2 L0
+        error({prob}) D0 D1 D2
+    """)
+    post_selected_dem = stim.DetectorErrorModel(f"""
+        logical_observable L0
+        error({prob**4}) L0
+    """)
+    dem_arrays = decoders.DetectorErrorModelArrays(dem)
+    assert (
+        dem_arrays.post_selected_on([0, 1, 2], order=2)
+        .to_dem()
+        .approx_equals(post_selected_dem, atol=1e-10)
+    )
 
     dem = stim.DetectorErrorModel("error(0.1) D0")
     with pytest.raises(ValueError, match="order"):

--- a/src/qldpc/decoders/dems_test.py
+++ b/src/qldpc/decoders/dems_test.py
@@ -16,6 +16,7 @@ limitations under the License.
 """
 
 import numpy as np
+import pytest
 import stim
 
 from qldpc import decoders
@@ -199,6 +200,10 @@ def test_post_selection() -> None:
     """)
     dem_arrays = decoders.DetectorErrorModelArrays(dem)
     assert dem_arrays.post_selected_on([0, 1], order=1).to_dem() == post_selected_dem
+
+    dem = stim.DetectorErrorModel("error(0.1) D0")
+    with pytest.raises(ValueError, match="order"):
+        decoders.DetectorErrorModelArrays(dem).post_selected_on([0], order=3)
 
 
 def test_decomposing_errors() -> None:

--- a/src/qldpc/decoders/dems_test.py
+++ b/src/qldpc/decoders/dems_test.py
@@ -224,7 +224,6 @@ def test_post_selection() -> None:
         .approx_equals(post_selected_dem, atol=1e-10)
     )
 
-    dem = stim.DetectorErrorModel("error(0.1) D0")
     with pytest.raises(ValueError, match="order"):
         decoders.DetectorErrorModelArrays(dem).post_selected_on([0], order=3)
 

--- a/src/qldpc/decoders/dems_test.py
+++ b/src/qldpc/decoders/dems_test.py
@@ -164,25 +164,7 @@ def test_with_erasure() -> None:
 
 def test_post_selection() -> None:
     """Post select on some detectors."""
-    dem = stim.DetectorErrorModel("""
-        detector D0
-        detector D1
-        logical_observable L0
-        logical_observable L1
-        error(0.3) D0 D1 L0
-        error(0.3) D1 L1
-    """)
-    post_selected_dem = stim.DetectorErrorModel("""
-        detector D0
-        logical_observable L0
-        logical_observable L1
-        error(0.3) D0 L1
-    """)
-    dem_arrays = decoders.DetectorErrorModelArrays(dem)
-    assert dem_arrays.post_selected_on([0]).to_dem() == post_selected_dem
-
-    # post-selecting on D0 should drop errors that trigger D0, keep the rest, and remap
-    # detector IDs in the surviving suggested decompositions
+    # post-selecting removes detectors, the errors that trigger them, and remaps detector IDs
     dem = stim.DetectorErrorModel("""
         detector D0
         detector D1
@@ -197,6 +179,26 @@ def test_post_selection() -> None:
     """)
     dem_arrays = decoders.DetectorErrorModelArrays(dem)
     assert dem_arrays.post_selected_on([0]).to_dem() == post_selected_dem
+
+    # if passed an integer order > 0, combinations of 2*order error mechanisms that do not flip the
+    # post-selected detectors are added back to the detector error model
+    prob = 0.1
+    dem = stim.DetectorErrorModel(f"""
+        detector D0
+        detector D1
+        logical_observable L0
+        error({prob}) D0 D2
+        error({prob}) D0 L0
+        error({prob}) D1 D2
+        error({prob}) D1 L0
+    """)
+    post_selected_dem = stim.DetectorErrorModel(f"""
+        detector D0
+        logical_observable L0
+        error({2 * prob**2 - 2 * prob**4}) D0 L0
+    """)
+    dem_arrays = decoders.DetectorErrorModelArrays(dem)
+    assert dem_arrays.post_selected_on([0, 1], order=1).to_dem() == post_selected_dem
 
 
 def test_decomposing_errors() -> None:


### PR DESCRIPTION
Previously `DetectorErrorModelArrays.post_selected_on` simply removed (a) post-selected detectors and (b) error mechanisms that triggered post-selected detectors from a DEM.  This is useful for building smaller DEMs to decode.

This PR adds the capability to add even-weight combinations of error mechanisms back to a DEM.  This capability is useful for sampling from DEM.

NOTE: some errors in this PR were fixed, and the definition of `order` slightly changed, in #510 