### PR TITLE
Minor bugfixes and cleanup in recent `noise_model.py` additions

### DIFF
--- a/src/qldpc/circuits/noise_model.py
+++ b/src/qldpc/circuits/noise_model.py
@@ -325,7 +325,7 @@ class PauliChannel:
         return self._probabilities
 
     def __bool__(self) -> bool:
-        """Is this channel nontrivial?  (Any zero-prob entries are already dropped in __init__.)"""
+        """Is this channel nontrivial?"""
         return bool(self._probabilities)
 
     def __eq__(self, other: object) -> bool:
@@ -334,22 +334,12 @@ class PauliChannel:
         return self._num_qubits == other._num_qubits and self._probabilities == other._probabilities
 
     def __hash__(self) -> int:
-        # Canonical order is guaranteed by __init__, so tuple(items()) is deterministic.
         return hash((self._num_qubits, tuple(self._probabilities.items())))
 
     def __repr__(self) -> str:
         if not self._probabilities and self._num_qubits:
             return f"PauliChannel({{}}, num_qubits={self._num_qubits})"
         return f"PauliChannel({dict(self._probabilities)!r})"
-
-    def __getstate__(self) -> tuple[int, dict[str, float]]:
-        """Support pickling.  ``types.MappingProxyType`` is not itself picklable."""
-        return self._num_qubits, dict(self._probabilities)
-
-    def __setstate__(self, state: tuple[int, dict[str, float]]) -> None:
-        num_qubits, probs = state
-        self._num_qubits = num_qubits
-        self._probabilities = types.MappingProxyType(probs)
 
     @staticmethod
     def depolarizing(num_qubits: int, probability: float) -> PauliChannel:

--- a/src/qldpc/circuits/noise_model.py
+++ b/src/qldpc/circuits/noise_model.py
@@ -613,22 +613,9 @@ class NoiseRule:
             )
 
         if isinstance(self.after, PauliChannel):
-            if k == 1:
-                # stim natively broadcasts PAULI_CHANNEL_1 across all targets.
-                probs = self.after.probabilities
-                args = [probs.get(p, 0.0) for p in _PAULI_CHANNEL_1_ORDER]
-                if any(args):
-                    circuit.append("PAULI_CHANNEL_1", qubit_targets, args)
-            elif k == 2:
-                # stim natively broadcasts PAULI_CHANNEL_2 across pairs.
-                probs = self.after.probabilities
-                args = [probs.get(p, 0.0) for p in _PAULI_CHANNEL_2_ORDER]
-                if any(args):
-                    circuit.append("PAULI_CHANNEL_2", qubit_targets, args)
-            else:
-                # Higher-arity channels emit a CE chain per k-qubit gate.
-                for i in range(0, n_targets, k):
-                    _append_pauli_channel(circuit, self.after, qubit_targets[i : i + k])
+            # Emit once per k-qubit chunk.
+            for i in range(0, n_targets, k):
+                _append_pauli_channel(circuit, self.after, qubit_targets[i : i + k])
         else:
             # stim.Circuit escape hatch: apply the fragment verbatim to each k-qubit block, with
             # qubit indices remapped from [0, k) to the block's targets.
@@ -735,17 +722,17 @@ class NoiseModel:
         merged_nq_input: dict[int, NoiseRule | PauliChannel | Mapping[str, float] | float] = (
             dict(clifford_nq_error) if clifford_nq_error else {}
         )
-        rule_1q = _as_noise_rule(clifford_1q_error, "DEPOLARIZE1")
-        rule_2q = _as_noise_rule(clifford_2q_error, "DEPOLARIZE2")
+        rule_1q = _as_noise_rule(clifford_1q_error, 1)
+        rule_2q = _as_noise_rule(clifford_2q_error, 2)
         if rule_1q is not None:
             merged_nq_input[1] = rule_1q
         if rule_2q is not None:
             merged_nq_input[2] = rule_2q
         self.clifford_nq_error = _normalize_clifford_nq_error(merged_nq_input)
 
-        self.idle_error = _as_noise_rule(idle_error, "DEPOLARIZE1")
+        self.idle_error = _as_noise_rule(idle_error, 1)
         self.additional_error_waiting_for_m_or_r = _as_noise_rule(
-            additional_error_waiting_for_m_or_r, "DEPOLARIZE1"
+            additional_error_waiting_for_m_or_r, 1
         )
         # Idle noise is applied per-qubit, so anything with a declared arity != 1 has no natural
         # interpretation here.  Validate the declared arity BEFORE trivializing so a user typo like
@@ -1093,12 +1080,47 @@ class SI1000NoiseModel(NoiseModel):
 # Floating-point tolerance used for probability comparisons throughout this module.  Small enough
 # to catch real bugs, large enough to absorb the ~O(n * eps) drift that accumulates when summing
 # or renormalizing many probabilities.
-_APPROX_TOL = 1e-9
+_ABSOLUTE_ERROR_TOLERANCE = 1e-9
 
 
-def _is_approx_in_unit_interval(value: float, *, tol: float = _APPROX_TOL) -> bool:
+def _is_approx_in_unit_interval(value: float, *, atol: float = _ABSOLUTE_ERROR_TOLERANCE) -> bool:
     """Return True if ``value`` is in [0, 1], up to floating-point tolerance ``tol``."""
-    return -tol <= value <= 1 + tol
+    return -atol <= value <= 1 + atol
+
+
+def _is_uniform_depolarizing(args: list[float], *, atol: float = _ABSOLUTE_ERROR_TOLERANCE) -> bool:
+    """Return True if all ``args`` are equal (up to ``atol``) and non-zero.
+
+    Detects a ``PauliChannel.depolarizing(k, p)`` shape at emit time so it can be written as
+    ``DEPOLARIZE{k}(p)`` instead of ``PAULI_CHANNEL_{k}(p/n, ..., p/n)``.
+    """
+    return bool(args) and args[0] > 0 and all(abs(x - args[0]) <= atol for x in args[1:])
+
+
+def _pauli_channel_1_shortcut(args: list[float]) -> tuple[str, list[float]]:
+    """Return the compact stim ``(name, args)`` for a 1-qubit Pauli-channel probability vector.
+
+    Emits ``DEPOLARIZE1(p)`` when the three probabilities are equal and non-zero, or
+    ``{X,Y,Z}_ERROR(p)`` when exactly one is non-zero, else falls back to ``PAULI_CHANNEL_1``.
+    """
+    if _is_uniform_depolarizing(args):
+        return "DEPOLARIZE1", [sum(args)]
+    nonzero_positions = [i for i, x in enumerate(args) if x > 0]
+    if len(nonzero_positions) == 1:
+        (i,) = nonzero_positions
+        return f"{_PAULI_CHANNEL_1_ORDER[i]}_ERROR", [args[i]]
+    return "PAULI_CHANNEL_1", args
+
+
+def _pauli_channel_2_shortcut(args: list[float]) -> tuple[str, list[float]]:
+    """Return the compact stim ``(name, args)`` for a 2-qubit Pauli-channel probability vector.
+
+    Emits ``DEPOLARIZE2(p)`` when the fifteen probabilities are equal and non-zero, else falls
+    back to ``PAULI_CHANNEL_2``.
+    """
+    if _is_uniform_depolarizing(args):
+        return "DEPOLARIZE2", [sum(args)]
+    return "PAULI_CHANNEL_2", args
 
 
 def _get_gate_aliases(op: stim.CircuitInstruction) -> tuple[str, ...]:
