### PR TITLE
User-specified idling errors and tread one/two-qubit `SPP/SPP_DAG` as one/two-qubit Cliffords

### DIFF
--- a/src/qldpc/circuits/noise_model.py
+++ b/src/qldpc/circuits/noise_model.py
@@ -388,6 +388,12 @@ class NoiseModel:
             return self.clifford_1q_error
         if self.clifford_2q_error is not None and op_type == CLIFFORD_2Q:
             return self.clifford_2q_error
+        if op_type == CLIFFORD_PP:
+            num_qubits = sum(1 for target in op.targets_copy() if not target.is_combiner)
+            if num_qubits == 1 and self.clifford_1q_error is not None:
+                return self.clifford_1q_error
+            if num_qubits == 2 and self.clifford_2q_error is not None:
+                return self.clifford_2q_error
 
         if self.readout_error and op.name in JUST_MEASURE_OPS:
             return NoiseRule(readout_error=self.readout_error)

--- a/src/qldpc/circuits/noise_model.py
+++ b/src/qldpc/circuits/noise_model.py
@@ -320,8 +320,8 @@ class NoiseModel:
         readout_error: float | None = None,
         reset_error: float | None = None,
         *,
-        idle_error: float | None = None,
-        additional_error_waiting_for_m_or_r: float | None = None,
+        idle_error: NoiseRule | float | None = None,
+        additional_error_waiting_for_m_or_r: NoiseRule | float | None = None,
         rules: dict[str, NoiseRule] | None = None,
     ):
         """Initializes a noise model with specified parameters.
@@ -333,24 +333,24 @@ class NoiseModel:
                 Clifford gates.
             readout_error: Default probability of flipping measurement results.
             reset_error: Default probability of resetting qubits to the wrong state.
-            idle_error: Probability of depolarization for each idling qubit in any given moment.
-            additional_error_waiting_for_m_or_r: Additional depolarization probability applied to
-                qubits that are waiting while other qubits undergo measurement or reset operations.
+            idle_error: Noise rule or depolarization probability applied to each idling qubit in any
+                given moment.  If a NoiseRule is provided, its `after` channels are appended to the
+                idle qubits (its readout_error/reset_error fields are ignored).
+            additional_error_waiting_for_m_or_r: Additional noise rule or depolarization probability
+                applied to qubits that are waiting while other qubits undergo measurement or reset
+                operations.  Same NoiseRule semantics as `idle_error`.
             rules: Dictionary mapping specific gate names to their noise rules.  Overrides all other
                 rules for unitary, measurement, and reset gates.
         """
-        if not (isinstance(clifford_1q_error, NoiseRule) or clifford_1q_error is None):
-            clifford_1q_error = NoiseRule(after={"DEPOLARIZE1": clifford_1q_error})
-        if not (isinstance(clifford_2q_error, NoiseRule) or clifford_2q_error is None):
-            clifford_2q_error = NoiseRule(after={"DEPOLARIZE2": clifford_2q_error})
-
         self.rules = rules
-        self.clifford_1q_error = clifford_1q_error
-        self.clifford_2q_error = clifford_2q_error
+        self.clifford_1q_error = _as_noise_rule(clifford_1q_error, "DEPOLARIZE1")
+        self.clifford_2q_error = _as_noise_rule(clifford_2q_error, "DEPOLARIZE2")
         self.readout_error = readout_error or 0
         self.reset_error = reset_error or 0
-        self.idle_error = idle_error
-        self.additional_error_waiting_for_m_or_r = additional_error_waiting_for_m_or_r
+        self.idle_error = _as_noise_rule(idle_error, "DEPOLARIZE1")
+        self.additional_error_waiting_for_m_or_r = _as_noise_rule(
+            additional_error_waiting_for_m_or_r, "DEPOLARIZE1"
+        )
 
     def __bool__(self) -> bool:
         """Is this noise model nontrivial?"""
