### PR TITLE
Add `DetectorErrorModelArrays.to_circuit`

### DIFF
--- a/src/qldpc/decoders/dems.py
+++ b/src/qldpc/decoders/dems.py
@@ -286,6 +286,29 @@ class DetectorErrorModelArrays:
 
         return dem
 
+    def to_circuit(self) -> stim.Circuit:
+        """Convert this DEM to a synthetic stim.Circuit with the same detector error model.
+
+        Each error mechanism becomes a noisy measurement M(p) on a dedicated qubit.
+        DETECTOR and OBSERVABLE_INCLUDE instructions then reference those measurements.
+        """
+        circuit = stim.Circuit()
+
+        for error, prob in enumerate(self.error_probs):
+            circuit.append("M", [error], float(prob))
+
+        for det in range(self.num_detectors):
+            triggers = self.detector_flip_matrix[det].nonzero()[1].tolist()
+            targets = [stim.target_rec(trigger - self.num_errors) for trigger in triggers]
+            circuit.append("DETECTOR", targets)
+
+        for obs in range(self.num_observables):
+            triggers = self.observable_flip_matrix[obs].nonzero()[1].tolist()
+            targets = [stim.target_rec(trigger - self.num_errors) for trigger in triggers]
+            circuit.append("OBSERVABLE_INCLUDE", targets, obs)
+
+        return circuit
+
     def simplified(self) -> DetectorErrorModelArrays:
         """Simplify this DetectorErrorModelArrays object by merging errors."""
         return DetectorErrorModelArrays(self.to_detector_error_model(), simplify=True)

--- a/src/qldpc/decoders/dems_test.py
+++ b/src/qldpc/decoders/dems_test.py
@@ -228,6 +228,19 @@ def test_post_selection() -> None:
         decoders.DetectorErrorModelArrays(dem).post_selected_on([0], order=3)
 
 
+def test_to_circuit() -> None:
+    """Round-trip a DEM through DetectorErrorModelArrays and to_circuit."""
+    dem = stim.DetectorErrorModel("""
+        detector D0
+        detector D1
+        logical_observable L0
+        error(0.1) D0 D1
+        error(0.2) D1 L0
+    """)
+    circuit = decoders.DetectorErrorModelArrays(dem).to_circuit()
+    assert dem.approx_equals(decoders.DetectorErrorModelArrays(circuit).to_dem(), atol=1e-10)
+
+
 def test_decomposing_errors() -> None:
     """Apply suggested decompositions to split errors into their components."""
     dem = stim.DetectorErrorModel("""


### PR DESCRIPTION
This is primarily a hack to convert a simplified DEM into an object that can be handed to `sinter.Task`.