### PR TITLE
Add a missing guard + raise error for invalid inputs to `circuits.get_logical_tableau`

### DIFF
--- a/examples/scripts/find_bbcode_layouts.py
+++ b/examples/scripts/find_bbcode_layouts.py
@@ -133,7 +133,7 @@ def get_max_qubit_distance(code: qldpc.codes.BBCode) -> float:
 def get_check_supports(code: qldpc.codes.BBCode) -> npt.NDArray[np.int_]:
     """Identify the support of the parity checks of the given code."""
     return np.vstack(
-        [np.where(stabilizer) for stabilizer in itertools.chain(code.matrix_x, code.matrix_z)]
+        [np.flatnonzero(stabilizer) for stabilizer in itertools.chain(code.matrix_x, code.matrix_z)]
     )
 
 

--- a/src/qldpc/abstract/groups_test.py
+++ b/src/qldpc/abstract/groups_test.py
@@ -132,7 +132,7 @@ def assert_valid_lifts(group: abstract.Group) -> None:
     # invert elements: g -> g**(-1)
     assert all(
         np.array_equal(
-            np.where(group.inversion_matrix[:, group.index(gg)]),
+            np.flatnonzero(group.inversion_matrix[:, group.index(gg)]),
             [[group.index(~gg)]],
         )
         for gg in group_members
@@ -156,7 +156,7 @@ def assert_valid_lifts(group: abstract.Group) -> None:
     else:
         assert all(
             np.array_equal(
-                np.where(group.adjoint_lift(aa)[:, group.index(bb)]),
+                np.flatnonzero(group.adjoint_lift(aa)[:, group.index(bb)]),
                 [[group.index(aa * bb * ~aa)]],
             )
             for aa, bb in itertools.product(group_members, repeat=2)

--- a/src/qldpc/abstract/groups_test.py
+++ b/src/qldpc/abstract/groups_test.py
@@ -133,7 +133,7 @@ def assert_valid_lifts(group: abstract.Group) -> None:
     assert all(
         np.array_equal(
             np.flatnonzero(group.inversion_matrix[:, group.index(gg)]),
-            [[group.index(~gg)]],
+            [group.index(~gg)],
         )
         for gg in group_members
     )
@@ -157,7 +157,7 @@ def assert_valid_lifts(group: abstract.Group) -> None:
         assert all(
             np.array_equal(
                 np.flatnonzero(group.adjoint_lift(aa)[:, group.index(bb)]),
-                [[group.index(aa * bb * ~aa)]],
+                [group.index(aa * bb * ~aa)],
             )
             for aa, bb in itertools.product(group_members, repeat=2)
         )

--- a/src/qldpc/circuits/encoding.py
+++ b/src/qldpc/circuits/encoding.py
@@ -294,17 +294,27 @@ def _get_logical_tableau_from_code_data(
         sector_l = slice(dimension)
         sector_g = slice(dimension, dimension + gauge_dimension)
         sector_s = slice(dimension + gauge_dimension, len(encoder))
-        x2x, x2z, z2x, z2z, *_ = decoded_tableau.to_numpy()
+        x2x, x2z, z2x, z2z, _, z_signs = decoded_tableau.to_numpy()
 
         # sanity check: stabilizers, logicals, and gauge operators should not pick up destabilizers
-        assert not np.any(z2x[:, sector_s])
-        assert not np.any(x2x[sector_l, sector_s])
-        assert not np.any(x2x[sector_g, sector_s])
+        ops_acquired_destabilizers = (
+            np.any(z2x[:, sector_s])
+            or np.any(x2x[sector_l, sector_s])
+            or np.any(x2x[sector_g, sector_s])
+        )
 
         # sanity check: gauge operators should not pick up logical factors
-        assert not np.any(x2x[sector_g, sector_l])
-        assert not np.any(x2z[sector_g, sector_l])
-        assert not np.any(z2x[sector_g, sector_l])
-        assert not np.any(z2z[sector_g, sector_l])
+        gauges_acquired_logicals = (
+            np.any(x2x[sector_g, sector_l])
+            or np.any(x2z[sector_g, sector_l])
+            or np.any(z2x[sector_g, sector_l])
+            or np.any(z2z[sector_g, sector_l])
+        )
+
+        # sanity check: no stabilizers get flipped
+        stabilizers_flipped = np.any(z_signs)
+
+        if ops_acquired_destabilizers or gauges_acquired_logicals or stabilizers_flipped:
+            raise ValueError("The provided physical circuit does not implement a logical operation")
 
     return logical_tableau

--- a/src/qldpc/circuits/encoding.py
+++ b/src/qldpc/circuits/encoding.py
@@ -312,7 +312,7 @@ def _get_logical_tableau_from_code_data(
         )
 
         # sanity check: no stabilizers get flipped
-        stabilizers_flipped = np.any(z_signs)
+        stabilizers_flipped = np.any(z_signs[sector_s])
 
         if ops_acquired_destabilizers or gauges_acquired_logicals or stabilizers_flipped:
             raise ValueError("The provided physical circuit does not implement a logical operation")

--- a/src/qldpc/circuits/encoding_test.py
+++ b/src/qldpc/circuits/encoding_test.py
@@ -42,8 +42,8 @@ def test_encoding_circuit(pytestconfig: pytest.Config) -> None:
                 size=code.dimension + code.gauge_dimension,
             )
             basis_prep = stim.Circuit()
-            basis_prep.append("H", np.where(bases != Pauli.Z)[0])
-            basis_prep.append("S", np.where(bases == Pauli.Y)[0])
+            basis_prep.append("H", np.flatnonzero(bases != Pauli.Z))
+            basis_prep.append("S", np.flatnonzero(bases == Pauli.Y))
             simulator.do(basis_prep)
 
         encoder = circuits.get_encoding_circuit(code, only_zero=only_zero)

--- a/src/qldpc/circuits/encoding_test.py
+++ b/src/qldpc/circuits/encoding_test.py
@@ -104,6 +104,15 @@ def test_logical_tableau() -> None:
     reconstructed_logical_tableau = circuits.get_logical_tableau(code, physical_circuit)
     assert logical_circuit.to_tableau() == reconstructed_logical_tableau
 
+    # logical Pauli operations (which flip logical operator signs) are valid logical operations
+    logical_x = math.op_to_string(code.get_logical_ops(Pauli.X, symplectic=True)[0])
+    reconstructed_logical_tableau = circuits.get_logical_tableau(code, logical_x.to_tableau())
+    assert stim.Circuit("X 0").to_tableau() == reconstructed_logical_tableau
+
+    # a physical circuit that does not preserve the code space is not a logical operation
+    with pytest.raises(ValueError, match="does not implement a logical operation"):
+        circuits.get_logical_tableau(code, stim.Circuit("X 0"))
+
 
 def test_state_stabilizers(pytestconfig: pytest.Config) -> None:
     """Identify the stabilizers of state prepared by a circuit."""

--- a/src/qldpc/circuits/memory/memory.py
+++ b/src/qldpc/circuits/memory/memory.py
@@ -276,7 +276,7 @@ def _get_basis_memory_experiment_parts(
     readout.append("SHIFT_COORDS", [], (1, 0, 0))
     check_support = code.get_matrix(basis)
     for kk, check_id in enumerate(basis_check_ids):
-        data_support = np.where(check_support[kk])[0]
+        data_support = np.flatnonzero(check_support[kk])
         readout.append(
             "DETECTOR",
             [measurement_record.get_target_rec(data_ids[qq]) for qq in data_support]

--- a/src/qldpc/codes/common.py
+++ b/src/qldpc/codes/common.py
@@ -684,7 +684,7 @@ class ClassicalCode(AbstractCode):
         assert all(0 <= bit < len(self) for bit in bits)
         new_matrix = self.matrix.copy()
         for bit in sorted(bits, reverse=True):
-            nonzero_rows = np.where(new_matrix[:, bit])[0]
+            nonzero_rows = np.flatnonzero(new_matrix[:, bit])
             if nonzero_rows.size:
                 pivot_row, rows_to_reduce = nonzero_rows[0], nonzero_rows[1:]
                 if rows_to_reduce.size:

--- a/src/qldpc/decoders/custom.py
+++ b/src/qldpc/decoders/custom.py
@@ -608,10 +608,10 @@ class GUFDecoder(Decoder):
         """Decode an error syndrome and return an inferred error."""
         max_weight = max_weight if max_weight is not None else self.default_max_weight
         syndrome = syndrome.view(self.code.field)
-        syndrome_bits = np.where(syndrome)[0]
+        syndrome_bits = np.flatnonzero(syndrome)
 
         # construct an "error set", within which we look for solutions to the decoding problem
-        error_set = set(Node(index, is_data=False) for index in syndrome_bits)
+        error_set = set(Node(int(index), is_data=False) for index in syndrome_bits)
         solutions = np.zeros((0, len(self.code)), dtype=int)
         last_error_set_size = 0
         while solutions.size == 0:

--- a/src/qldpc/decoders/dems.py
+++ b/src/qldpc/decoders/dems.py
@@ -471,7 +471,7 @@ def _with_higher_order_corrections(
     """
     assert order > 1
 
-    removed_error_indices = np.where(~errors_to_keep)[0]
+    removed_error_indices = np.flatnonzero(~errors_to_keep)
     removed_det_flip_submatrix = dem_arrays.detector_flip_matrix[
         np.ix_(detectors_to_remove, removed_error_indices.tolist())
     ]


### PR DESCRIPTION
Also use `np.flatnonzero` in some places instead of `np.where(...)[0]`