@@ -591,11 +591,11 @@ class NoiseModel:
         idle_qubits = sorted(non_collapse_qubits - set(operation_qubits))
 
         if self.idle_error and idle_qubits:
-            circuit.append("DEPOLARIZE1", idle_qubits, self.idle_error)
+            for op_name, args in self.idle_error.after.items():
+                circuit.append(op_name, idle_qubits, args)
         if self.additional_error_waiting_for_m_or_r and collapsed_qubits and non_collapse_qubits:
-            circuit.append(
-                "DEPOLARIZE1", non_collapse_qubits, self.additional_error_waiting_for_m_or_r
-            )
+            for op_name, args in self.additional_error_waiting_for_m_or_r.after.items():
+                circuit.append(op_name, non_collapse_qubits, args)
 
 
 class DepolarizingNoiseModel(NoiseModel):
@@ -641,6 +641,19 @@ class SI1000NoiseModel(NoiseModel):
             idle_error=p / 10,
             additional_error_waiting_for_m_or_r=2 * p,
         )
+
+
+def _as_noise_rule(error: NoiseRule | float | None, default_channel: str) -> NoiseRule | None:
+    """Normalize a noise-error argument to a NoiseRule (or None if falsy).
+
+    A falsy scalar (0, False, None) or empty NoiseRule collapses to None.  A truthy scalar is
+    wrapped as `NoiseRule(after={default_channel: error})`.
+    """
+    if isinstance(error, NoiseRule):
+        return error or None
+    if not error:
+        return None
+    return NoiseRule(after={default_channel: error})
 
 
 def _get_standardized_name(op: stim.CircuitInstruction) -> str:

--- a/src/qldpc/circuits/noise_model_test.py
+++ b/src/qldpc/circuits/noise_model_test.py
@@ -236,6 +236,61 @@ def test_pauli_product_measurements() -> None:
     assert _circuits_are_equivalent(noisy_circuit, noise_model.noisy_circuit(circuit))
 
 
+def test_pauli_product_cliffords() -> None:
+    """SPP gates on 1 or 2 qubits get, respectively, 1q or 2q noise."""
+
+    # SPP on one qubit -> clifford_1q_error; SPP on two qubits -> clifford_2q_error;
+    # SPP on three or more qubits is ignored by default.
+    circuit = stim.Circuit("""
+        SPP X0
+        TICK
+        SPP X0*Y1
+        TICK
+        SPP_DAG X0*Y1*Z2
+    """)
+    noise_model = circuits.NoiseModel(clifford_1q_error=0.1, clifford_2q_error=0.2)
+    noisy_circuit = stim.Circuit("""
+        SPP X0
+        DEPOLARIZE1(0.1) 0
+        TICK
+        SPP X0*Y1
+        DEPOLARIZE2(0.2) 0 1
+        TICK
+        SPP_DAG X0*Y1*Z2
+    """)
+    assert _circuits_are_equivalent(noisy_circuit, noise_model.noisy_circuit(circuit))
+
+    # multi-product SPP is split so each Pauli product is treated independently
+    circuit = stim.Circuit("""
+        SPP X0 Y1*Z2 X0*Y1*Z2
+    """)
+    noisy_circuit = stim.Circuit("""
+        SPP X0
+        SPP Y1*Z2
+        SPP X0*Y1*Z2
+        DEPOLARIZE1(0.1) 0
+        DEPOLARIZE2(0.2) 1 2
+    """)
+    assert _circuits_are_equivalent(noisy_circuit, noise_model.noisy_circuit(circuit))
+
+    # explicit rules dict overrides the default weight-based dispatch, including for weight >= 3
+    noise_rule = circuits.NoiseRule(after={"DEPOLARIZE1": 0.3})
+    noise_model = circuits.NoiseModel(clifford_1q_error=0.1, rules={"SPP": noise_rule})
+    circuit = stim.Circuit("""
+        SPP X0
+        TICK
+        SPP X0*Y1*Z2
+    """)
+    noisy_circuit = stim.Circuit("""
+        SPP X0
+        DEPOLARIZE1(0.3) 0
+        TICK
+        SPP X0*Y1*Z2
+        DEPOLARIZE1(0.3) 0 1 2
+    """)
+    assert _circuits_are_equivalent(noisy_circuit, noise_model.noisy_circuit(circuit))
+
+
 def test_repeat_blocks() -> None:
     """Repeat blocks get special treatment."""
 

