### PR TITLE
Add `tsim` support to `NoiseModel`

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -80,7 +80,7 @@ jobs:
     name: Pytest and coverage check
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
-    timeout-minutes: 6
+    timeout-minutes: 7
     needs: install
     steps:
       - uses: actions/checkout@v6

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,12 +38,14 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
+  "bloqade-tsim>=0.1.4",
   "checks-superstaq>=0.5.62",
   "jupyter>=1.1.1",
   "python-lsp-server[all]>=1.14.0",
   "relay-bp[stim]==0.2.1",
 ]
 relay-bp = ["relay-bp[stim]==0.2.1"]
+tsim = ["bloqade-tsim>=0.1.4"]
 
 [project.urls]
 Repository = "https://github.com/qLDPCOrg/qLDPC"

--- a/src/qldpc/circuits/noise_model.py
+++ b/src/qldpc/circuits/noise_model.py
@@ -1,4 +1,4 @@
-"""Implementation of noise models for Stim circuits
+"""Implementation of noise models for Stim (and tsim) circuits
 
 The main components of this module are:
 - NoiseRule: Defines how to add noise to individual operations.
@@ -49,8 +49,17 @@ from __future__ import annotations
 
 import collections
 from collections.abc import Collection, Iterable, Iterator
+from typing import TypeVar
 
 import stim
+
+try:
+    import tsim
+
+    stim_or_tsim_Circuit = TypeVar("stim_or_tsim_Circuit", stim.Circuit, tsim.Circuit)
+except ImportError:
+    tsim = None  # type:ignore[assignment]
+    stim_or_tsim_Circuit = TypeVar("stim_or_tsim_Circuit", bound=stim.Circuit)  # type:ignore[misc]
 
 CLIFFORD_1Q = "C1"
 CLIFFORD_2Q = "C2"
@@ -177,8 +186,10 @@ COLLAPSING_OPS = JUST_MEASURE_OPS | JUST_RESET_OPS | MEASURE_AND_RESET_OPS
 DEFAULT_IMMUNE_OP_TAG = "__IMMUNE_TO_NOISE__"
 
 
-def as_noiseless_circuit(circuit: stim.Circuit) -> stim.Circuit:
+def as_noiseless_circuit(circuit: stim_or_tsim_Circuit) -> stim_or_tsim_Circuit:
     """Wrap a circuit in a noiseless, one-repitition stim.CircuitRepeatBlock."""
+    if tsim is not None and isinstance(circuit, tsim.Circuit):
+        return tsim.Circuit.from_stim_program(as_noiseless_circuit(circuit._stim_circ))
     block = stim.CircuitRepeatBlock(repeat_count=1, body=circuit.copy(), tag=DEFAULT_IMMUNE_OP_TAG)
     noiseless_circuit = stim.Circuit()
     noiseless_circuit.append(block)
@@ -387,13 +398,13 @@ class NoiseModel:
 
     def noisy_circuit(
         self,
-        circuit: stim.Circuit,
+        circuit: stim_or_tsim_Circuit,
         *,
         system_qubits: Collection[int] | None = None,
         immune_qubits: Collection[int] | None = None,
         immune_op_tag: str = DEFAULT_IMMUNE_OP_TAG,
         insert_ticks: bool = True,
-    ) -> stim.Circuit:
+    ) -> stim_or_tsim_Circuit:
         f"""Construct a noisy version of the given circuit.
 
         This method first uses TICKs to split the input circuit into moments of operations that can
@@ -412,8 +423,19 @@ class NoiseModel:
                 conflicts.  If False, assumes that this preprocessing is not necessary.
 
         Returns:
-            stim.Circuit: A noisy version of the input circuit.
+            The input circuit with added noise.
         """
+        if tsim is not None and isinstance(circuit, tsim.Circuit):
+            return tsim.Circuit.from_stim_program(
+                self.noisy_circuit(
+                    circuit._stim_circ,
+                    system_qubits=system_qubits,
+                    immune_qubits=immune_qubits,
+                    immune_op_tag=immune_op_tag,
+                    insert_ticks=insert_ticks,
+                )
+            )
+
         system_qubits = set(system_qubits or range(circuit.num_qubits))
         immune_qubits = set(immune_qubits or [])
 

--- a/src/qldpc/circuits/noise_model.py
+++ b/src/qldpc/circuits/noise_model.py
@@ -49,7 +49,7 @@ from __future__ import annotations
 
 import collections
 from collections.abc import Collection, Iterable, Iterator
-from typing import TypeVar
+from typing import TYPE_CHECKING, TypeVar
 
 import stim
 
@@ -57,9 +57,11 @@ try:
     import tsim
 
     stim_or_tsim_Circuit = TypeVar("stim_or_tsim_Circuit", stim.Circuit, tsim.Circuit)
