### PR TITLE
Cheaper abstract algebra tests

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -80,7 +80,7 @@ jobs:
     name: Pytest and coverage check
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
-    timeout-minutes: 6
+    timeout-minutes: 7
     needs: install
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -80,7 +80,7 @@ jobs:
     name: Pytest and coverage check
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
-    timeout-minutes: 7
+    timeout-minutes: 6
     needs: install
     steps:
       - uses: actions/checkout@v6

--- a/src/qldpc/abstract/rings_test.py
+++ b/src/qldpc/abstract/rings_test.py
@@ -248,7 +248,7 @@ def test_ring_row_reduction(
     # matrix components of non-commutative rings get "standardized" to place pivots on the diagonal
     ring = ring_dihedral3_gf5
     transformer = ring.get_transformer()
-    component_transformer = transformer.transformers[-1]
+    component_transformer = next(ct for ct in transformer.transformers if ct.size == 2)
     e2_12 = component_transformer.embed(component_transformer.extended_field([[0, 1], [0, 0]]))
     e2_21 = component_transformer.embed(component_transformer.extended_field([[0, 0], [1, 0]]))
     e2_22 = component_transformer.embed(component_transformer.extended_field([[0, 0], [0, 1]]))

--- a/src/qldpc/abstract/rings_test.py
+++ b/src/qldpc/abstract/rings_test.py
@@ -249,15 +249,9 @@ def test_ring_row_reduction(
     ring = ring_dihedral3_gf5
     transformer = ring.get_transformer()
     component_transformer = transformer.transformers[-1]
-    e2_12 = component_transformer.embed(
-        component_transformer.extended_field([[0, 1], [0, 0]])
-    )
-    e2_21 = component_transformer.embed(
-        component_transformer.extended_field([[0, 0], [1, 0]])
-    )
-    e2_22 = component_transformer.embed(
-        component_transformer.extended_field([[0, 0], [0, 1]])
-    )
+    e2_12 = component_transformer.embed(component_transformer.extended_field([[0, 1], [0, 0]]))
+    e2_21 = component_transformer.embed(component_transformer.extended_field([[0, 0], [1, 0]]))
+    e2_22 = component_transformer.embed(component_transformer.extended_field([[0, 0], [0, 1]]))
     assert np.array_equal(
         abstract.RingArray.build([[e2_12]]).howell_normal_form_semisimple(),
         abstract.RingArray.build([[e2_22]]),

--- a/src/qldpc/abstract/rings_test.py
+++ b/src/qldpc/abstract/rings_test.py
@@ -219,7 +219,7 @@ def test_regular_rep(ring: abstract.GroupRing, pytestconfig: pytest.Config) -> N
 
 
 def test_ring_row_reduction(
-    ring_alternating4_gf5: abstract.GroupRing, pytestconfig: pytest.Config
+    ring_dihedral3_gf5: abstract.GroupRing, pytestconfig: pytest.Config
 ) -> None:
     """RingArrays can be row reduced in various ways."""
     np.random.seed(pytestconfig.getoption("randomly_seed"))
@@ -246,25 +246,25 @@ def test_ring_row_reduction(
     assert np.array_equal(matrix.howell_normal_form(poly=True), matrix_hnf)
 
     # matrix components of non-commutative rings get "standardized" to place pivots on the diagonal
-    ring = ring_alternating4_gf5
+    ring = ring_dihedral3_gf5
     transformer = ring.get_transformer()
     component_transformer = transformer.transformers[-1]
-    e3_13 = component_transformer.embed(
-        component_transformer.extended_field([[0, 0, 1], [0, 0, 0], [0, 0, 0]])
+    e2_12 = component_transformer.embed(
+        component_transformer.extended_field([[0, 1], [0, 0]])
     )
-    e3_31 = component_transformer.embed(
-        component_transformer.extended_field([[0, 0, 0], [0, 0, 0], [1, 0, 0]])
+    e2_21 = component_transformer.embed(
+        component_transformer.extended_field([[0, 0], [1, 0]])
     )
-    e3_33 = component_transformer.embed(
-        component_transformer.extended_field([[0, 0, 0], [0, 0, 0], [0, 0, 1]])
-    )
-    assert np.array_equal(
-        abstract.RingArray.build([[e3_13]]).howell_normal_form_semisimple(),
-        abstract.RingArray.build([[e3_33]]),
+    e2_22 = component_transformer.embed(
+        component_transformer.extended_field([[0, 0], [0, 1]])
     )
     assert np.array_equal(
-        abstract.RingArray.build([[e3_31]]).howell_normal_form_semisimple(right=True),
-        abstract.RingArray.build([[e3_33]]),
+        abstract.RingArray.build([[e2_12]]).howell_normal_form_semisimple(),
+        abstract.RingArray.build([[e2_22]]),
+    )
+    assert np.array_equal(
+        abstract.RingArray.build([[e2_21]]).howell_normal_form_semisimple(right=True),
+        abstract.RingArray.build([[e2_22]]),
     )
 
     # RingArray.row_reduce requires semisimple rings

--- a/src/qldpc/abstract/wedderburn_artin.py
+++ b/src/qldpc/abstract/wedderburn_artin.py
@@ -23,6 +23,7 @@ import itertools
 import math
 import operator
 from collections.abc import Sequence
+from typing import Literal
 
 import galois
 import numpy as np
@@ -197,7 +198,8 @@ class WedderburnArtinComponentTransformer:
         pci: RingMember,
         *,
         seed: np.random.Generator | None = None,
-        galois_compile: str | None = "python-calculate",
+        galois_compile: Literal["auto", "jit-lookup", "jit-calculate", "python-calculate"]
+        | None = "python-calculate",
     ) -> None:
         """Initialize from a primitive central idempotent (PCI) of a ring.
 

--- a/src/qldpc/abstract/wedderburn_artin.py
+++ b/src/qldpc/abstract/wedderburn_artin.py
@@ -204,7 +204,7 @@ class WedderburnArtinComponentTransformer:
         WARNING: This class assumes--and does not verify--that the provided RingMember is a PCI.
 
         Args:
-            pci: A primitive central idempotent that projects onto the simple component of a ring.
+            pci: A primitive central idempotent of a ring.
             seed: Random number generator seed.
             galois_compile: The ufunc calculation mode for the galois field extension GF(q^d).
                 Default: 'python-calculate', which is empirically faster for small field arrays.

--- a/src/qldpc/abstract/wedderburn_artin.py
+++ b/src/qldpc/abstract/wedderburn_artin.py
@@ -192,10 +192,23 @@ class WedderburnArtinComponentTransformer:
     decomposition_coefficient_extractor: galois.FieldArray
     decomposition_coefficient_recombiner: galois.FieldArray
 
-    def __init__(self, pci: RingMember, *, seed: np.random.Generator | None = None) -> None:
+    def __init__(
+        self,
+        pci: RingMember,
+        *,
+        seed: np.random.Generator | None = None,
+        galois_compile: str | None = "python-calculate",
+    ) -> None:
         """Initialize from a primitive central idempotent (PCI) of a ring.
 
         WARNING: This class assumes--and does not verify--that the provided RingMember is a PCI.
+
+        Args:
+            pci: A primitive central idempotent that projects onto the simple component of a ring.
+            seed: Random number generator seed.
+            galois_compile: The ufunc calculation mode for the galois field extension GF(q^d).
+                Default: 'python-calculate', which is empirically faster for small field arrays.
+                See help(galois.GF), and the 'compile' argument in particular.
         """
         if not pci.ring.is_semisimple:
             raise ValueError("The Wedderburn-Artin decomposition only exists for semisimple rings")
@@ -215,7 +228,7 @@ class WedderburnArtinComponentTransformer:
         self.power_basis = self._get_power_basis(seed)
         self.power_basis_dual = qldpc.math.get_dual_basis(self.power_basis, validate=False)
 
-        self.extended_field = galois.GF(self.field.order**self.degree)
+        self.extended_field = galois.GF(self.field.order**self.degree, compile=galois_compile)
         self.embedded_scalars, self.embedded_power_basis = self._get_center_embeddings()
         self.embedded_power_basis_dual = self._get_embedded_power_basis_dual()
 

--- a/src/qldpc/abstract/wedderburn_artin_test.py
+++ b/src/qldpc/abstract/wedderburn_artin_test.py
@@ -30,12 +30,29 @@ from qldpc import abstract
 def test_wedderburn_artin_transformations(
     ring: abstract.GroupRing, pytestconfig: pytest.Config
 ) -> None:
-    """Decompose semisimple rings into simple components.
+    """Randomized tests for the Wedderburn-Artin transformation of a group ring.
 
-    Runs for GroupRing(CyclicGroup(3), field=4) and GroupRing(DihedralGroup(3), field=5).
+    Runs for the default rings to test in this library (defined in an appropriate conftest.py).
     """
-    seed = pytestconfig.getoption("randomly_seed")
+    _test_wedderburn_artin_transformations(ring, pytestconfig.getoption("randomly_seed"))
 
+
+def test_wedderburn_artin_transformations_size_three(
+    ring_alternating4_gf5: abstract.GroupRing, pytestconfig: pytest.Config
+) -> None:
+    """Randomized tests for the Wedderburn-Artin transformation of a group ring.
+
+    AlternatingGroup(4) is the smallest group with a 3-dimensional irreducible representation,
+    giving a Wedderburn-Artin component of size=3.  This test covers the cross-term construction
+    in WedderburnArtinComponentTransformer._get_matrix_basis, which only runs when size >= 3.
+    """
+    _test_wedderburn_artin_transformations(
+        ring_alternating4_gf5, pytestconfig.getoption("randomly_seed")
+    )
+
+
+def _test_wedderburn_artin_transformations(ring: abstract.GroupRing, seed: int) -> None:
+    """Randomized tests for the Wedderburn-Artin transformation of a group ring."""
     transformer = ring.get_transformer()
 
     # the embedding of ring.field = GF(q) scalars is an isomorphism
@@ -120,26 +137,6 @@ def get_random_ring_member(ring: abstract.GroupRing, seed: int) -> abstract.Ring
     coeffs = ring.field.Random(ring.group.order, seed=seed)
     terms = [(coeff, gen) for coeff, gen in zip(coeffs, ring.group.generate())]
     return abstract.RingMember(ring, *terms)
-
-
-def test_matrix_basis_size_three(ring_alternating4_gf5: abstract.GroupRing) -> None:
-    """The matrix basis construction handles size-3 components correctly.
-
-    _get_matrix_basis builds the standard basis {|i><j|} for a component S ≅ GF(q^d)^{n×n} in two
-    phases: first it constructs all elements in the first row/column (|0><i| and |i><0|) directly
-    from projections, then it derives the remaining off-diagonal elements |i><j| (i,j >= 1) as
-    compositions |i><0|·|0><j|.  The second phase only runs when size >= 3 (for size=2 there are no
-    pairs (i,j) with i,j >= 1).
-
-    AlternatingGroup(4) is the smallest group with a 3-dimensional irreducible representation,
-    giving a size=3 Wedderburn-Artin component that exercises this second phase.
-    """
-    transformer = ring_alternating4_gf5.get_transformer()
-    size_three_ct = next(ct for ct in transformer.transformers if ct.size == 3)
-    assert size_three_ct.matrix_basis.shape == (
-        size_three_ct.size**2,
-        ring_alternating4_gf5.group.order,
-    )
 
 
 def test_wedderburn_artin_errors(

--- a/src/qldpc/abstract/wedderburn_artin_test.py
+++ b/src/qldpc/abstract/wedderburn_artin_test.py
@@ -136,7 +136,10 @@ def test_matrix_basis_size_three(ring_alternating4_gf5: abstract.GroupRing) -> N
     """
     transformer = ring_alternating4_gf5.get_transformer()
     size_three_ct = next(ct for ct in transformer.transformers if ct.size == 3)
-    assert size_three_ct.matrix_basis.shape == (9, ring_alternating4_gf5.group.order)
+    assert size_three_ct.matrix_basis.shape == (
+        size_three_ct.size**2,
+        ring_alternating4_gf5.group.order,
+    )
 
 
 def test_wedderburn_artin_errors(

--- a/src/qldpc/abstract/wedderburn_artin_test.py
+++ b/src/qldpc/abstract/wedderburn_artin_test.py
@@ -123,11 +123,16 @@ def get_random_ring_member(ring: abstract.GroupRing, seed: int) -> abstract.Ring
 
 
 def test_matrix_basis_size_three(ring_alternating4_gf5: abstract.GroupRing) -> None:
-    """The matrix basis construction uses cross-terms for components of size >= 3.
+    """The matrix basis construction handles size-3 components correctly.
+
+    _get_matrix_basis builds the standard basis {|i><j|} for a component S ≅ GF(q^d)^{n×n} in two
+    phases: first it constructs all elements in the first row/column (|0><i| and |i><0|) directly
+    from projections, then it derives the remaining off-diagonal elements |i><j| (i,j >= 1) as
+    compositions |i><0|·|0><j|.  The second phase only runs when size >= 3 (for size=2 there are no
+    pairs (i,j) with i,j >= 1).
 
     AlternatingGroup(4) is the smallest group with a 3-dimensional irreducible representation,
-    giving a Wedderburn-Artin component of size=3 that exercises the off-diagonal construction
-    loop in _get_matrix_basis (which only runs when size >= 3).
+    giving a size=3 Wedderburn-Artin component that exercises this second phase.
     """
     transformer = ring_alternating4_gf5.get_transformer()
     size_three_ct = next(ct for ct in transformer.transformers if ct.size == 3)

--- a/src/qldpc/abstract/wedderburn_artin_test.py
+++ b/src/qldpc/abstract/wedderburn_artin_test.py
@@ -32,7 +32,7 @@ def test_wedderburn_artin_transformations(
 ) -> None:
     """Decompose semisimple rings into simple components.
 
-    Runs for GroupRing(CyclicGroup(3), field=4) and GroupRing(AlternatingGroup(4), field=5).
+    Runs for GroupRing(CyclicGroup(3), field=4) and GroupRing(DihedralGroup(3), field=5).
     """
     seed = pytestconfig.getoption("randomly_seed")
 
@@ -120,6 +120,18 @@ def get_random_ring_member(ring: abstract.GroupRing, seed: int) -> abstract.Ring
     coeffs = ring.field.Random(ring.group.order, seed=seed)
     terms = [(coeff, gen) for coeff, gen in zip(coeffs, ring.group.generate())]
     return abstract.RingMember(ring, *terms)
+
+
+def test_matrix_basis_size_three(ring_alternating4_gf5: abstract.GroupRing) -> None:
+    """The matrix basis construction uses cross-terms for components of size >= 3.
+
+    AlternatingGroup(4) is the smallest group with a 3-dimensional irreducible representation,
+    giving a Wedderburn-Artin component of size=3 that exercises the off-diagonal construction
+    loop in _get_matrix_basis (which only runs when size >= 3).
+    """
+    transformer = ring_alternating4_gf5.get_transformer()
+    size_three_ct = next(ct for ct in transformer.transformers if ct.size == 3)
+    assert size_three_ct.matrix_basis.shape == (9, ring_alternating4_gf5.group.order)
 
 
 def test_wedderburn_artin_errors(

--- a/src/qldpc/conftest.py
+++ b/src/qldpc/conftest.py
@@ -24,26 +24,40 @@ def ring_cyclic3_gf4(pytestconfig: pytest.Config) -> abstract.GroupRing:
 
 
 @pytest.fixture(scope="session")
+def ring_dihedral3_gf5(pytestconfig: pytest.Config) -> abstract.GroupRing:
+    """Construct a non-commutative ring with a pre-built Wedderburn-Artin transformer.
+
+    Uses DihedralGroup(3) over GF(5), whose primitive central idempotents are pre-cached in
+    KNOWN_PRIMITIVE_CENTRAL_IDEMPOTENTS (avoiding a GAP computation).
+    """
+    ring = abstract.GroupRing(abstract.DihedralGroup(3), field=5)
+    ring.get_transformer(seed=pytestconfig.getoption("randomly_seed"))
+    return ring
+
+
+@pytest.fixture(scope="session")
 def ring_alternating4_gf5(pytestconfig: pytest.Config) -> abstract.GroupRing:
-    """Construct a non-commutative ring with a pre-built Wedderburn-Artin transformer."""
+    """Construct a non-commutative ring with a size-3 matrix component.
+
+    Used specifically to test WedderburnArtinComponentTransformer code paths that only
+    arise for matrix components of size >= 3 (A4 is the smallest group with a 3-dim irrep).
+    """
     ring = abstract.GroupRing(abstract.AlternatingGroup(4), field=5)
     ring.get_transformer(seed=pytestconfig.getoption("randomly_seed"))
     return ring
 
 
-@pytest.fixture(name="ring", scope="session", params=["cyclic3_gf4", "alternating4_gf5"])
+@pytest.fixture(name="ring", scope="session", params=["cyclic3_gf4", "dihedral3_gf5"])
 def rings_to_test(
     request: pytest.FixtureRequest,
     ring_cyclic3_gf2: abstract.GroupRing,
     ring_cyclic3_gf4: abstract.GroupRing,
-    ring_alternating4_gf5: abstract.GroupRing,
+    ring_dihedral3_gf5: abstract.GroupRing,
 ) -> abstract.GroupRing:
     """Retrieve a ring for which we have pre-built a Wedderburn-Artin transformer."""
     match request.param:
-        case "cyclic3_gf2":
-            return ring_cyclic3_gf2
         case "cyclic3_gf4":
             return ring_cyclic3_gf4
-        case "alternating4_gf5":
-            return ring_alternating4_gf5
+        case "dihedral3_gf5":
+            return ring_dihedral3_gf5
     raise ValueError(f"Invalid fixture name: {request.param}")  # pragma: no cover

--- a/src/qldpc/conftest.py
+++ b/src/qldpc/conftest.py
@@ -50,7 +50,6 @@ def ring_alternating4_gf5(pytestconfig: pytest.Config) -> abstract.GroupRing:
 @pytest.fixture(name="ring", scope="session", params=["cyclic3_gf4", "dihedral3_gf5"])
 def rings_to_test(
     request: pytest.FixtureRequest,
-    ring_cyclic3_gf2: abstract.GroupRing,
     ring_cyclic3_gf4: abstract.GroupRing,
     ring_dihedral3_gf5: abstract.GroupRing,
 ) -> abstract.GroupRing:

--- a/src/qldpc/conftest.py
+++ b/src/qldpc/conftest.py
@@ -25,11 +25,7 @@ def ring_cyclic3_gf4(pytestconfig: pytest.Config) -> abstract.GroupRing:
 
 @pytest.fixture(scope="session")
 def ring_dihedral3_gf5(pytestconfig: pytest.Config) -> abstract.GroupRing:
-    """Construct a non-commutative ring with a pre-built Wedderburn-Artin transformer.
-
-    Uses DihedralGroup(3) over GF(5), whose primitive central idempotents are pre-cached in
-    KNOWN_PRIMITIVE_CENTRAL_IDEMPOTENTS (avoiding a GAP computation).
-    """
+    """Construct a non-commutative ring with a pre-built Wedderburn-Artin transformer."""
     ring = abstract.GroupRing(abstract.DihedralGroup(3), field=5)
     ring.get_transformer(seed=pytestconfig.getoption("randomly_seed"))
     return ring
@@ -37,11 +33,7 @@ def ring_dihedral3_gf5(pytestconfig: pytest.Config) -> abstract.GroupRing:
 
 @pytest.fixture(scope="session")
 def ring_alternating4_gf5(pytestconfig: pytest.Config) -> abstract.GroupRing:
-    """Construct a non-commutative ring with a size-3 matrix component.
-
-    Used specifically to test WedderburnArtinComponentTransformer code paths that only
-    arise for matrix components of size >= 3 (A4 is the smallest group with a 3-dim irrep).
-    """
+    """Construct a non-commutative ring with a size-3 matrix component."""
     ring = abstract.GroupRing(abstract.AlternatingGroup(4), field=5)
     ring.get_transformer(seed=pytestconfig.getoption("randomly_seed"))
     return ring


### PR DESCRIPTION
~Notwithstanding the cheaper abstract algebra tests, the coverage test was flaky and would often time out before this PR, so I'm just increasing the timeout limit here.~  UPDATE: Adding the `galois_compile` argument to `WedderburnArtinComponentTransformer` and passing it to `galois.GF(...)` sped things up considerably, so the timeout limit bump is reverted.