--- a/src/qldpc/circuits/noise_model_test.py
+++ b/src/qldpc/circuits/noise_model_test.py
@@ -294,7 +294,7 @@ def test_pauli_product_cliffords() -> None:
     circuit = stim.Circuit("""
         SPP X0 Y1*Z2 X3*Y4*Z5
     """)
-    noisy_circuit = circuit + stim.Circuit("""
+    noisy_circuit = stim.Circuit("""
         SPP X0 Y1*Z2 X3*Y4*Z5
         DEPOLARIZE1(0.1) 0
         DEPOLARIZE2(0.2) 1 2

--- a/src/qldpc/circuits/noise_model_test.py
+++ b/src/qldpc/circuits/noise_model_test.py
@@ -292,12 +292,10 @@ def test_pauli_product_cliffords() -> None:
 
     # multi-product SPP is split so each Pauli product is treated independently
     circuit = stim.Circuit("""
-        SPP X0 Y1*Z2 X0*Y1*Z2
+        SPP X0 Y1*Z2 X3*Y4*Z5
     """)
-    noisy_circuit = stim.Circuit("""
-        SPP X0
-        SPP Y1*Z2
-        SPP X0*Y1*Z2
+    noisy_circuit = circuit + stim.Circuit("""
+        SPP X0 Y1*Z2 X3*Y4*Z5
         DEPOLARIZE1(0.1) 0
         DEPOLARIZE2(0.2) 1 2
     """)

--- a/src/qldpc/circuits/noise_model_test.py
+++ b/src/qldpc/circuits/noise_model_test.py
@@ -126,6 +126,36 @@ def test_idle_errors() -> None:
     """)
     assert _circuits_are_equivalent(noisy_circuit, noise_model.noisy_circuit(circuit))
 
+    # user-defined idling noise via NoiseRule (overrides the default DEPOLARIZE1 channel)
+    idle_rule = circuits.NoiseRule(after={"PAULI_CHANNEL_1": [0.05, 0.0, 0.1]})
+    m_or_r_rule = circuits.NoiseRule(after={"X_ERROR": 0.2, "Z_ERROR": 0.3})
+    noise_model = circuits.NoiseModel(
+        readout_error=0.1, idle_error=idle_rule, additional_error_waiting_for_m_or_r=m_or_r_rule
+    )
+    noisy_circuit = stim.Circuit("""
+        H 0 1 2
+        H 1
+        M(0.1) 0
+        DETECTOR rec[-1]
+        PAULI_CHANNEL_1(0.05, 0.0, 0.1) 2
+        X_ERROR(0.2) 1 2
+        Z_ERROR(0.3) 1 2
+    """)
+    assert _circuits_are_equivalent(noisy_circuit, noise_model.noisy_circuit(circuit))
+
+    # zero/None errors normalize to None for all NoiseRule-valued fields
+    noise_model = circuits.NoiseModel(
+        clifford_1q_error=0,
+        clifford_2q_error=0,
+        idle_error=0,
+        additional_error_waiting_for_m_or_r=None,
+    )
+    assert noise_model.clifford_1q_error is None
+    assert noise_model.clifford_2q_error is None
+    assert noise_model.idle_error is None
+    assert noise_model.additional_error_waiting_for_m_or_r is None
+    assert not bool(noise_model)
+
 
 def test_immunity() -> None:
     """Qubits and operations can be immune to errors."""


### PR DESCRIPTION
fixes #518 