-except ImportError:
-    tsim = None  # type:ignore[assignment]
-    stim_or_tsim_Circuit = TypeVar("stim_or_tsim_Circuit", bound=stim.Circuit)  # type:ignore[misc]
+except ImportError:  # pragma: no cover
+    if not TYPE_CHECKING:
+        tsim = None
+        stim_or_tsim_Circuit = TypeVar("stim_or_tsim_Circuit", bound=stim.Circuit)
+
 
 CLIFFORD_1Q = "C1"
 CLIFFORD_2Q = "C2"
@@ -189,7 +191,7 @@ DEFAULT_IMMUNE_OP_TAG = "__IMMUNE_TO_NOISE__"
 def as_noiseless_circuit(circuit: stim_or_tsim_Circuit) -> stim_or_tsim_Circuit:
     """Wrap a circuit in a noiseless, one-repitition stim.CircuitRepeatBlock."""
     if tsim is not None and isinstance(circuit, tsim.Circuit):
-        return tsim.Circuit.from_stim_program(as_noiseless_circuit(circuit._stim_circ))
+        return tsim.Circuit.from_stim_program(as_noiseless_circuit(circuit.stim_circuit))
     block = stim.CircuitRepeatBlock(repeat_count=1, body=circuit.copy(), tag=DEFAULT_IMMUNE_OP_TAG)
     noiseless_circuit = stim.Circuit()
     noiseless_circuit.append(block)
@@ -428,7 +430,7 @@ class NoiseModel:
         if tsim is not None and isinstance(circuit, tsim.Circuit):
             return tsim.Circuit.from_stim_program(
                 self.noisy_circuit(
-                    circuit._stim_circ,
+                    circuit.stim_circuit,
                     system_qubits=system_qubits,
                     immune_qubits=immune_qubits,
                     immune_op_tag=immune_op_tag,

--- a/src/qldpc/circuits/noise_model_test.py
+++ b/src/qldpc/circuits/noise_model_test.py
@@ -296,3 +296,27 @@ def test_trivial_noise() -> None:
     assert not bool(circuits.NoiseModel())
     assert bool(circuits.NoiseRule(readout_error=0.1))
     assert bool(circuits.NoiseModel(readout_error=0.1))
+
+
+def test_tsim_circuits() -> None:
+    """noisy_circuit and as_noiseless_circuit accept and return tsim.Circuit."""
+    try:
+        import tsim
+    except ImportError:
+        pytest.skip("tsim not installed")
+
+    stim_circuit = stim.Circuit("H 0\nCX 0 1\nM 0 1")
+    tsim_circuit = tsim.Circuit("H 0\nCX 0 1\nM 0 1")
+
+    noise_model = circuits.DepolarizingNoiseModel(0.01)
+
+    stim_noisy = noise_model.noisy_circuit(stim_circuit)
+    tsim_noisy = noise_model.noisy_circuit(tsim_circuit)
+    assert isinstance(stim_noisy, stim.Circuit)
+    assert isinstance(tsim_noisy, tsim.Circuit)
+    assert stim_noisy == tsim_noisy.stim_circuit
+
+    stim_noiseless = circuits.as_noiseless_circuit(stim_circuit)
+    tsim_noiseless = circuits.as_noiseless_circuit(tsim_circuit)
+    assert isinstance(stim_noiseless, stim.Circuit)
+    assert isinstance(tsim_noiseless, tsim.Circuit)

--- a/src/qldpc/circuits/noise_model_test.py
+++ b/src/qldpc/circuits/noise_model_test.py
@@ -301,10 +301,10 @@ def test_trivial_noise() -> None:
 
 def test_tsim_circuits() -> None:
     """noisy_circuit and as_noiseless_circuit accept and return tsim.Circuit."""
-    stim_circuit = stim.Circuit("H 0\nCX 0 1\nM 0 1")
-    tsim_circuit = tsim.Circuit("H 0\nCX 0 1\nM 0 1")
-
     noise_model = circuits.DepolarizingNoiseModel(0.01)
+
+    tsim_circuit = tsim.Circuit("H 0\nCX 0 1\nM 0 1")
+    stim_circuit = tsim_circuit.stim_circuit
 
     stim_noisy = noise_model.noisy_circuit(stim_circuit)
     tsim_noisy = noise_model.noisy_circuit(tsim_circuit)

--- a/src/qldpc/circuits/noise_model_test.py
+++ b/src/qldpc/circuits/noise_model_test.py
@@ -17,6 +17,7 @@ limitations under the License.
 
 import pytest
 import stim
+import tsim
 
 from qldpc import circuits
 
@@ -300,11 +301,6 @@ def test_trivial_noise() -> None:
 
 def test_tsim_circuits() -> None:
     """noisy_circuit and as_noiseless_circuit accept and return tsim.Circuit."""
-    try:
-        import tsim
-    except ImportError:
-        pytest.skip("tsim not installed")
-
     stim_circuit = stim.Circuit("H 0\nCX 0 1\nM 0 1")
     tsim_circuit = tsim.Circuit("H 0\nCX 0 1\nM 0 1")
 


### PR DESCRIPTION
`qldpc.circuits.NoiseModel` and `qdpc.circuits.as_noiseless_circuit` now accept/return `tsim` circuits as well.

@HaoTy could you please test this as a sanity check?