@@ -1171,12 +1193,9 @@ def _append_pauli_channel(
         probs_1q = {"X": 0.0, "Y": 0.0, "Z": 0.0}
         for string, prob in channel.probabilities.items():
             probs_1q[string[active_positions[0]]] = prob
-        circuit.append(
-            "PAULI_CHANNEL_1",
-            active_qubits,
-            [probs_1q[p] for p in _PAULI_CHANNEL_1_ORDER],
-            tag=tag,
-        )
+        args = [probs_1q[p] for p in _PAULI_CHANNEL_1_ORDER]
+        name, name_args = _pauli_channel_1_shortcut(args)
+        circuit.append(name, active_qubits, name_args, tag=tag)
         return
 
     if len(active_positions) == 2:
@@ -1184,12 +1203,9 @@ def _append_pauli_channel(
         probs_2q = {pair: 0.0 for pair in _PAULI_CHANNEL_2_ORDER}
         for string, prob in channel.probabilities.items():
             probs_2q[string[pos0] + string[pos1]] = prob
-        circuit.append(
-            "PAULI_CHANNEL_2",
-            active_qubits,
-            [probs_2q[p] for p in _PAULI_CHANNEL_2_ORDER],
-            tag=tag,
-        )
+        args = [probs_2q[p] for p in _PAULI_CHANNEL_2_ORDER]
+        name, name_args = _pauli_channel_2_shortcut(args)
+        circuit.append(name, active_qubits, name_args, tag=tag)
         return
 
     remaining = 1.0
@@ -1242,33 +1258,64 @@ def _validate_after_circuit(after_circuit: stim.Circuit) -> None:
             )
 
 
-# Names of the two Pauli-channel primitives, since their args are already the canonical
-# per-Pauli-string probability layout used by ``PauliChannel``.
-_PAULI_CHANNEL_MAPPING_NAMES: dict[str, tuple[str, ...]] = {
-    "PAULI_CHANNEL_1": _PAULI_CHANNEL_1_ORDER,
-    "PAULI_CHANNEL_2": _PAULI_CHANNEL_2_ORDER,
-}
+def _mapping_entry_to_pauli_probs(
+    name: str, args: tuple[float, ...]
+) -> tuple[int, dict[str, float]] | None:
+    """Return ``(arity, {Pauli string: probability})`` if this Mapping-form noise entry is
+    representable as a ``PauliChannel``, else ``None``.
+
+    Recognized shapes: ``X_ERROR`` / ``Y_ERROR`` / ``Z_ERROR`` (single Pauli), ``I_ERROR`` /
+    ``II_ERROR`` (identity noise — non-observable, so contributes no non-I terms),
+    ``DEPOLARIZE1`` / ``DEPOLARIZE2`` (uniform), ``PAULI_CHANNEL_1`` / ``PAULI_CHANNEL_2``
+    (per-string args).  Anything else (``HERALDED_ERASE``, ``HERALDED_PAULI_CHANNEL_1``, or a
+    malformed arg count) returns ``None`` so the caller falls back to a ``stim.Circuit``
+    fragment.
+    """
+    if len(args) == 1:
+        (p,) = args
+        if name == "X_ERROR":
+            return 1, {"X": p}
+        if name == "Y_ERROR":
+            return 1, {"Y": p}
+        if name == "Z_ERROR":
+            return 1, {"Z": p}
+        if name == "I_ERROR":
+            return 1, {}
+        if name == "II_ERROR":
+            return 2, {}
+        if name == "DEPOLARIZE1":
+            return 1, {pauli: p / 3 for pauli in _PAULI_CHANNEL_1_ORDER}
+        if name == "DEPOLARIZE2":
+            return 2, {pair: p / 15 for pair in _PAULI_CHANNEL_2_ORDER}
+    if name == "PAULI_CHANNEL_1" and len(args) == 3:
+        return 1, dict(zip(_PAULI_CHANNEL_1_ORDER, args))
+    if name == "PAULI_CHANNEL_2" and len(args) == 15:
+        return 2, dict(zip(_PAULI_CHANNEL_2_ORDER, args))
+    return None
 
 
 def _mapping_after_to_channel_or_circuit(
     mapping: dict[str, tuple[float, ...]],
 ) -> PauliChannel | stim.Circuit:
-    """Convert a Mapping-form ``after`` to a ``PauliChannel`` if possible, else a stim.Circuit.
+    """Convert a Mapping-form ``after`` to a ``PauliChannel`` when every entry is Pauli-
+    representable (X_ERROR, Y_ERROR, Z_ERROR, I_ERROR, II_ERROR, DEPOLARIZE1, DEPOLARIZE2,
+    PAULI_CHANNEL_1, PAULI_CHANNEL_2 — merged per-Pauli-string when multiple entries share an
+    arity), otherwise into a ``stim.Circuit`` fragment.
 
-    A single-entry mapping whose channel name is ``PAULI_CHANNEL_1`` / ``PAULI_CHANNEL_2`` — the
-    two stim primitives that already spell out per-Pauli-string probabilities — is exactly a
-    ``PauliChannel``.  Other Mapping-form entries (``X_ERROR``, ``DEPOLARIZE1``,
-    ``HERALDED_ERASE``, mixed entries, …) round-trip into a stim.Circuit fragment on qubits
-    ``[0, k)``, where ``k`` is 2 if any 2-qubit-broadcast entry is present and 1 otherwise.  The
-    emitter treats broadcast-friendly fragments (all instructions in ``BROADCAST_{1,2}Q_NOISE``)
-    as native broadcasts, preserving instruction identity (``DEPOLARIZE1`` stays ``DEPOLARIZE1``).
+    Using a ``PauliChannel`` where possible lets ``PauliChannel.conditioned_on`` project the
+    channel under partial immunity in ``_rule_with_immunity``; only the escape-hatch shapes
+    (``HERALDED_ERASE`` et al., or mismatched arg counts) fall back to the opaque fragment form.
     """
-    if len(mapping) == 1:
-        [(name, args)] = mapping.items()
-        if name in _PAULI_CHANNEL_MAPPING_NAMES:
-            strings = _PAULI_CHANNEL_MAPPING_NAMES[name]
-            if len(args) == len(strings):
-                return PauliChannel(dict(zip(strings, args)))
+    conversions = [_mapping_entry_to_pauli_probs(name, args) for name, args in mapping.items()]
+    if all(c is not None for c in conversions):
+        arities = {arity for arity, _ in conversions}  # type: ignore[misc]
+        if len(arities) == 1:
+            (arity,) = arities
+            merged: dict[str, float] = {}
+            for _, probs in conversions:  # type: ignore[misc]
+                for pauli_str, p in probs.items():
+                    merged[pauli_str] = merged.get(pauli_str, 0.0) + p
+            return PauliChannel(merged, num_qubits=arity)
     arity = 2 if any(op in BROADCAST_2Q_NOISE for op in mapping) else 1
     fragment = stim.Circuit()
     for name, args in mapping.items():
@@ -1390,8 +1437,13 @@ def _validate_custom_rule(rule: NoiseRule, op: stim.CircuitInstruction) -> None:
     )
 
 
-def _as_noise_rule(error: NoiseRule | float | None, default_channel: str) -> NoiseRule | None:
+def _as_noise_rule(error: NoiseRule | float | None, default_arity: int) -> NoiseRule | None:
     """Normalize a noise-error argument to a NoiseRule (or None if the input is ``None``).
+
+    A float scalar is interpreted as a uniform depolarizing channel of the given ``default_arity``.
+    Using a ``PauliChannel`` (rather than a Mapping-form ``DEPOLARIZE{n}`` fragment) preserves the
+    Pauli-channel structure so downstream ``PauliChannel.conditioned_on`` can project it under
+    partial immunity.
 
     Does NOT trivialize an empty NoiseRule to ``None`` — callers must run their guard checks on
     the declared shape (e.g. arity) BEFORE trivializing, so that user typos like
@@ -1402,7 +1454,7 @@ def _as_noise_rule(error: NoiseRule | float | None, default_channel: str) -> Noi
         return error
     if error is None:
         return None
-    return NoiseRule(after={default_channel: error})
+    return NoiseRule(after=PauliChannel.depolarizing(default_arity, error))
 
 
 def _normalize_clifford_nq_error(
@@ -1442,12 +1494,7 @@ def _normalize_clifford_nq_error(
                 raise ValueError(f"clifford_nq_error[{weight}]={entry} is not in [0, 1]")
             if entry == 0:
                 continue
-            if weight == 1:
-                rule = NoiseRule(after={"DEPOLARIZE1": entry})
-            elif weight == 2:
-                rule = NoiseRule(after={"DEPOLARIZE2": entry})
-            else:
-                rule = NoiseRule(after=PauliChannel.depolarizing(weight, entry))
+            rule = NoiseRule(after=PauliChannel.depolarizing(weight, entry))
         _validate_rule_for_arity(rule, weight, f"clifford_nq_error[{weight}]")
         if rule:
             result[weight] = rule

--- a/src/qldpc/circuits/noise_model.py
+++ b/src/qldpc/circuits/noise_model.py
@@ -277,12 +277,14 @@ class PauliChannel:
             self._num_qubits = num_qubits if num_qubits is not None else 0
             self._probabilities: Mapping[str, float] = types.MappingProxyType({})
             return
+
         first_key = next(iter(probabilities))
         derived_num_qubits = len(first_key)
         if num_qubits is not None and num_qubits != derived_num_qubits:
             raise ValueError(
                 f"num_qubits={num_qubits} disagrees with Pauli string length {derived_num_qubits}"
             )
+
         identity = "I" * derived_num_qubits
         for string, prob in probabilities.items():
             if len(string) != derived_num_qubits:
@@ -297,15 +299,14 @@ class PauliChannel:
                 raise ValueError(f"Identity string {string!r} is implicit and must not be listed")
             if not (0 <= prob <= 1):
                 raise ValueError(f"Probability {prob} for {string!r} is not in [0, 1]")
+
         # Use math.fsum for a precise sum, and allow a small tolerance so a mathematically-
         # normalized input isn't rejected due to per-value rounding (e.g.,
         # ``[p_i / sum(p_i) for p_i in ...]`` can accumulate to ~1 + O(n * eps)).
         total = math.fsum(probabilities.values())
         if not _is_approx_in_unit_interval(total):
             raise ValueError(f"Sum of Pauli channel probabilities {total} is not in [0, 1]")
-        # Drop zero-probability entries and canonicalize insertion order (lex over Pauli strings)
-        # so `__eq__`-equal channels produce identical noise chains at emission time.  Store
-        # behind a MappingProxyType so the object is effectively immutable (needed for hashing).
+
         nonzero = {
             string: probabilities[string]
             for string in sorted(probabilities)

--- a/src/qldpc/circuits/noise_model.py
+++ b/src/qldpc/circuits/noise_model.py
@@ -453,11 +453,9 @@ class NoiseRule:
                     can shift indices used by ``DETECTOR`` / ``rec[-k]`` — the caller is responsible
                     for making sure those indices remain consistent.
                 - ``Mapping[str, float | Iterable[float]]``: syntactic sugar.  A single-entry
-                    mapping over a pure-Pauli broadcast noise (e.g., ``X_ERROR``, ``DEPOLARIZE2``)
-                    is converted to the equivalent ``PauliChannel``; everything else (such as
-                    heralded noise) is converted to a ``stim.Circuit`` fragment.
-                    ``CORRELATED_ERROR`` and ``ELSE_CORRELATED_ERROR`` are not accepted here — pass
-                    a ``stim.Circuit`` instead.
+                    mapping from ``DEPOLARIZE[12]``, ``PAULI_CHANNEL_[12]``, or ``[XYZ]_ERROR`` to
+                    appropriate gate arguments is converted to the equivalent ``PauliChannel``.
+                    Everything else is converted into a ``stim.Circuit``.
             readout_error: The probability that a measurement result is reported incorrectly.  Only
                 allowed for operations that produce measurement results.  ``None`` (the default)
                 means the field is unset (validation ignores it); ``0.0`` is an explicit no-op flip
@@ -1264,12 +1262,32 @@ def _validate_after_circuit(after_circuit: stim.Circuit) -> None:
             )
 
 
-# Names of the two Pauli-channel primitives, since their args are already the canonical
-# per-Pauli-string probability layout used by ``PauliChannel``.
-_PAULI_CHANNEL_MAPPING_NAMES: dict[str, tuple[str, ...]] = {
-    "PAULI_CHANNEL_1": _PAULI_CHANNEL_1_ORDER,
-    "PAULI_CHANNEL_2": _PAULI_CHANNEL_2_ORDER,
-}
+def _single_entry_pauli_channel(name: str, args: tuple[float, ...]) -> PauliChannel | None:
+    """Return the ``PauliChannel`` equivalent of a single Mapping-form entry, else ``None``.
+
+    Recognizes the Pauli-representable stim noise primitives: ``X_ERROR`` / ``Y_ERROR`` /
+    ``Z_ERROR`` (single Pauli), ``DEPOLARIZE1`` / ``DEPOLARIZE2`` (uniform), and
+    ``PAULI_CHANNEL_1`` / ``PAULI_CHANNEL_2`` (per-Pauli-string args).  Anything else
+    (``I_ERROR`` / ``II_ERROR``, ``HERALDED_ERASE``, ``HERALDED_PAULI_CHANNEL_1``, or a malformed
+    arg count) returns ``None`` so the caller falls back to a ``stim.Circuit`` fragment.
+    """
+    if len(args) == 1:
+        (p,) = args
+        if name == "X_ERROR":
+            return PauliChannel({"X": p})
+        if name == "Y_ERROR":
+            return PauliChannel({"Y": p})
+        if name == "Z_ERROR":
+            return PauliChannel({"Z": p})
+        if name == "DEPOLARIZE1":
+            return PauliChannel.depolarizing(1, p)
+        if name == "DEPOLARIZE2":
+            return PauliChannel.depolarizing(2, p)
+    if name == "PAULI_CHANNEL_1" and len(args) == 3:
+        return PauliChannel(dict(zip(_PAULI_CHANNEL_1_ORDER, args)))
+    if name == "PAULI_CHANNEL_2" and len(args) == 15:
+        return PauliChannel(dict(zip(_PAULI_CHANNEL_2_ORDER, args)))
+    return None
 
 
 def _mapping_after_to_channel_or_circuit(
@@ -1277,21 +1295,25 @@ def _mapping_after_to_channel_or_circuit(
 ) -> PauliChannel | stim.Circuit:
     """Convert a Mapping-form ``after`` to a ``PauliChannel`` if possible, else a stim.Circuit.
 
-    A single-entry mapping whose channel name is ``PAULI_CHANNEL_1`` / ``PAULI_CHANNEL_2`` — the
-    two stim primitives that already spell out per-Pauli-string probabilities — is exactly a
-    ``PauliChannel``.  Every other Mapping-form input (``X_ERROR``, ``DEPOLARIZE1``,
-    ``HERALDED_ERASE``, multi-entry mappings, …) round-trips into a stim.Circuit fragment on
-    qubits ``[0, k)``, where ``k`` is 2 if any 2-qubit-broadcast entry is present and 1
-    otherwise.  Multi-entry Mappings intentionally do NOT merge into a joint ``PauliChannel``:
-    users writing ``{"X_ERROR": p, "Z_ERROR": q}`` expect two independent noise ops (which
-    compose stochastically, with ``P(Y) = p·q``) — merging would silently give ``P(Y) = 0``.
+    A single-entry mapping whose name is one of the Pauli-representable stim noise primitives
+    (``X_ERROR``, ``Y_ERROR``, ``Z_ERROR``, ``DEPOLARIZE1``, ``DEPOLARIZE2``, ``PAULI_CHANNEL_1``,
+    ``PAULI_CHANNEL_2``) is converted to the equivalent ``PauliChannel`` — preserving the
+    Pauli-channel structure so downstream
+    ``PauliChannel.conditioned_on`` can project it under partial immunity.
+
+    Every other input — heralded / measurement-producing noise (``HERALDED_ERASE`` et al.),
+    single-entry mappings with wrong arg counts, or multi-entry mappings — round-trips into a
+    stim.Circuit fragment on qubits ``[0, k)``, where ``k`` is 2 if any 2-qubit-broadcast entry
+    is present and 1 otherwise.  Multi-entry mappings intentionally do NOT merge into a joint
+    ``PauliChannel``: users writing ``{"X_ERROR": p, "Z_ERROR": q}`` expect two independent noise
+    ops (which compose stochastically, with ``P(Y) = p·q``) — merging would silently give
+    ``P(Y) = 0``.
     """
     if len(mapping) == 1:
         [(name, args)] = mapping.items()
-        if name in _PAULI_CHANNEL_MAPPING_NAMES:
-            strings = _PAULI_CHANNEL_MAPPING_NAMES[name]
-            if len(args) == len(strings):
-                return PauliChannel(dict(zip(strings, args)))
+        channel = _single_entry_pauli_channel(name, args)
+        if channel is not None:
+            return channel
     arity = 2 if any(op in BROADCAST_2Q_NOISE for op in mapping) else 1
     fragment = stim.Circuit()
     for name, args in mapping.items():

--- a/src/qldpc/circuits/noise_model.py
+++ b/src/qldpc/circuits/noise_model.py
@@ -79,8 +79,7 @@ Per-gate-application noise via a callback (`rule_func`):
         # Give any gate touching qubit 7 a heavier depolarizing kick; leave everything else alone.
         targets = [t for t in op.targets_copy() if not t.is_combiner]
         if any(t.qubit_value == 7 for t in targets):
-            channel = "DEPOLARIZE2" if len(targets) == 2 else "DEPOLARIZE1"
-            return NoiseRule(after={channel: 1e-2})
+            return NoiseRule(after=PauliChannel.depolarizing(len(targets), 1e-2))
         return None
 
     noise_model = NoiseModel(
@@ -252,13 +251,6 @@ class PauliChannel:
 
     Maps non-identity Pauli strings (over the alphabet ``{I, X, Y, Z}``) to their probabilities.
     The all-identity string is implicit; its probability is ``1 - sum(others)``.
-
-    Pauli strings are in the absolute Pauli basis: slot ``k`` of a string maps to the ``k``-th
-    non-combiner target of the operation the channel is applied to.
-
-    Emitted as a chain of ``CORRELATED_ERROR`` / ``ELSE_CORRELATED_ERROR`` instructions, whose
-    conditional firing probabilities are renormalized so that each Pauli string's (unconditional)
-    firing probability equals the value provided.
     """
 
     def __init__(self, probabilities: Mapping[str, float], *, num_qubits: int | None = None):
@@ -424,7 +416,7 @@ class NoiseRule:
     def __init__(
         self,
         *,
-        after: PauliChannel | stim.Circuit | Mapping[str, float | Iterable[float]] | None = None,
+        after: PauliChannel | Mapping[str, float] | stim.Circuit | None = None,
         readout_error: float | None = None,
         reset_error: float | None = None,
     ):
@@ -440,22 +432,16 @@ class NoiseRule:
                     ``PAULI_CHANNEL_1`` / ``PAULI_CHANNEL_2`` when ``k ≤ 2`` (stim broadcasts), or
                     as a ``CORRELATED_ERROR`` / ``ELSE_CORRELATED_ERROR`` chain per ``k``-qubit
                     block for ``k ≥ 3``.
-                - ``stim.Circuit``: an escape hatch — a raw fragment of noise instructions emitted
-                    verbatim after each ``k``-qubit block, with qubit indices remapped
-                    from ``[0, k)`` in the fragment to the corresponding block's targets.  The
-                    fragment's arity is inferred from ``circuit.num_qubits``.  Every instruction
-                    must be a noise instruction (``op_type(name) == NOISE``); repeat blocks are
-                    rejected.  Prefer ``PauliChannel`` or the ``Mapping`` sugar when they suffice
-                    — the ``stim.Circuit`` form skips native broadcasting and requires the user to
-                    spell out targets explicitly.  Caveat: measurement-producing noise
-                    (``HERALDED_ERASE``, ``HERALDED_PAULI_CHANNEL_1``) emitted via this form will
-                    change the number of measurement records the surrounding circuit produces, and
-                    can shift indices used by ``DETECTOR`` / ``rec[-k]`` — the caller is responsible
-                    for making sure those indices remain consistent.
-                - ``Mapping[str, float | Iterable[float]]``: syntactic sugar.  A single-entry
-                    mapping from ``DEPOLARIZE[12]``, ``PAULI_CHANNEL_[12]``, or ``[XYZ]_ERROR`` to
-                    appropriate gate arguments is converted to the equivalent ``PauliChannel``.
-                    Everything else is converted into a ``stim.Circuit``.
+                - ``Mapping[str, float]``: syntactic sugar for a ``PauliChannel``.  Keys are
+                    non-identity Pauli strings (e.g. ``"X"``, ``"IZ"``, ``"XYZ"``); values are
+                    probabilities.  Passed directly to ``PauliChannel(mapping)``.
+                - ``stim.Circuit``: a fragment of noise instructions emitted verbatim after each
+                    ``k``-qubit block, with qubit indices remapped from ``[0, k)`` in the fragment
+                    to the corresponding block's targets.  The fragment's arity is inferred from
+                    ``circuit.num_qubits``.  Every instruction must be a noise instruction
+                    (``op_type(name) == NOISE``); repeat blocks are rejected.  ``PauliChannel`` and
+                    ``Mapping`` arguments are preferred when they suffice, as the ``stim.Circuit``
+                    form skips native broadcasting.
             readout_error: The probability that a measurement result is reported incorrectly.  Only
                 allowed for operations that produce measurement results.  ``None`` (the default)
                 means the field is unset (validation ignores it); ``0.0`` is an explicit no-op flip
@@ -465,9 +451,8 @@ class NoiseRule:
                 ``readout_error``.
 
         Raises:
-            ValueError: If any noise channel name is not recognized, any net probability of an
-                error is not in [0, 1], if a broadcast ``after`` mixes 1q and 2q entries, or if
-                the ``stim.Circuit`` form contains a non-noise instruction.
+            ValueError: If any Pauli string is invalid, any probability is not in [0, 1], or the
+                ``stim.Circuit`` form contains a non-noise instruction.
         """
         self.readout_error = readout_error
         if readout_error is not None and not (0 <= readout_error <= 1):
@@ -486,47 +471,7 @@ class NoiseRule:
             _validate_after_circuit(after)
             self.after = after
         else:
-            # Mapping form is syntactic sugar: normalize into either a PauliChannel (native
-            # broadcast) or a stim.Circuit (raw fragment) so the downstream code paths deal only
-            # with those two forms.  Full validation happens before we drop all-zero entries so a
-            # malformed spelling is rejected loudly even when the probabilities themselves are zero.
-            normalized_mapping: dict[str, tuple[float, ...]] = {}
-            for op, prob_or_probs in after.items():
-                if isinstance(prob_or_probs, Iterable) and not isinstance(
-                    prob_or_probs, (str, bytes)
-                ):
-                    normalized_mapping[op] = tuple(prob_or_probs)
-                else:
-                    normalized_mapping[op] = (prob_or_probs,)  # type: ignore[assignment]
-            has_1q = False
-            has_2q = False
-            for op, probs in normalized_mapping.items():
-                if op_type(op) != NOISE:
-                    raise ValueError(f"Invalid or unrecognized noise channel {op!r} in {after=}")
-                if op in CORRELATED_ERROR_NAMES:
-                    raise ValueError(
-                        f"{op} cannot be specified in a broadcast `after` mapping; pass an "
-                        "explicit stim.Circuit or a PauliChannel instead"
-                    )
-                if not _is_approx_in_unit_interval(math.fsum(probs)):
-                    raise ValueError(
-                        f"The net probability of an error is not between 0 and 1 in {after=}"
-                    )
-                if op in BROADCAST_1Q_NOISE:
-                    has_1q = True
-                if op in BROADCAST_2Q_NOISE:
-                    has_2q = True
-            if has_1q and has_2q:
-                raise ValueError(
-                    f"broadcast `after` mixes 1-qubit and 2-qubit noise entries in {after=}; "
-                    "combine them into a single 2-qubit PauliChannel, or pass an explicit "
-                    "stim.Circuit fragment"
-                )
-            filtered_mapping = {op: probs for op, probs in normalized_mapping.items() if any(probs)}
-            if not filtered_mapping:
-                self.after = None
-            else:
-                self.after = _mapping_after_to_channel_or_circuit(filtered_mapping)
+            self.after = PauliChannel(after) or None
 
         if (readout_error is not None or reset_error is not None) and self.after is not None:
             raise ValueError(
@@ -632,13 +577,13 @@ class NoiseModel:
 
     def __init__(
         self,
-        clifford_1q_error: float | PauliChannel | Mapping[str, float] | NoiseRule | None = None,
-        clifford_2q_error: float | PauliChannel | Mapping[str, float] | NoiseRule | None = None,
+        clifford_1q_error: float | Mapping[str, float] | PauliChannel | NoiseRule | None = None,
+        clifford_2q_error: float | Mapping[str, float] | PauliChannel | NoiseRule | None = None,
         readout_error: float | None = None,
         reset_error: float | None = None,
         *,
         clifford_nq_error: (
-            Mapping[int, float | PauliChannel | Mapping[str, float] | NoiseRule] | None
+            Mapping[int, float | Mapping[str, float] | PauliChannel | NoiseRule] | None
         ) = None,
         idle_error: NoiseRule | float | None = None,
         additional_error_waiting_for_m_or_r: NoiseRule | float | None = None,
@@ -650,21 +595,16 @@ class NoiseModel:
         Args:
             clifford_1q_error: Default noise applied after each one-qubit unitary Clifford gate.
                 A float ``p`` is a uniform 1-qubit depolarizing channel of total error probability
-                ``p``.  Also accepts a 1-qubit ``PauliChannel``, a raw ``Mapping[str, float]`` of
-                Pauli-string probabilities (wrapped into a ``PauliChannel``), or a ``NoiseRule``.
+                ``p``.  Also accepts a ``Mapping[str, float]`` from one-qubit non-identity
+                Pauli-strings to probabilities, a ``PauliChannel``, or a ``NoiseRule``.
             clifford_2q_error: Default noise applied after each two-qubit unitary Clifford gate.
-                A float ``p`` is a uniform 2-qubit depolarizing channel of total error probability
-                ``p``.  Also accepts a 2-qubit ``PauliChannel``, a raw ``Mapping[str, float]`` of
-                Pauli-string probabilities (wrapped into a ``PauliChannel``), or a ``NoiseRule``.
+                A float ``p`` is a uniform 1-qubit depolarizing channel of total error probability
+                ``p``.  Also accepts a ``Mapping[str, float]`` from two-qubit non-identity
+                Pauli-strings to probabilities, a ``PauliChannel``, or a ``NoiseRule``.
             readout_error: Default probability of flipping measurement results.
             reset_error: Default probability of resetting qubits to the wrong state.
             clifford_nq_error: Optional mapping from a qubit count ``k`` to the noise applied
-                after each ``k``-qubit unitary Clifford gate.  Values may be one of
-                    - a float ``p`` (interpreted as a uniform ``k``-qubit depolarizing channel of
-                        total error probability ``p``),
-                    - a ``PauliChannel``,
-                    - a raw ``Mapping[str, float]`` (auto-wrapped as ``PauliChannel``), or
-                    - a ``NoiseRule``.
+                after each ``k``-qubit unitary Clifford gate, similarly to ``clifford_?q_error``.
                 Specifying both ``clifford_nq_error[1]`` and ``clifford_1q_error`` raises an
                 ambiguity error; likewise with ``clifford_nq_error[2]`` and ``clifford_2q_error``.
             idle_error: Noise rule or depolarization probability applied to each idling qubit in any
@@ -1260,65 +1200,6 @@ def _validate_after_circuit(after_circuit: stim.Circuit) -> None:
             )
 
 
-def _single_entry_pauli_channel(name: str, args: tuple[float, ...]) -> PauliChannel | None:
-    """Return the ``PauliChannel`` equivalent of a single Mapping-form entry, else ``None``.
-
-    Recognizes the Pauli-representable stim noise primitives: ``X_ERROR`` / ``Y_ERROR`` /
-    ``Z_ERROR`` (single Pauli), ``DEPOLARIZE1`` / ``DEPOLARIZE2`` (uniform), and
-    ``PAULI_CHANNEL_1`` / ``PAULI_CHANNEL_2`` (per-Pauli-string args).  Anything else
-    (``I_ERROR`` / ``II_ERROR``, ``HERALDED_ERASE``, ``HERALDED_PAULI_CHANNEL_1``, or a malformed
-    arg count) returns ``None`` so the caller falls back to a ``stim.Circuit`` fragment.
-    """
-    if len(args) == 1:
-        (p,) = args
-        if name == "X_ERROR":
-            return PauliChannel({"X": p})
-        if name == "Y_ERROR":
-            return PauliChannel({"Y": p})
-        if name == "Z_ERROR":
-            return PauliChannel({"Z": p})
-        if name == "DEPOLARIZE1":
-            return PauliChannel.depolarizing(1, p)
-        if name == "DEPOLARIZE2":
-            return PauliChannel.depolarizing(2, p)
-    if name == "PAULI_CHANNEL_1" and len(args) == 3:
-        return PauliChannel(dict(zip(_PAULI_CHANNEL_1_ORDER, args)))
-    if name == "PAULI_CHANNEL_2" and len(args) == 15:
-        return PauliChannel(dict(zip(_PAULI_CHANNEL_2_ORDER, args)))
-    return None
-
-
-def _mapping_after_to_channel_or_circuit(
-    mapping: dict[str, tuple[float, ...]],
-) -> PauliChannel | stim.Circuit:
-    """Convert a Mapping-form ``after`` to a ``PauliChannel`` if possible, else a stim.Circuit.
-
-    A single-entry mapping whose name is one of the Pauli-representable stim noise primitives
-    (``X_ERROR``, ``Y_ERROR``, ``Z_ERROR``, ``DEPOLARIZE1``, ``DEPOLARIZE2``, ``PAULI_CHANNEL_1``,
-    ``PAULI_CHANNEL_2``) is converted to the equivalent ``PauliChannel`` — preserving the
-    Pauli-channel structure so downstream
-    ``PauliChannel.conditioned_on`` can project it under partial immunity.
-
-    Every other input — heralded / measurement-producing noise (``HERALDED_ERASE`` et al.),
-    single-entry mappings with wrong arg counts, or multi-entry mappings — round-trips into a
-    stim.Circuit fragment on qubits ``[0, k)``, where ``k`` is 2 if any 2-qubit-broadcast entry
-    is present and 1 otherwise.  Multi-entry mappings intentionally do NOT merge into a joint
-    ``PauliChannel``: users writing ``{"X_ERROR": p, "Z_ERROR": q}`` expect two independent noise
-    ops (which compose stochastically, with ``P(Y) = p·q``) — merging would silently give
-    ``P(Y) = 0``.
-    """
-    if len(mapping) == 1:
-        [(name, args)] = mapping.items()
-        channel = _single_entry_pauli_channel(name, args)
-        if channel is not None:
-            return channel
-    arity = 2 if any(op in BROADCAST_2Q_NOISE for op in mapping) else 1
-    fragment = stim.Circuit()
-    for name, args in mapping.items():
-        fragment.append(name, list(range(arity)), list(args))
-    return fragment
-
-
 def _rule_with_immunity(
     rule: NoiseRule,
     op: stim.CircuitInstruction,
@@ -1458,7 +1339,12 @@ def _as_noise_rule(
         return NoiseRule(after=PauliChannel(error))
     if error is None:
         return None
-    return NoiseRule(after=PauliChannel.depolarizing(default_arity, error))
+    if not isinstance(error, (int, float)):
+        raise TypeError(
+            f"expected a float, PauliChannel, Mapping[str, float], or NoiseRule; "
+            f"got {type(error).__name__!r}"
+        )
+    return NoiseRule(after=PauliChannel.depolarizing(default_arity, float(error)))
 
 
 def _normalize_clifford_nq_error(

--- a/src/qldpc/circuits/noise_model.py
+++ b/src/qldpc/circuits/noise_model.py
@@ -424,7 +424,7 @@ class NoiseRule:
     def __init__(
         self,
         *,
-        after: PauliChannel | Mapping[str, float | Iterable[float]] | stim.Circuit | None = None,
+        after: PauliChannel | stim.Circuit | Mapping[str, float | Iterable[float]] | None = None,
         readout_error: float | None = None,
         reset_error: float | None = None,
     ):
@@ -440,12 +440,6 @@ class NoiseRule:
                     ``PAULI_CHANNEL_1`` / ``PAULI_CHANNEL_2`` when ``k ≤ 2`` (stim broadcasts), or
                     as a ``CORRELATED_ERROR`` / ``ELSE_CORRELATED_ERROR`` chain per ``k``-qubit
                     block for ``k ≥ 3``.
-                - ``Mapping[str, float | Iterable[float]]``: syntactic sugar.  A single-entry
-                    mapping over a pure-Pauli broadcast noise (e.g., ``X_ERROR``, ``DEPOLARIZE2``)
-                    is converted to the equivalent ``PauliChannel``; everything else (such as
-                    heralded noise) is converted to a ``stim.Circuit`` fragment.
-                    ``CORRELATED_ERROR`` and ``ELSE_CORRELATED_ERROR`` are not accepted here — pass
-                    a ``PauliChannel`` or a ``stim.Circuit`` instead.
                 - ``stim.Circuit``: an escape hatch — a raw fragment of noise instructions emitted
                     verbatim after each ``k``-qubit block, with qubit indices remapped
                     from ``[0, k)`` in the fragment to the corresponding block's targets.  The
@@ -458,6 +452,12 @@ class NoiseRule:
                     change the number of measurement records the surrounding circuit produces, and
                     can shift indices used by ``DETECTOR`` / ``rec[-k]`` — the caller is responsible
                     for making sure those indices remain consistent.
+                - ``Mapping[str, float | Iterable[float]]``: syntactic sugar.  A single-entry
+                    mapping over a pure-Pauli broadcast noise (e.g., ``X_ERROR``, ``DEPOLARIZE2``)
+                    is converted to the equivalent ``PauliChannel``; everything else (such as
+                    heralded noise) is converted to a ``stim.Circuit`` fragment.
+                    ``CORRELATED_ERROR`` and ``ELSE_CORRELATED_ERROR`` are not accepted here — pass
+                    a ``stim.Circuit`` instead.
             readout_error: The probability that a measurement result is reported incorrectly.  Only
                 allowed for operations that produce measurement results.  ``None`` (the default)
                 means the field is unset (validation ignores it); ``0.0`` is an explicit no-op flip
@@ -634,13 +634,13 @@ class NoiseModel:
 
     def __init__(
         self,
-        clifford_1q_error: NoiseRule | float | None = None,
-        clifford_2q_error: NoiseRule | float | None = None,
+        clifford_1q_error: float | PauliChannel | Mapping[str, float] | NoiseRule | None = None,
+        clifford_2q_error: float | PauliChannel | Mapping[str, float] | NoiseRule | None = None,
         readout_error: float | None = None,
         reset_error: float | None = None,
         *,
         clifford_nq_error: (
-            Mapping[int, NoiseRule | PauliChannel | Mapping[str, float] | float] | None
+            Mapping[int, float | PauliChannel | Mapping[str, float] | NoiseRule] | None
         ) = None,
         idle_error: NoiseRule | float | None = None,
         additional_error_waiting_for_m_or_r: NoiseRule | float | None = None,
@@ -650,10 +650,16 @@ class NoiseModel:
         """Initializes a noise model with specified parameters.
 
         Args:
-            clifford_1q_error: Default noise rule or depolarization probability for one-qubit
-                unitary Clifford gates.
-            clifford_2q_error: Default noise rule or depolarization probability for two-qubit
-                unitary Clifford gates.
+            clifford_1q_error: Default noise applied after each one-qubit unitary Clifford gate.
+                A float ``p`` is a uniform 1-qubit depolarizing channel of total error probability
+                ``p``.  Also accepts a 1-qubit ``PauliChannel``, a raw ``Mapping[str, float]`` of
+                Pauli-string probabilities (auto-wrapped as ``PauliChannel``), or a full
+                ``NoiseRule``.
+            clifford_2q_error: Default noise applied after each two-qubit unitary Clifford gate.
+                A float ``p`` is a uniform 2-qubit depolarizing channel of total error probability
+                ``p``.  Also accepts a 2-qubit ``PauliChannel``, a raw ``Mapping[str, float]`` of
+                Pauli-string probabilities (auto-wrapped as ``PauliChannel``), or a full
+                ``NoiseRule``.
             readout_error: Default probability of flipping measurement results.
             reset_error: Default probability of resetting qubits to the wrong state.
             clifford_nq_error: Optional mapping from a qubit count ``k`` to the noise applied
@@ -1258,64 +1264,34 @@ def _validate_after_circuit(after_circuit: stim.Circuit) -> None:
             )
 
 
-def _mapping_entry_to_pauli_probs(
-    name: str, args: tuple[float, ...]
-) -> tuple[int, dict[str, float]] | None:
-    """Return ``(arity, {Pauli string: probability})`` if this Mapping-form noise entry is
-    representable as a ``PauliChannel``, else ``None``.
-
-    Recognized shapes: ``X_ERROR`` / ``Y_ERROR`` / ``Z_ERROR`` (single Pauli), ``I_ERROR`` /
-    ``II_ERROR`` (identity noise — non-observable, so contributes no non-I terms),
-    ``DEPOLARIZE1`` / ``DEPOLARIZE2`` (uniform), ``PAULI_CHANNEL_1`` / ``PAULI_CHANNEL_2``
-    (per-string args).  Anything else (``HERALDED_ERASE``, ``HERALDED_PAULI_CHANNEL_1``, or a
-    malformed arg count) returns ``None`` so the caller falls back to a ``stim.Circuit``
-    fragment.
-    """
-    if len(args) == 1:
-        (p,) = args
-        if name == "X_ERROR":
-            return 1, {"X": p}
-        if name == "Y_ERROR":
-            return 1, {"Y": p}
-        if name == "Z_ERROR":
-            return 1, {"Z": p}
-        if name == "I_ERROR":
-            return 1, {}
-        if name == "II_ERROR":
-            return 2, {}
-        if name == "DEPOLARIZE1":
-            return 1, {pauli: p / 3 for pauli in _PAULI_CHANNEL_1_ORDER}
-        if name == "DEPOLARIZE2":
-            return 2, {pair: p / 15 for pair in _PAULI_CHANNEL_2_ORDER}
-    if name == "PAULI_CHANNEL_1" and len(args) == 3:
-        return 1, dict(zip(_PAULI_CHANNEL_1_ORDER, args))
-    if name == "PAULI_CHANNEL_2" and len(args) == 15:
-        return 2, dict(zip(_PAULI_CHANNEL_2_ORDER, args))
-    return None
+# Names of the two Pauli-channel primitives, since their args are already the canonical
+# per-Pauli-string probability layout used by ``PauliChannel``.
+_PAULI_CHANNEL_MAPPING_NAMES: dict[str, tuple[str, ...]] = {
+    "PAULI_CHANNEL_1": _PAULI_CHANNEL_1_ORDER,
+    "PAULI_CHANNEL_2": _PAULI_CHANNEL_2_ORDER,
+}
 
 
 def _mapping_after_to_channel_or_circuit(
     mapping: dict[str, tuple[float, ...]],
 ) -> PauliChannel | stim.Circuit:
-    """Convert a Mapping-form ``after`` to a ``PauliChannel`` when every entry is Pauli-
-    representable (X_ERROR, Y_ERROR, Z_ERROR, I_ERROR, II_ERROR, DEPOLARIZE1, DEPOLARIZE2,
-    PAULI_CHANNEL_1, PAULI_CHANNEL_2 — merged per-Pauli-string when multiple entries share an
-    arity), otherwise into a ``stim.Circuit`` fragment.
+    """Convert a Mapping-form ``after`` to a ``PauliChannel`` if possible, else a stim.Circuit.
 
-    Using a ``PauliChannel`` where possible lets ``PauliChannel.conditioned_on`` project the
-    channel under partial immunity in ``_rule_with_immunity``; only the escape-hatch shapes
-    (``HERALDED_ERASE`` et al., or mismatched arg counts) fall back to the opaque fragment form.
+    A single-entry mapping whose channel name is ``PAULI_CHANNEL_1`` / ``PAULI_CHANNEL_2`` — the
+    two stim primitives that already spell out per-Pauli-string probabilities — is exactly a
+    ``PauliChannel``.  Every other Mapping-form input (``X_ERROR``, ``DEPOLARIZE1``,
+    ``HERALDED_ERASE``, multi-entry mappings, …) round-trips into a stim.Circuit fragment on
+    qubits ``[0, k)``, where ``k`` is 2 if any 2-qubit-broadcast entry is present and 1
+    otherwise.  Multi-entry Mappings intentionally do NOT merge into a joint ``PauliChannel``:
+    users writing ``{"X_ERROR": p, "Z_ERROR": q}`` expect two independent noise ops (which
+    compose stochastically, with ``P(Y) = p·q``) — merging would silently give ``P(Y) = 0``.
     """
-    conversions = [_mapping_entry_to_pauli_probs(name, args) for name, args in mapping.items()]
-    if all(c is not None for c in conversions):
-        arities = {arity for arity, _ in conversions}  # type: ignore[misc]
-        if len(arities) == 1:
-            (arity,) = arities
-            merged: dict[str, float] = {}
-            for _, probs in conversions:  # type: ignore[misc]
-                for pauli_str, p in probs.items():
-                    merged[pauli_str] = merged.get(pauli_str, 0.0) + p
-            return PauliChannel(merged, num_qubits=arity)
+    if len(mapping) == 1:
+        [(name, args)] = mapping.items()
+        if name in _PAULI_CHANNEL_MAPPING_NAMES:
+            strings = _PAULI_CHANNEL_MAPPING_NAMES[name]
+            if len(args) == len(strings):
+                return PauliChannel(dict(zip(strings, args)))
     arity = 2 if any(op in BROADCAST_2Q_NOISE for op in mapping) else 1
     fragment = stim.Circuit()
     for name, args in mapping.items():
@@ -1437,12 +1413,16 @@ def _validate_custom_rule(rule: NoiseRule, op: stim.CircuitInstruction) -> None:
     )
 
 
-def _as_noise_rule(error: NoiseRule | float | None, default_arity: int) -> NoiseRule | None:
+def _as_noise_rule(
+    error: NoiseRule | PauliChannel | Mapping[str, float] | float | None, default_arity: int
+) -> NoiseRule | None:
     """Normalize a noise-error argument to a NoiseRule (or None if the input is ``None``).
 
     A float scalar is interpreted as a uniform depolarizing channel of the given ``default_arity``.
-    Using a ``PauliChannel`` (rather than a Mapping-form ``DEPOLARIZE{n}`` fragment) preserves the
-    Pauli-channel structure so downstream ``PauliChannel.conditioned_on`` can project it under
+    A ``PauliChannel`` — or a raw ``Mapping[str, float]`` of Pauli-string probabilities, which is
+    auto-wrapped as a ``PauliChannel`` — is used as the rule's ``after``.  Storing the depolarizing
+    shape as a ``PauliChannel`` (rather than a Mapping-form ``DEPOLARIZE{n}`` fragment) preserves
+    the Pauli-channel structure so downstream ``PauliChannel.conditioned_on`` can project it under
     partial immunity.
 
     Does NOT trivialize an empty NoiseRule to ``None`` — callers must run their guard checks on
@@ -1452,6 +1432,10 @@ def _as_noise_rule(error: NoiseRule | float | None, default_arity: int) -> Noise
     """
     if isinstance(error, NoiseRule):
         return error
+    if isinstance(error, PauliChannel):
+        return NoiseRule(after=error)
+    if isinstance(error, Mapping):
+        return NoiseRule(after=PauliChannel(error))
     if error is None:
         return None
     return NoiseRule(after=PauliChannel.depolarizing(default_arity, error))

--- a/src/qldpc/circuits/noise_model.py
+++ b/src/qldpc/circuits/noise_model.py
@@ -651,13 +651,11 @@ class NoiseModel:
             clifford_1q_error: Default noise applied after each one-qubit unitary Clifford gate.
                 A float ``p`` is a uniform 1-qubit depolarizing channel of total error probability
                 ``p``.  Also accepts a 1-qubit ``PauliChannel``, a raw ``Mapping[str, float]`` of
-                Pauli-string probabilities (auto-wrapped as ``PauliChannel``), or a full
-                ``NoiseRule``.
+                Pauli-string probabilities (wrapped into a ``PauliChannel``), or a ``NoiseRule``.
             clifford_2q_error: Default noise applied after each two-qubit unitary Clifford gate.
                 A float ``p`` is a uniform 2-qubit depolarizing channel of total error probability
                 ``p``.  Also accepts a 2-qubit ``PauliChannel``, a raw ``Mapping[str, float]`` of
-                Pauli-string probabilities (auto-wrapped as ``PauliChannel``), or a full
-                ``NoiseRule``.
+                Pauli-string probabilities (wrapped into a ``PauliChannel``), or a ``NoiseRule``.
             readout_error: Default probability of flipping measurement results.
             reset_error: Default probability of resetting qubits to the wrong state.
             clifford_nq_error: Optional mapping from a qubit count ``k`` to the noise applied

--- a/src/qldpc/circuits/noise_model.py
+++ b/src/qldpc/circuits/noise_model.py
@@ -1090,41 +1090,6 @@ def _is_approx_in_unit_interval(value: float, *, atol: float = _ABSOLUTE_ERROR_T
     return -atol <= value <= 1 + atol
 
 
-def _is_uniform_depolarizing(args: list[float], *, atol: float = _ABSOLUTE_ERROR_TOLERANCE) -> bool:
-    """Return True if all ``args`` are equal (up to ``atol``) and non-zero.
-
-    Detects a ``PauliChannel.depolarizing(k, p)`` shape at emit time so it can be written as
-    ``DEPOLARIZE{k}(p)`` instead of ``PAULI_CHANNEL_{k}(p/n, ..., p/n)``.
-    """
-    return bool(args) and args[0] > 0 and all(abs(x - args[0]) <= atol for x in args[1:])
-
-
-def _pauli_channel_1_shortcut(args: list[float]) -> tuple[str, list[float]]:
-    """Return the compact stim ``(name, args)`` for a 1-qubit Pauli-channel probability vector.
-
-    Emits ``DEPOLARIZE1(p)`` when the three probabilities are equal and non-zero, or
-    ``{X,Y,Z}_ERROR(p)`` when exactly one is non-zero, else falls back to ``PAULI_CHANNEL_1``.
-    """
-    if _is_uniform_depolarizing(args):
-        return "DEPOLARIZE1", [sum(args)]
-    nonzero_positions = [i for i, x in enumerate(args) if x > 0]
-    if len(nonzero_positions) == 1:
-        (i,) = nonzero_positions
-        return f"{_PAULI_CHANNEL_1_ORDER[i]}_ERROR", [args[i]]
-    return "PAULI_CHANNEL_1", args
-
-
-def _pauli_channel_2_shortcut(args: list[float]) -> tuple[str, list[float]]:
-    """Return the compact stim ``(name, args)`` for a 2-qubit Pauli-channel probability vector.
-
-    Emits ``DEPOLARIZE2(p)`` when the fifteen probabilities are equal and non-zero, else falls
-    back to ``PAULI_CHANNEL_2``.
-    """
-    if _is_uniform_depolarizing(args):
-        return "DEPOLARIZE2", [sum(args)]
-    return "PAULI_CHANNEL_2", args
-
-
 def _get_gate_aliases(op: stim.CircuitInstruction) -> tuple[str, ...]:
     """Return the names by which ``op`` can be matched in ``rules`` and ``rule_func``.
 
@@ -1227,6 +1192,41 @@ def _append_pauli_channel(
                 break
             circuit.append("ELSE_CORRELATED_ERROR", pauli_targets, [prob / remaining], tag=tag)
         remaining -= prob
+
+
+def _pauli_channel_1_shortcut(args: list[float]) -> tuple[str, list[float]]:
+    """Return the compact stim ``(name, args)`` for a 1-qubit Pauli-channel probability vector.
+
+    Emits ``DEPOLARIZE1(p)`` when the three probabilities are equal and non-zero, or
+    ``{X,Y,Z}_ERROR(p)`` when exactly one is non-zero, else falls back to ``PAULI_CHANNEL_1``.
+    """
+    if _is_uniform_depolarizing(args):
+        return "DEPOLARIZE1", [sum(args)]
+    nonzero_positions = [i for i, x in enumerate(args) if x > 0]
+    if len(nonzero_positions) == 1:
+        (i,) = nonzero_positions
+        return f"{_PAULI_CHANNEL_1_ORDER[i]}_ERROR", [args[i]]
+    return "PAULI_CHANNEL_1", args
+
+
+def _pauli_channel_2_shortcut(args: list[float]) -> tuple[str, list[float]]:
+    """Return the compact stim ``(name, args)`` for a 2-qubit Pauli-channel probability vector.
+
+    Emits ``DEPOLARIZE2(p)`` when the fifteen probabilities are equal and non-zero, else falls
+    back to ``PAULI_CHANNEL_2``.
+    """
+    if _is_uniform_depolarizing(args):
+        return "DEPOLARIZE2", [sum(args)]
+    return "PAULI_CHANNEL_2", args
+
+
+def _is_uniform_depolarizing(args: list[float], *, atol: float = _ABSOLUTE_ERROR_TOLERANCE) -> bool:
+    """Return True if all ``args`` are equal (up to ``atol``) and non-zero.
+
+    Detects a ``PauliChannel.depolarizing(k, p)`` shape at emit time so it can be written as
+    ``DEPOLARIZE{k}(p)`` instead of ``PAULI_CHANNEL_{k}(p/n, ..., p/n)``.
+    """
+    return bool(args) and args[0] > 0 and all(abs(x - args[0]) <= atol for x in args[1:])
 
 
 def _pauli_string_to_targets(string: str, qubit_targets: list[int]) -> list[stim.GateTarget]:

--- a/src/qldpc/circuits/noise_model_test.py
+++ b/src/qldpc/circuits/noise_model_test.py
@@ -137,16 +137,15 @@ def test_idle_errors() -> None:
     noise_model = circuits.NoiseModel(
         readout_error=0.1, idle_error=idle_rule, additional_error_waiting_for_m_or_r=m_or_r_rule
     )
+    # The Mapping-form ``{"X_ERROR": 0.2, "Z_ERROR": 0.3}`` is auto-merged into a single
+    # ``PauliChannel({"X": 0.2, "Z": 0.3})``, emitted as one ``PAULI_CHANNEL_1(0.2, 0, 0.3)``.
     noisy_circuit = stim.Circuit("""
         H 0 1 2
         H 1
         M(0.1) 0
         DETECTOR rec[-1]
         PAULI_CHANNEL_1(0.05, 0.0, 0.1) 2
-        X_ERROR(0.2) 1
-        Z_ERROR(0.3) 1
-        X_ERROR(0.2) 2
-        Z_ERROR(0.3) 2
+        PAULI_CHANNEL_1(0.2, 0, 0.3) 1 2
     """)
     assert _circuits_are_equivalent(noisy_circuit, noise_model.noisy_circuit(circuit))
 
@@ -230,7 +229,9 @@ def test_immune_qubits() -> None:
     immunize_gates=True (the default); immunize_gates=False raises on any nontrivial case."""
 
     # 2-qubit broadcast pairs: (0, 1) both immune → drop, (1, 2) partial → drop under True /
-    # raise under False, (3, 4) neither immune → keep full 2q noise.
+    # condition to DEPOLARIZE1(p/5) on surviving qubit under False, (3, 4) neither immune → keep
+    # full 2q noise.  DEPOLARIZE2(p) conditioned on one immune position gives a uniform 1q
+    # depolarizing channel of total probability p/5 on the surviving qubit.
     circuit = stim.Circuit("""
         CNOT 0 1 1 2 3 4
     """)
@@ -245,8 +246,17 @@ def test_immune_qubits() -> None:
         """),
         dm.noisy_circuit(circuit, immune_qubits=[0, 1], immunize_gates=True),
     )
-    with pytest.raises(ValueError, match="partial immunity"):
-        dm.noisy_circuit(circuit, immune_qubits=[0, 1], immunize_gates=False)
+    assert _circuits_are_equivalent(
+        stim.Circuit("""
+            CNOT 0 1
+            TICK
+            CNOT 1 2
+            CNOT 3 4
+            DEPOLARIZE1(0.02) 2
+            DEPOLARIZE2(0.1) 3 4
+        """),
+        dm.noisy_circuit(circuit, immune_qubits=[0, 1], immunize_gates=False),
+    )
 
     # 3q PauliChannel with an immune middle position: whole gate's noise drops under True; under
     # False the channel is projected via ``PauliChannel.conditioned_on`` — surviving strings
@@ -709,7 +719,7 @@ def test_clifford_nq_error() -> None:
     noisy = noise_model.noisy_circuit(circuit)
     expected = stim.Circuit("""
         SPP X0 Y1*Z2 X3*Y4*Z5
-        PAULI_CHANNEL_1(0.01, 0, 0) 0
+        X_ERROR(0.01) 0
         PAULI_CHANNEL_2(0, 0, 0, 0, 0, 0.02, 0, 0, 0, 0, 0, 0, 0, 0, 0) 1 2
         CORRELATED_ERROR(0.03) X3 Y4 Z5
     """)
@@ -965,6 +975,32 @@ def test_noise_rule_errors() -> None:
         circuits.NoiseRule(after={"X_ERROR": 0.01}, readout_error=0.1)
     with pytest.raises(ValueError, match="after.*readout_error"):
         circuits.NoiseRule(after=circuits.PauliChannel({"X": 0.01}), reset_error=0.1)
+
+
+def test_mapping_form_pauli_channel_conversion() -> None:
+    """Mapping-form ``after`` entries are auto-converted to ``PauliChannel`` when possible.
+
+    All the shapes below cover the recognized Pauli-representable noise names in
+    ``_mapping_entry_to_pauli_probs`` (Y_ERROR / I_ERROR / II_ERROR / PAULI_CHANNEL_2 /
+    non-convertible HERALDED_ERASE fallback), plus the stim.Circuit fallback path.
+    """
+    # Y_ERROR alone becomes a single-Pauli PauliChannel.
+    rule = circuits.NoiseRule(after={"Y_ERROR": 0.1})
+    assert rule.after == circuits.PauliChannel({"Y": 0.1})
+
+    # I_ERROR is identity noise; the converter yields an empty PauliChannel (trivial rule).
+    assert not bool(circuits.NoiseRule(after={"I_ERROR": 0.1}))
+    # II_ERROR is 2-qubit identity noise; also trivial.
+    assert not bool(circuits.NoiseRule(after={"II_ERROR": 0.1}))
+
+    # A Mapping-form PAULI_CHANNEL_2 round-trips into a PauliChannel of arity 2.
+    args = [0.001] * 15
+    rule = circuits.NoiseRule(after={"PAULI_CHANNEL_2": args})
+    assert isinstance(rule.after, circuits.PauliChannel) and rule.after.num_qubits == 2
+
+    # A non-Pauli-representable name (HERALDED_ERASE) falls back to a stim.Circuit fragment.
+    rule = circuits.NoiseRule(after={"HERALDED_ERASE": 0.05})
+    assert isinstance(rule.after, stim.Circuit)
 
 
 def test_after_stim_circuit_form() -> None:

--- a/src/qldpc/circuits/noise_model_test.py
+++ b/src/qldpc/circuits/noise_model_test.py
@@ -63,20 +63,6 @@ def test_gate_errors() -> None:
     """)
     assert _circuits_are_equivalent(noisy_circuit, noise_model.noisy_circuit(circuit))
 
-    circuit = stim.Circuit("""
-        CX 0 1
-    """)
-    noise_rule = circuits.NoiseRule(
-        after=stim.Circuit("DEPOLARIZE2(0.2) 0 1\nPAULI_CHANNEL_1(0, 0.1, 0.1) 0 1")
-    )
-    noise_model = circuits.NoiseModel(rules={"CX": noise_rule})
-    noisy_circuit = stim.Circuit("""
-        CX 0 1
-        DEPOLARIZE2(0.2) 0 1
-        PAULI_CHANNEL_1(0, 0.1, 0.1) 0 1
-    """)
-    assert _circuits_are_equivalent(noisy_circuit, noise_model.noisy_circuit(circuit))
-
     # compose gate errors
     p_m = 0.1
     double_p_m = 1 - (1 - p_m) ** 2
@@ -540,24 +526,6 @@ def test_rule_func() -> None:
     result = kick_all.noisy_circuit(repeat_circuit, immune_op_tag="__skip__")
     assert "X_ERROR" not in str(result)
 
-    # Calling `get_noise_rule` directly with an unsplit multi-product MPP/SPP is a caller-side
-    # invariant violation; alias enumeration raises rather than silently returning a garbled name.
-    multi_product_mpp = stim.CircuitInstruction(
-        "MPP",
-        [
-            stim.target_x(0),
-            stim.target_combiner(),
-            stim.target_y(1),
-            stim.target_z(2),
-            stim.target_combiner(),
-            stim.target_x(3),
-        ],
-    )
-    with pytest.raises(ValueError, match="MPP must be split into a single Pauli product"):
-        circuits.NoiseModel(rules={"MXY": circuits.NoiseRule(readout_error=0.1)}).get_noise_rule(
-            multi_product_mpp
-        )
-
 
 def test_pauli_channel_class() -> None:
     """PauliChannel construction, validation, and helpers."""
@@ -678,14 +646,6 @@ def test_multi_qubit_pauli_channel_after_gate() -> None:
     """)
     assert _circuits_are_equivalent(noisy_circuit, noise_model.noisy_circuit(circuit))
 
-    # A PauliChannel passed as `after` is stored on `self.after` directly.
-    rule = circuits.NoiseRule(after=circuits.PauliChannel({"XY": 0.01}))
-    assert isinstance(rule.after, circuits.PauliChannel)
-    # A raw Mapping is auto-wrapped as a PauliChannel with the same Pauli-string keys.
-    rule = circuits.NoiseRule(after={"XY": 0.01})
-    assert isinstance(rule.after, circuits.PauliChannel)
-    assert rule.after == circuits.PauliChannel({"XY": 0.01})
-
 
 def test_clifford_nq_error() -> None:
     """clifford_nq_error dispatches by qubit count k."""
@@ -790,12 +750,6 @@ def test_clifford_nq_error_errors() -> None:
     with pytest.raises(ValueError, match="expects a multiple of 2 qubits"):
         noise_model.noisy_circuit(stim.Circuit("SPP X0*Y1*Z2"))
 
-    # CORRELATED_ERROR / ELSE_CORRELATED_ERROR / E are not valid Pauli strings in a broadcast
-    # `after` mapping; users are directed to wrap in a PauliChannel or use a stim.Circuit instead.
-    for name in ("CORRELATED_ERROR", "ELSE_CORRELATED_ERROR", "E"):
-        with pytest.raises(ValueError):
-            circuits.NoiseRule(after={name: 0.01})
-
     # A 2-qubit `after` broadcast (via a 2q PauliChannel) applied to a wrong-arity gate raises
     # at construction time via `_validate_rule_for_arity`, both for fixed-arity gate names and
     # for basis-suffixed rule keys ("MXYZ" is arity 3 — a 2q `after` is caught up front).
@@ -819,54 +773,31 @@ def test_clifford_nq_error_errors() -> None:
     with pytest.raises(ValueError, match="reset_error.*only valid on reset"):
         circuits.NoiseModel(rules={"M": circuits.NoiseRule(reset_error=0.1)})
 
-    # Unrecognized `after` Pauli string → ValueError.
-    with pytest.raises(ValueError):
-        circuits.NoiseRule(after={"NOT_A_GATE": 0.01})
-
 
 def test_pauli_channel_idle_error_rejection() -> None:
-    """Multi-qubit `after` rules are not accepted on idle-error rules."""
-    # 2-qubit PauliChannel
+    """Multi-qubit `after` rules are not accepted on idle-error rules (all shapes rejected)."""
     channel = circuits.PauliChannel({"XY": 0.01})
     with pytest.raises(ValueError, match="idle_error.*multi-qubit"):
         circuits.NoiseModel(idle_error=circuits.NoiseRule(after=channel))
     with pytest.raises(ValueError, match="additional_error_waiting_for_m_or_r.*multi-qubit"):
         circuits.NoiseModel(additional_error_waiting_for_m_or_r=circuits.NoiseRule(after=channel))
-    # 2-qubit stim.Circuit form
+    # stim.Circuit form is rejected on the same grounds
     with pytest.raises(ValueError, match="idle_error.*multi-qubit"):
         circuits.NoiseModel(
             idle_error=circuits.NoiseRule(after=stim.Circuit("DEPOLARIZE2(0.1) 0 1"))
         )
-    # 2-qubit broadcast form (via a 2q PauliChannel)
-    with pytest.raises(ValueError, match="idle_error.*multi-qubit"):
-        circuits.NoiseModel(
-            idle_error=circuits.NoiseRule(after=circuits.PauliChannel.depolarizing(2, 0.1))
-        )
 
 
-def test_pauli_channel_canonicalizes_order_and_drops_zeros() -> None:
-    """PauliChannel drops zero-prob entries and canonicalizes insertion order."""
+def test_pauli_channel_drops_zeros() -> None:
+    """PauliChannel drops zero-prob entries but preserves arity."""
     ch = circuits.PauliChannel({"XI": 0.0, "IX": 0.05, "XX": 0.05})
-    # "XI":0.0 is dropped, remaining keys are lex-sorted.
     assert list(ch.probabilities.keys()) == ["IX", "XX"]
-    # Two channels differing only in insertion order compare equal and emit identical circuits.
-    ch_alt = circuits.PauliChannel({"XX": 0.05, "IX": 0.05, "XI": 0.0})
-    assert ch == ch_alt
-    m1 = circuits.NoiseModel(rules={"SPP": circuits.NoiseRule(after=ch)})
-    m2 = circuits.NoiseModel(rules={"SPP": circuits.NoiseRule(after=ch_alt)})
-    assert m1.noisy_circuit(stim.Circuit("SPP X0*Y1")) == m2.noisy_circuit(
-        stim.Circuit("SPP X0*Y1")
-    )
-    # An all-zero PauliChannel drops its zero-probability entries but keeps the arity derived
-    # from the input strings.
+    # An all-zero PauliChannel drops its entries but keeps the arity derived from the strings,
+    # and normalizes to a trivial `after` when attached to a NoiseRule.
     all_zero = circuits.PauliChannel({"XY": 0.0})
-    assert all_zero.num_qubits == 2
-    assert dict(all_zero.probabilities) == {}
-    assert not bool(all_zero)
-    # ...and attaching one to a NoiseRule normalizes to an empty `after`, so the rule is trivial.
+    assert all_zero.num_qubits == 2 and dict(all_zero.probabilities) == {} and not bool(all_zero)
     all_zero_rule = circuits.NoiseRule(after=circuits.PauliChannel({"XY": 0.0}))
-    assert not all_zero_rule.after
-    assert not bool(all_zero_rule)
+    assert not all_zero_rule.after and not bool(all_zero_rule)
 
 
 def test_pauli_channel_hashable_and_frozen() -> None:
@@ -898,17 +829,6 @@ def test_pauli_channel_float_drift_clamped() -> None:
         ELSE_CORRELATED_ERROR(1.0) Y0 Y1 Y2
     """)
     assert _circuits_are_equivalent(expected, noisy)
-
-
-def test_pauli_channel_pickle_round_trip() -> None:
-    """PauliChannel supports pickle round-trip (needed for cache / multiprocessing)."""
-    import pickle
-
-    channel = circuits.PauliChannel({"XYZ": 0.01, "ZZZ": 0.02})
-    restored = pickle.loads(pickle.dumps(channel))
-    assert restored == channel
-    assert hash(restored) == hash(channel)
-    assert restored.num_qubits == 3
 
 
 def test_repeat_blocks() -> None:
@@ -960,10 +880,6 @@ def test_noise_rule_errors() -> None:
         circuits.NoiseRule(readout_error=1.1)
     with pytest.raises(ValueError, match="not between 0 and 1"):
         circuits.NoiseRule(reset_error=1.1)
-    with pytest.raises(ValueError):
-        circuits.NoiseRule(after={"X": -0.1})
-    with pytest.raises(ValueError):
-        circuits.NoiseRule(after={"S": 0.5})
 
     # Passing a non-numeric, non-Mapping, non-NoiseRule type for a scalar noise field raises.
     with pytest.raises(TypeError, match="expected a float"):
@@ -988,6 +904,24 @@ def test_noise_rule_errors() -> None:
             idle_error=circuits.NoiseRule(after=circuits.PauliChannel({}, num_qubits=3))
         )
 
+    # get_noise_rule requires pre-split (single Pauli product) MPP/SPP ops.
+    with pytest.raises(ValueError, match="split into a single Pauli product"):
+        # Two products: X0*Y1 and Z2*X3 — targets at odd indices include non-combiners (Z2, X3).
+        multi = stim.CircuitInstruction(
+            "MPP",
+            [
+                stim.target_x(0),
+                stim.target_combiner(),
+                stim.target_y(1),
+                stim.target_z(2),
+                stim.target_combiner(),
+                stim.target_x(3),
+            ],
+        )
+        circuits.NoiseModel(rules={"MXY": circuits.NoiseRule(readout_error=0.1)}).get_noise_rule(
+            multi
+        )
+
     # NoiseRule cannot combine `after`-noise with readout_error / reset_error — those should be
     # separate rules (or handled via NoiseModel-level defaults).
     with pytest.raises(ValueError, match="after.*readout_error"):
@@ -1000,6 +934,16 @@ def test_after_stim_circuit_form() -> None:
     """`after=stim.Circuit(...)`: fragments emit verbatim per k-qubit block (with remapped
     qubits); immunity filters per instruction under immunize_gates=True and raises on any
     partial-immunity case under immunize_gates=False."""
+
+    # Multiple noise ops in one fragment (combining DEPOLARIZE2 + PAULI_CHANNEL_1 — not expressible
+    # as a single PauliChannel — is the canonical reason to use the stim.Circuit escape hatch).
+    noise_rule = circuits.NoiseRule(
+        after=stim.Circuit("DEPOLARIZE2(0.2) 0 1\nPAULI_CHANNEL_1(0, 0.1, 0.1) 0 1")
+    )
+    assert _circuits_are_equivalent(
+        stim.Circuit("CX 0 1\nDEPOLARIZE2(0.2) 0 1\nPAULI_CHANNEL_1(0, 0.1, 0.1) 0 1"),
+        circuits.NoiseModel(rules={"CX": noise_rule}).noisy_circuit(stim.Circuit("CX 0 1")),
+    )
 
     circuit = stim.Circuit("SPP X0*Y1*Z2")
 
@@ -1057,11 +1001,9 @@ def test_after_stim_circuit_form() -> None:
 
 
 def test_trivial_noise() -> None:
-    """Boolean testing for trivial noise rules/models."""
+    """A NoiseModel with only a rule_func is truthy even before the func is consulted."""
     assert not bool(circuits.NoiseRule())
     assert not bool(circuits.NoiseModel())
-    assert bool(circuits.NoiseRule(readout_error=0.1))
-    assert bool(circuits.NoiseModel(readout_error=0.1))
     assert bool(circuits.NoiseModel(rule_func=lambda op: None))
 
 

--- a/src/qldpc/circuits/noise_model_test.py
+++ b/src/qldpc/circuits/noise_model_test.py
@@ -205,8 +205,13 @@ def test_immunity() -> None:
 
 
 def test_immune_qubits() -> None:
-    """immune_qubits + immunize_gates: partial-immune noise is dropped per broadcast atom under
-    immunize_gates=True (the default); immunize_gates=False raises on any nontrivial case."""
+    """immune_qubits + immunize_gates: noise on partially-immune gates and measurements.
+
+    Under immunize_gates=True (the default), partial-immune noise is dropped per broadcast atom.
+    Under immunize_gates=False, PauliChannel after-noise is conditioned via
+    ``PauliChannel.conditioned_on``; stim.Circuit fragments and readout_error on partial immunity
+    raise instead.
+    """
 
     # 2-qubit broadcast pairs: (0, 1) both immune → drop, (1, 2) partial → drop under True /
     # condition to DEPOLARIZE1(p/5) on surviving qubit under False, (3, 4) neither immune → keep
@@ -907,20 +912,9 @@ def test_noise_rule_errors() -> None:
     # get_noise_rule requires pre-split (single Pauli product) MPP/SPP ops.
     with pytest.raises(ValueError, match="split into a single Pauli product"):
         # Two products: X0*Y1 and Z2*X3 — targets at odd indices include non-combiners (Z2, X3).
-        multi = stim.CircuitInstruction(
-            "MPP",
-            [
-                stim.target_x(0),
-                stim.target_combiner(),
-                stim.target_y(1),
-                stim.target_z(2),
-                stim.target_combiner(),
-                stim.target_x(3),
-            ],
-        )
-        circuits.NoiseModel(rules={"MXY": circuits.NoiseRule(readout_error=0.1)}).get_noise_rule(
-            multi
-        )
+        mpp = stim.Circuit("MPP X0*Y1 Z2*X3")[0]
+        rule = circuits.NoiseRule(readout_error=0.1)
+        circuits.NoiseModel(rules={"MXY": rule}).get_noise_rule(mpp)
 
     # NoiseRule cannot combine `after`-noise with readout_error / reset_error — those should be
     # separate rules (or handled via NoiseModel-level defaults).
@@ -931,9 +925,11 @@ def test_noise_rule_errors() -> None:
 
 
 def test_after_stim_circuit_form() -> None:
-    """`after=stim.Circuit(...)`: fragments emit verbatim per k-qubit block (with remapped
-    qubits); immunity filters per instruction under immunize_gates=True and raises on any
-    partial-immunity case under immunize_gates=False."""
+    """`after=stim.Circuit(...)`: verbatim-fragment emission and immunity filtering.
+
+    Fragments emit verbatim per k-qubit block (with remapped qubits).  Immunity drops the whole
+    fragment under immunize_gates=True and raises under immunize_gates=False.
+    """
 
     # Multiple noise ops in one fragment (combining DEPOLARIZE2 + PAULI_CHANNEL_1 — not expressible
     # as a single PauliChannel — is the canonical reason to use the stim.Circuit escape hatch).

--- a/src/qldpc/circuits/noise_model_test.py
+++ b/src/qldpc/circuits/noise_model_test.py
@@ -109,6 +109,39 @@ def test_gate_errors() -> None:
         noise_model.noisy_circuit(circuit, insert_ticks=False)
 
 
+def test_mapping_form_single_entry_pauli_channel() -> None:
+    """Single-entry Mapping-form ``after`` entries with Pauli-representable names are auto-
+    converted to ``PauliChannel``; anything else (heralded noise, mismatched arg counts,
+    multi-entry mappings) falls back to a ``stim.Circuit`` fragment."""
+
+    # Single-Pauli errors → single-string PauliChannel.
+    assert circuits.NoiseRule(after={"Y_ERROR": 0.1}).after == circuits.PauliChannel({"Y": 0.1})
+    assert circuits.NoiseRule(after={"Z_ERROR": 0.1}).after == circuits.PauliChannel({"Z": 0.1})
+
+    # DEPOLARIZE1 / DEPOLARIZE2 → uniform PauliChannel of the right arity.
+    r = circuits.NoiseRule(after={"DEPOLARIZE1": 0.3})
+    assert r.after == circuits.PauliChannel.depolarizing(1, 0.3)
+    r = circuits.NoiseRule(after={"DEPOLARIZE2": 0.15})
+    assert r.after == circuits.PauliChannel.depolarizing(2, 0.15)
+
+    # I_ERROR / II_ERROR are identity noise — not recognized as Pauli-channel-representable, so
+    # they fall through to the stim.Circuit fragment path.
+    assert isinstance(circuits.NoiseRule(after={"I_ERROR": 0.1}).after, stim.Circuit)
+    assert isinstance(circuits.NoiseRule(after={"II_ERROR": 0.1}).after, stim.Circuit)
+
+    # PAULI_CHANNEL_2 with the correct 15 args → 2-qubit PauliChannel.
+    r = circuits.NoiseRule(after={"PAULI_CHANNEL_2": [0.001] * 15})
+    assert isinstance(r.after, circuits.PauliChannel) and r.after.num_qubits == 2
+
+    # HERALDED_ERASE (not Pauli-representable) → stim.Circuit fragment.
+    assert isinstance(circuits.NoiseRule(after={"HERALDED_ERASE": 0.05}).after, stim.Circuit)
+
+    # PAULI_CHANNEL_1 with wrong argcount → stim.Circuit fragment (stim itself rejects at
+    # circuit-build time; the conversion path simply declines to auto-wrap).
+    with pytest.raises(Exception):
+        circuits.NoiseRule(after={"PAULI_CHANNEL_1": (0.1,)})
+
+
 def test_idle_errors() -> None:
     """Add idling errors to a circuit."""
 

--- a/src/qldpc/circuits/noise_model_test.py
+++ b/src/qldpc/circuits/noise_model_test.py
@@ -137,15 +137,16 @@ def test_idle_errors() -> None:
     noise_model = circuits.NoiseModel(
         readout_error=0.1, idle_error=idle_rule, additional_error_waiting_for_m_or_r=m_or_r_rule
     )
-    # The Mapping-form ``{"X_ERROR": 0.2, "Z_ERROR": 0.3}`` is auto-merged into a single
-    # ``PauliChannel({"X": 0.2, "Z": 0.3})``, emitted as one ``PAULI_CHANNEL_1(0.2, 0, 0.3)``.
     noisy_circuit = stim.Circuit("""
         H 0 1 2
         H 1
         M(0.1) 0
         DETECTOR rec[-1]
         PAULI_CHANNEL_1(0.05, 0.0, 0.1) 2
-        PAULI_CHANNEL_1(0.2, 0, 0.3) 1 2
+        X_ERROR(0.2) 1
+        Z_ERROR(0.3) 1
+        X_ERROR(0.2) 2
+        Z_ERROR(0.3) 2
     """)
     assert _circuits_are_equivalent(noisy_circuit, noise_model.noisy_circuit(circuit))
 
@@ -747,6 +748,20 @@ def test_clifford_nq_error() -> None:
     assert circuits.NoiseModel(clifford_nq_error={3: 0.0}).clifford_nq_error == {}
     assert circuits.NoiseModel(clifford_nq_error={3: circuits.NoiseRule()}).clifford_nq_error == {}
 
+    # clifford_1q_error / clifford_2q_error also accept a PauliChannel directly, or a raw
+    # Pauli-string Mapping (auto-wrapped as PauliChannel).
+    noise_model = circuits.NoiseModel(
+        clifford_1q_error=circuits.PauliChannel({"X": 0.01}),
+        clifford_2q_error={"XY": 0.02},
+    )
+    assert _circuits_are_equivalent(
+        stim.Circuit(
+            "H 0\nX_ERROR(0.01) 0\nTICK\nCX 0 1\nPAULI_CHANNEL_2("
+            + "0, 0, 0, 0, 0, 0.02, 0, 0, 0, 0, 0, 0, 0, 0, 0) 0 1"
+        ),
+        noise_model.noisy_circuit(stim.Circuit("H 0\nCX 0 1")),
+    )
+
 
 def test_clifford_nq_error_errors() -> None:
     """Validation errors around clifford_nq_error and related rules."""
@@ -975,32 +990,6 @@ def test_noise_rule_errors() -> None:
         circuits.NoiseRule(after={"X_ERROR": 0.01}, readout_error=0.1)
     with pytest.raises(ValueError, match="after.*readout_error"):
         circuits.NoiseRule(after=circuits.PauliChannel({"X": 0.01}), reset_error=0.1)
-
-
-def test_mapping_form_pauli_channel_conversion() -> None:
-    """Mapping-form ``after`` entries are auto-converted to ``PauliChannel`` when possible.
-
-    All the shapes below cover the recognized Pauli-representable noise names in
-    ``_mapping_entry_to_pauli_probs`` (Y_ERROR / I_ERROR / II_ERROR / PAULI_CHANNEL_2 /
-    non-convertible HERALDED_ERASE fallback), plus the stim.Circuit fallback path.
-    """
-    # Y_ERROR alone becomes a single-Pauli PauliChannel.
-    rule = circuits.NoiseRule(after={"Y_ERROR": 0.1})
-    assert rule.after == circuits.PauliChannel({"Y": 0.1})
-
-    # I_ERROR is identity noise; the converter yields an empty PauliChannel (trivial rule).
-    assert not bool(circuits.NoiseRule(after={"I_ERROR": 0.1}))
-    # II_ERROR is 2-qubit identity noise; also trivial.
-    assert not bool(circuits.NoiseRule(after={"II_ERROR": 0.1}))
-
-    # A Mapping-form PAULI_CHANNEL_2 round-trips into a PauliChannel of arity 2.
-    args = [0.001] * 15
-    rule = circuits.NoiseRule(after={"PAULI_CHANNEL_2": args})
-    assert isinstance(rule.after, circuits.PauliChannel) and rule.after.num_qubits == 2
-
-    # A non-Pauli-representable name (HERALDED_ERASE) falls back to a stim.Circuit fragment.
-    rule = circuits.NoiseRule(after={"HERALDED_ERASE": 0.05})
-    assert isinstance(rule.after, stim.Circuit)
 
 
 def test_after_stim_circuit_form() -> None:

--- a/src/qldpc/circuits/noise_model_test.py
+++ b/src/qldpc/circuits/noise_model_test.py
@@ -63,10 +63,6 @@ def test_gate_errors() -> None:
     """)
     assert _circuits_are_equivalent(noisy_circuit, noise_model.noisy_circuit(circuit))
 
-    # Mixed 1q + 2q entries in a Mapping-form `after` are rejected — combine them via a
-    # stim.Circuit escape hatch if needed.
-    with pytest.raises(ValueError, match="mixes 1-qubit and 2-qubit"):
-        circuits.NoiseRule(after={"DEPOLARIZE2": 0.2, "PAULI_CHANNEL_1": [0, 0.1, 0.1]})
     circuit = stim.Circuit("""
         CX 0 1
     """)
@@ -109,39 +105,6 @@ def test_gate_errors() -> None:
         noise_model.noisy_circuit(circuit, insert_ticks=False)
 
 
-def test_mapping_form_single_entry_pauli_channel() -> None:
-    """Single-entry Mapping-form ``after`` entries with Pauli-representable names are auto-
-    converted to ``PauliChannel``; anything else (heralded noise, mismatched arg counts,
-    multi-entry mappings) falls back to a ``stim.Circuit`` fragment."""
-
-    # Single-Pauli errors → single-string PauliChannel.
-    assert circuits.NoiseRule(after={"Y_ERROR": 0.1}).after == circuits.PauliChannel({"Y": 0.1})
-    assert circuits.NoiseRule(after={"Z_ERROR": 0.1}).after == circuits.PauliChannel({"Z": 0.1})
-
-    # DEPOLARIZE1 / DEPOLARIZE2 → uniform PauliChannel of the right arity.
-    r = circuits.NoiseRule(after={"DEPOLARIZE1": 0.3})
-    assert r.after == circuits.PauliChannel.depolarizing(1, 0.3)
-    r = circuits.NoiseRule(after={"DEPOLARIZE2": 0.15})
-    assert r.after == circuits.PauliChannel.depolarizing(2, 0.15)
-
-    # I_ERROR / II_ERROR are identity noise — not recognized as Pauli-channel-representable, so
-    # they fall through to the stim.Circuit fragment path.
-    assert isinstance(circuits.NoiseRule(after={"I_ERROR": 0.1}).after, stim.Circuit)
-    assert isinstance(circuits.NoiseRule(after={"II_ERROR": 0.1}).after, stim.Circuit)
-
-    # PAULI_CHANNEL_2 with the correct 15 args → 2-qubit PauliChannel.
-    r = circuits.NoiseRule(after={"PAULI_CHANNEL_2": [0.001] * 15})
-    assert isinstance(r.after, circuits.PauliChannel) and r.after.num_qubits == 2
-
-    # HERALDED_ERASE (not Pauli-representable) → stim.Circuit fragment.
-    assert isinstance(circuits.NoiseRule(after={"HERALDED_ERASE": 0.05}).after, stim.Circuit)
-
-    # PAULI_CHANNEL_1 with wrong argcount → stim.Circuit fragment (stim itself rejects at
-    # circuit-build time; the conversion path simply declines to auto-wrap).
-    with pytest.raises(Exception):
-        circuits.NoiseRule(after={"PAULI_CHANNEL_1": (0.1,)})
-
-
 def test_idle_errors() -> None:
     """Add idling errors to a circuit."""
 
@@ -165,8 +128,8 @@ def test_idle_errors() -> None:
     assert _circuits_are_equivalent(noisy_circuit, noise_model.noisy_circuit(circuit))
 
     # user-defined idling noise via NoiseRule (overrides the default DEPOLARIZE1 channel)
-    idle_rule = circuits.NoiseRule(after={"PAULI_CHANNEL_1": [0.05, 0.0, 0.1]})
-    m_or_r_rule = circuits.NoiseRule(after={"X_ERROR": 0.2, "Z_ERROR": 0.3})
+    idle_rule = circuits.NoiseRule(after={"X": 0.05, "Z": 0.1})
+    m_or_r_rule = circuits.NoiseRule(after=circuits.PauliChannel({"X": 0.2, "Z": 0.3}))
     noise_model = circuits.NoiseModel(
         readout_error=0.1, idle_error=idle_rule, additional_error_waiting_for_m_or_r=m_or_r_rule
     )
@@ -176,10 +139,7 @@ def test_idle_errors() -> None:
         M(0.1) 0
         DETECTOR rec[-1]
         PAULI_CHANNEL_1(0.05, 0.0, 0.1) 2
-        X_ERROR(0.2) 1
-        Z_ERROR(0.3) 1
-        X_ERROR(0.2) 2
-        Z_ERROR(0.3) 2
+        PAULI_CHANNEL_1(0.2, 0, 0.3) 1 2
     """)
     assert _circuits_are_equivalent(noisy_circuit, noise_model.noisy_circuit(circuit))
 
@@ -428,7 +388,7 @@ def test_pauli_product_cliffords() -> None:
     assert _circuits_are_equivalent(noisy_circuit, noise_model.noisy_circuit(circuit))
 
     # explicit rules dict overrides the default weight-based dispatch, including for weight >= 3
-    noise_rule = circuits.NoiseRule(after={"DEPOLARIZE1": 0.3})
+    noise_rule = circuits.NoiseRule(after=circuits.PauliChannel.depolarizing(1, 0.3))
     noise_model = circuits.NoiseModel(clifford_1q_error=0.1, rules={"SPP": noise_rule})
     circuit = stim.Circuit("""
         SPP X0 X0*Y1*Z2
@@ -455,7 +415,7 @@ def test_rule_func() -> None:
         targets = [t for t in op.targets_copy() if not t.is_combiner]
         seen.append((op.name, op.tag, tuple(t.qubit_value for t in targets)))
         if op.name == "H" and targets[0].qubit_value == 1:
-            return circuits.NoiseRule(after={"X_ERROR": 0.5})
+            return circuits.NoiseRule(after={"X": 0.5})
         return None
 
     noise_model = circuits.NoiseModel(clifford_1q_error=0.1, rule_func=per_qubit)
@@ -474,7 +434,7 @@ def test_rule_func() -> None:
     def per_pair(op: stim.CircuitInstruction) -> circuits.NoiseRule | None:
         targets = op.targets_copy()
         if op.name == "CX" and {t.qubit_value for t in targets} == {2, 3}:
-            return circuits.NoiseRule(after={"DEPOLARIZE2": 0.9})
+            return circuits.NoiseRule(after=circuits.PauliChannel.depolarizing(2, 0.9))
         return None
 
     noise_model = circuits.NoiseModel(clifford_2q_error=0.1, rule_func=per_pair)
@@ -489,10 +449,11 @@ def test_rule_func() -> None:
     # The callback takes top priority over `rules`, and receives the instruction's tag.
     def tagged(op: stim.CircuitInstruction) -> circuits.NoiseRule:
         assert op.tag == "mytag"
-        return circuits.NoiseRule(after={"DEPOLARIZE1": 0.7})
+        return circuits.NoiseRule(after=circuits.PauliChannel.depolarizing(1, 0.7))
 
     noise_model = circuits.NoiseModel(
-        rules={"H": circuits.NoiseRule(after={"DEPOLARIZE1": 0.2})}, rule_func=tagged
+        rules={"H": circuits.NoiseRule(after=circuits.PauliChannel.depolarizing(1, 0.2))},
+        rule_func=tagged,
     )
     circuit = stim.Circuit()
     circuit.append("H", [0], tag="mytag")
@@ -524,7 +485,7 @@ def test_rule_func() -> None:
 
     # Noise-immune qubits still take precedence over the callback.
     def kick(op: stim.CircuitInstruction) -> circuits.NoiseRule:
-        return circuits.NoiseRule(after={"DEPOLARIZE1": 0.5})
+        return circuits.NoiseRule(after=circuits.PauliChannel.depolarizing(1, 0.5))
 
     noise_model = circuits.NoiseModel(rule_func=kick)
     circuit = stim.Circuit("H 0 1")
@@ -541,7 +502,7 @@ def test_rule_func() -> None:
 
     def record(op: stim.CircuitInstruction) -> circuits.NoiseRule:
         consulted.append(op.name)
-        return circuits.NoiseRule(after={"X_ERROR": 0.5})
+        return circuits.NoiseRule(after={"X": 0.5})
 
     noise_model = circuits.NoiseModel(rule_func=record)
     noise_model.noisy_circuit(stim.Circuit("QUBIT_COORDS(0, 0) 0\nM 0\nCX rec[-1] 1"))
@@ -557,7 +518,7 @@ def test_rule_func() -> None:
 
     # A returned rule's `after` arity must match the gate application's qubit count.
     bad_arity = circuits.NoiseModel(
-        rule_func=lambda op: circuits.NoiseRule(after={"DEPOLARIZE1": 0.1})
+        rule_func=lambda op: circuits.NoiseRule(after=circuits.PauliChannel.depolarizing(1, 0.1))
     )
     with pytest.raises(ValueError, match="rule for 'CX'.*`after` has arity 1"):
         bad_arity.noisy_circuit(stim.Circuit("CX 0 1"))
@@ -570,7 +531,7 @@ def test_rule_func() -> None:
     assert "PAULI_CHANNEL_3" in str(noisy_circuit) or "CORRELATED_ERROR" in str(noisy_circuit)
 
     # The recursive noisy_circuit call inside a REPEAT block forwards immune_op_tag.
-    kick_all = circuits.NoiseModel(rule_func=lambda op: circuits.NoiseRule(after={"X_ERROR": 0.5}))
+    kick_all = circuits.NoiseModel(rule_func=lambda op: circuits.NoiseRule(after={"X": 0.5}))
     body = stim.Circuit()
     body.append("H", [0], tag="__skip__")
     body.append("TICK")
@@ -720,10 +681,10 @@ def test_multi_qubit_pauli_channel_after_gate() -> None:
     # A PauliChannel passed as `after` is stored on `self.after` directly.
     rule = circuits.NoiseRule(after=circuits.PauliChannel({"XY": 0.01}))
     assert isinstance(rule.after, circuits.PauliChannel)
-    # A raw dict is NOT auto-wrapped: Mapping `after` is broadcast noise, so a Pauli-string key
-    # like "XY" is treated as an unrecognized channel name.
-    with pytest.raises(ValueError, match="unrecognized noise channel"):
-        circuits.NoiseRule(after={"XY": 0.01})
+    # A raw Mapping is auto-wrapped as a PauliChannel with the same Pauli-string keys.
+    rule = circuits.NoiseRule(after={"XY": 0.01})
+    assert isinstance(rule.after, circuits.PauliChannel)
+    assert rule.after == circuits.PauliChannel({"XY": 0.01})
 
 
 def test_clifford_nq_error() -> None:
@@ -829,23 +790,27 @@ def test_clifford_nq_error_errors() -> None:
     with pytest.raises(ValueError, match="expects a multiple of 2 qubits"):
         noise_model.noisy_circuit(stim.Circuit("SPP X0*Y1*Z2"))
 
-    # CORRELATED_ERROR / ELSE_CORRELATED_ERROR / E are rejected in a broadcast `after` mapping;
-    # users are directed to wrap in a PauliChannel or use a stim.Circuit instead.
+    # CORRELATED_ERROR / ELSE_CORRELATED_ERROR / E are not valid Pauli strings in a broadcast
+    # `after` mapping; users are directed to wrap in a PauliChannel or use a stim.Circuit instead.
     for name in ("CORRELATED_ERROR", "ELSE_CORRELATED_ERROR", "E"):
-        with pytest.raises(ValueError, match="cannot be specified in a broadcast"):
+        with pytest.raises(ValueError):
             circuits.NoiseRule(after={name: 0.01})
 
-    # Pairwise `after` broadcast entries (DEPOLARIZE2, ...) applied to a wrong-arity gate raise
+    # A 2-qubit `after` broadcast (via a 2q PauliChannel) applied to a wrong-arity gate raises
     # at construction time via `_validate_rule_for_arity`, both for fixed-arity gate names and
-    # for basis-suffixed rule keys ("MXYZ" is arity 3 — a DEPOLARIZE2 `after` is caught up front).
+    # for basis-suffixed rule keys ("MXYZ" is arity 3 — a 2q `after` is caught up front).
     with pytest.raises(ValueError, match="arity 2; expected 1"):
-        circuits.NoiseModel(rules={"H": circuits.NoiseRule(after={"DEPOLARIZE2": 0.01})})
+        circuits.NoiseModel(
+            rules={"H": circuits.NoiseRule(after=circuits.PauliChannel.depolarizing(2, 0.01))}
+        )
     with pytest.raises(ValueError, match="arity 2; expected 3"):
-        circuits.NoiseModel(rules={"MXYZ": circuits.NoiseRule(after={"DEPOLARIZE2": 0.01})})
+        circuits.NoiseModel(
+            rules={"MXYZ": circuits.NoiseRule(after=circuits.PauliChannel.depolarizing(2, 0.01))}
+        )
     # Bare "MPP" / "SPP" remain variable-arity; wrong-arity `after` is caught at emission.
     with pytest.raises(ValueError, match="expects a multiple of 2 qubits"):
         circuits.NoiseModel(
-            rules={"MPP": circuits.NoiseRule(after={"DEPOLARIZE2": 0.01})}
+            rules={"MPP": circuits.NoiseRule(after=circuits.PauliChannel.depolarizing(2, 0.01))}
         ).noisy_circuit(stim.Circuit("MPP X0*Y1*Z2"))
 
     # readout_error / reset_error are rejected on rules for gates that can't measure/reset.
@@ -854,8 +819,8 @@ def test_clifford_nq_error_errors() -> None:
     with pytest.raises(ValueError, match="reset_error.*only valid on reset"):
         circuits.NoiseModel(rules={"M": circuits.NoiseRule(reset_error=0.1)})
 
-    # Unrecognized `after` channel name → ValueError (not a bare KeyError).
-    with pytest.raises(ValueError, match="Invalid or unrecognized noise channel"):
+    # Unrecognized `after` Pauli string → ValueError.
+    with pytest.raises(ValueError):
         circuits.NoiseRule(after={"NOT_A_GATE": 0.01})
 
 
@@ -872,9 +837,11 @@ def test_pauli_channel_idle_error_rejection() -> None:
         circuits.NoiseModel(
             idle_error=circuits.NoiseRule(after=stim.Circuit("DEPOLARIZE2(0.1) 0 1"))
         )
-    # 2-qubit broadcast Mapping form
+    # 2-qubit broadcast form (via a 2q PauliChannel)
     with pytest.raises(ValueError, match="idle_error.*multi-qubit"):
-        circuits.NoiseModel(idle_error=circuits.NoiseRule(after={"DEPOLARIZE2": 0.1}))
+        circuits.NoiseModel(
+            idle_error=circuits.NoiseRule(after=circuits.PauliChannel.depolarizing(2, 0.1))
+        )
 
 
 def test_pauli_channel_canonicalizes_order_and_drops_zeros() -> None:
@@ -993,10 +960,14 @@ def test_noise_rule_errors() -> None:
         circuits.NoiseRule(readout_error=1.1)
     with pytest.raises(ValueError, match="not between 0 and 1"):
         circuits.NoiseRule(reset_error=1.1)
-    with pytest.raises(ValueError, match="not between 0 and 1"):
-        circuits.NoiseRule(after={"X_ERROR": -0.1})
-    with pytest.raises(ValueError, match="Invalid or unrecognized noise channel"):
+    with pytest.raises(ValueError):
+        circuits.NoiseRule(after={"X": -0.1})
+    with pytest.raises(ValueError):
         circuits.NoiseRule(after={"S": 0.5})
+
+    # Passing a non-numeric, non-Mapping, non-NoiseRule type for a scalar noise field raises.
+    with pytest.raises(TypeError, match="expected a float"):
+        circuits.NoiseModel(clifford_1q_error="DEPOLARIZE1")  # type: ignore[arg-type]
 
     # `after` as a stim.Circuit rejects non-noise instructions and repeat blocks.
     with pytest.raises(ValueError, match="non-noise instruction"):
@@ -1020,7 +991,7 @@ def test_noise_rule_errors() -> None:
     # NoiseRule cannot combine `after`-noise with readout_error / reset_error — those should be
     # separate rules (or handled via NoiseModel-level defaults).
     with pytest.raises(ValueError, match="after.*readout_error"):
-        circuits.NoiseRule(after={"X_ERROR": 0.01}, readout_error=0.1)
+        circuits.NoiseRule(after={"X": 0.01}, readout_error=0.1)
     with pytest.raises(ValueError, match="after.*readout_error"):
         circuits.NoiseRule(after=circuits.PauliChannel({"X": 0.01}), reset_error=0.1)
 
@@ -1061,7 +1032,7 @@ def test_after_stim_circuit_form() -> None:
         )
 
     # A Mapping `after` whose entries all have zero probabilities normalizes to a trivial rule.
-    zero_rule = circuits.NoiseRule(after={"DEPOLARIZE1": 0.0, "PAULI_CHANNEL_1": (0.0, 0.0, 0.0)})
+    zero_rule = circuits.NoiseRule(after={"X": 0.0, "Y": 0.0, "Z": 0.0})
     assert not bool(zero_rule)
 
     # A mixed 1q+2q stim.Circuit fragment must emit per-k-qubit-block, NOT native-broadcast


### PR DESCRIPTION
@acasta-yhliu this should fix your issue [here](https://github.com/qLDPCOrg/qLDPC/issues/426#issuecomment-4919397056)

## Summary

This PR improves the `NoiseRule` / `NoiseModel` API in `noise_model.py`.

**Unified `Mapping`-form `after` semantics.** `NoiseRule(after={"X": 0.1, "IZ": 0.05})` now uses Pauli-string keys, consistent with `PauliChannel` and `NoiseModel`. Previously the mapping used stim gate-name keys (`"X_ERROR"`, `"DEPOLARIZE1"`, etc.), which was inconsistent with every other place in the API accepting a `Mapping`. Old gate-name keys now raise a clear `ValueError`.

**Widened `clifford_1q_error` / `clifford_2q_error`.** Both now accept `float | PauliChannel | Mapping[str, float] | NoiseRule | None`, matching the types already accepted by `clifford_nq_error`.

**Scalar depolarizing noise routes through `PauliChannel`.** A scalar float like `clifford_2q_error=0.01` now internally constructs `PauliChannel.depolarizing(k, p)`. This fixes a bug where `immunize_gates=False` on a partially-immune gate raised an error even for plain depolarizing noise, since the channel can now be correctly conditioned via `PauliChannel.conditioned_on`.