### PR TITLE
Allow a `LookupDecoder` to ignore post-selected syndrome bits

### DIFF
--- a/src/qldpc/decoders/custom.py
+++ b/src/qldpc/decoders/custom.py
@@ -253,11 +253,9 @@ class LookupDecoder(Decoder):
 
     If provided a post_select collection of syndrome-bit (i.e., detector) indices, this decoder
     post-selects on those bits being trivial: when constructing the lookup table, it only considers
-    errors whose syndrome is zero on all post-selected bits, and it drops those bits from the
-    syndrome keys.  Syndromes passed to decode() should likewise omit the post-selected bits.  Any
-    error (or combination of errors) that would flip a post-selected bit is thus excluded from
-    consideration; the caller is responsible for discarding shots in which a post-selected bit is
-    observed to be nontrivial.
+    combinations of errors whose syndrome is zero on all post-selected bits, and it drops those bits
+    from the syndrome keys.  For consistency with the post-selection options in sinter, syndromes
+    passed to LookupDecoder.decode() should still contain all syndrome bits.
     """
 
     def __init__(

--- a/src/qldpc/decoders/custom.py
+++ b/src/qldpc/decoders/custom.py
@@ -333,11 +333,6 @@ class LookupDecoder(Decoder):
                 [self.default_error_to_return, np.ones(1, dtype=pcm.dtype)]
             )
 
-        def _maybe_add_erasure_bit(error: npt.NDArray[np.int_]) -> npt.NDArray[np.int_]:
-            return (
-                np.hstack([error, np.zeros(1, dtype=pcm.dtype)]) if self.has_erasure_bit else error
-            )
-
         # start working on the decoding map from syndrome -> error
         self.syndrome_to_error: dict[tuple[int, ...], npt.NDArray[np.int_]] = {}
 
@@ -348,10 +343,10 @@ class LookupDecoder(Decoder):
                 pcm, max_weight, symplectic, np.array(post_select, dtype=np.intp)
             ):
                 if penalty_func is None:
-                    self.syndrome_to_error[syndrome] = _maybe_add_erasure_bit(error)
+                    self.syndrome_to_error[syndrome] = self._maybe_add_erasure_bit(error)
                 elif (error_weight := penalty_func(error)) <= error_penalty.get(syndrome, np.inf):
                     error_penalty[syndrome] = error_weight
-                    self.syndrome_to_error[syndrome] = _maybe_add_erasure_bit(error)
+                    self.syndrome_to_error[syndrome] = self._maybe_add_erasure_bit(error)
             return  # we have built the syndrome_to_error map, so we have no more to do!
 
         # If we got here, we are building a lookup table that maps each syndrome to an error that
@@ -393,7 +388,13 @@ class LookupDecoder(Decoder):
                 prediction = np.asarray(most_likely_obs_flip, dtype=pcm.dtype)
             else:
                 prediction = most_likely_errors[syndrome, most_likely_obs_flip]
-            self.syndrome_to_error[syndrome] = _maybe_add_erasure_bit(prediction)
+            self.syndrome_to_error[syndrome] = self._maybe_add_erasure_bit(prediction)
+
+    def _maybe_add_erasure_bit(self, error: npt.NDArray[np.int_]) -> npt.NDArray[np.int_]:
+        """Append a trivial (zero) erasure bit to an error if this decoder tracks erasure bits."""
+        if not self.has_erasure_bit:
+            return error
+        return np.hstack([error, np.zeros(1, dtype=error.dtype)])
 
     def __len__(self) -> int:
         """The number of entries in this lookup table."""
@@ -477,24 +478,52 @@ class WeightedLookupDecoder(LookupDecoder):
         *,
         symplectic: bool = False,
         add_erasure_bit: bool = False,
+        predict_observable_flips: bool = False,
+        post_select: Collection[int] = (),
     ) -> None:
-        pcm = (
-            DetectorErrorModelArrays(pcm_or_dem, simplify=False).detector_flip_matrix
-            if isinstance(pcm_or_dem, stim.DetectorErrorModel)
-            else pcm_or_dem
-        )
+        observable_flip_matrix: IntegerArray | None = None
+        if isinstance(pcm_or_dem, stim.DetectorErrorModel):
+            dem_arrays = DetectorErrorModelArrays(pcm_or_dem, simplify=False)
+            pcm = dem_arrays.detector_flip_matrix
+            if dem_arrays.num_observables > 0:
+                observable_flip_matrix = dem_arrays.observable_flip_matrix
+        else:
+            pcm = pcm_or_dem
 
-        def _maybe_add_erasure_bit(error: npt.NDArray[np.int_]) -> npt.NDArray[np.int_]:
-            return np.hstack([error, np.zeros(1, dtype=pcm.dtype)]) if add_erasure_bit else error
-
-        self.syndrome_to_candidates: dict[tuple[int, ...], list[npt.NDArray[np.int_]]] = (
-            collections.defaultdict(list)
-        )
-        for error, syndrome in LookupDecoder.iter_errors_and_syndromes(pcm, max_weight, symplectic):
-            self.syndrome_to_candidates[syndrome].append(_maybe_add_erasure_bit(error))
+        if predict_observable_flips and observable_flip_matrix is None:  # pragma: no cover
+            raise ValueError(
+                "Predicting observable flips with a WeightedLookupDecoder requires providing a"
+                " stim.DetectorErrorModel with observables"
+            )
 
         self.has_erasure_bit = add_erasure_bit
-        self.default_correction = np.zeros(pcm.shape[1], dtype=pcm.dtype)
+        self.predict_observable_flips = predict_observable_flips
+        if predict_observable_flips:
+            assert observable_flip_matrix is not None  # primarily for type-checking reasons
+            output_length = observable_flip_matrix.shape[0]
+        else:
+            output_length = pcm.shape[1]
+
+        # Record all errors consistent with each syndrome, together with the output to return if
+        # that error is selected: an observable-flip prediction if requested (else the error
+        # itself), with a trivial erasure bit appended.  The output is precomputed here so that
+        # decode() only has to select the minimum-penalty candidate error.
+        self.syndrome_to_candidates: dict[
+            tuple[int, ...], list[tuple[npt.NDArray[np.int_], npt.NDArray[np.int_]]]
+        ] = collections.defaultdict(list)
+        for error, syndrome in LookupDecoder.iter_errors_and_syndromes(
+            pcm, max_weight, symplectic, np.array(post_select, dtype=np.intp)
+        ):
+            if predict_observable_flips:
+                assert observable_flip_matrix is not None  # primarily for type-checking reasons
+                output = (observable_flip_matrix @ error).view(np.ndarray) % 2
+            else:
+                output = error
+            self.syndrome_to_candidates[syndrome].append(
+                (error, self._maybe_add_erasure_bit(output))
+            )
+
+        self.default_correction = np.zeros(output_length, dtype=pcm.dtype)
         if add_erasure_bit:
             self.default_correction = np.hstack(
                 [self.default_correction, np.ones(1, dtype=pcm.dtype)]
@@ -512,10 +541,16 @@ class WeightedLookupDecoder(LookupDecoder):
         ),
     ) -> npt.NDArray[np.int_]:
         """Decode an error syndrome and return an inferred error."""
-        errors = self.syndrome_to_candidates.get(
-            tuple(syndrome.view(np.ndarray)), [self.default_correction]
-        )
-        return (min(errors, key=penalty_func) if penalty_func is not None else errors[-1]).copy()
+        key = tuple(syndrome.view(np.ndarray))
+        if key not in self.syndrome_to_candidates:
+            return self.default_correction.copy()
+
+        candidates = self.syndrome_to_candidates[key]
+        if penalty_func is None:
+            output = candidates[-1][1]
+        else:
+            output = min(candidates, key=lambda candidate: penalty_func(candidate[0]))[1]
+        return output.copy()
 
 
 class ILPDecoder(Decoder):

--- a/src/qldpc/decoders/custom.py
+++ b/src/qldpc/decoders/custom.py
@@ -568,7 +568,7 @@ class WeightedLookupDecoder(LookupDecoder):
     def decode(
         self,
         syndrome: npt.NDArray[np.int_],
-        penalty_func: Callable[[npt.NDArray[np.int_]], float] = lambda vec: int(
+        penalty_func: Callable[[npt.NDArray[np.int_]], float] | None = lambda vec: int(
             np.count_nonzero(vec)
         ),
     ) -> npt.NDArray[np.int_]:

--- a/src/qldpc/decoders/custom.py
+++ b/src/qldpc/decoders/custom.py
@@ -21,7 +21,7 @@ import collections
 import functools
 import itertools
 import warnings
-from collections.abc import Callable, Iterator, Sequence
+from collections.abc import Callable, Collection, Iterator, Sequence
 from typing import Any, Protocol
 
 import cvxpy
@@ -263,6 +263,7 @@ class LookupDecoder(Decoder):
         penalty_func: Callable[[npt.NDArray[np.int_] | Sequence[int]], float] | None = None,
         observable_flip_matrix: IntegerArray | None = None,
         predict_observable_flips: bool = False,
+        post_select: Collection[int] = (),
     ) -> None:
         if isinstance(pcm_or_dem, stim.DetectorErrorModel):
             # Initialize from a stim.DetectorErrorModel:
@@ -336,7 +337,7 @@ class LookupDecoder(Decoder):
             # Loop over all errors in decreasing weight; assign each syndrome its likeliest error.
             error_penalty: dict[tuple[int, ...], float] = {}
             for error, syndrome in LookupDecoder.iter_errors_and_syndromes(
-                pcm, max_weight, symplectic
+                pcm, max_weight, symplectic, np.array(post_select, dtype=np.intp)
             ):
                 if penalty_func is None:
                     self.syndrome_to_error[syndrome] = _maybe_add_erasure_bit(error)
@@ -366,7 +367,9 @@ class LookupDecoder(Decoder):
         net_probs: dict[Bitstring, dict[Bitstring, float]] = collections.defaultdict(dict)
         most_likely_errors: dict[tuple[Bitstring, Bitstring], npt.NDArray[np.int_]] = {}
         most_likely_error_probs: dict[tuple[Bitstring, Bitstring], float] = {}
-        for error, syndrome in LookupDecoder.iter_errors_and_syndromes(pcm, max_weight, symplectic):
+        for error, syndrome in LookupDecoder.iter_errors_and_syndromes(
+            pcm, max_weight, symplectic, np.array(post_select, dtype=np.intp)
+        ):
             obs_flip = _get_obs_flip(error)
             prob = np.exp(-penalty_func(error))
             net_probs[syndrome][obs_flip] = net_probs[syndrome].get(obs_flip, 0.0) + prob
@@ -390,7 +393,7 @@ class LookupDecoder(Decoder):
 
     @staticmethod
     def iter_errors_and_syndromes(
-        matrix: IntegerArray, max_weight: int, symplectic: bool
+        matrix: IntegerArray, max_weight: int, symplectic: bool, post_select: npt.NDArray[np.intp]
     ) -> Iterator[tuple[npt.NDArray[np.int_], tuple[int, ...]]]:
         """Iterate over all errors that this decoder considers, and their associated syndromes.
 
@@ -399,6 +402,10 @@ class LookupDecoder(Decoder):
         dtype = matrix.dtype
         code = codes.ClassicalCode(matrix) if not symplectic else codes.QuditCode(matrix)
         matrix = code.matrix if not symplectic else -math.symplectic_conjugate(code.matrix)
+
+        # identify syndrome bits to keep
+        keep = np.ones(len(matrix), dtype=bool)
+        keep[post_select] = False
 
         # identify the set of local errors that can occur
         repeat = 2 if symplectic else 1
@@ -413,7 +420,11 @@ class LookupDecoder(Decoder):
                     error[:, error_site_indices] = np.asarray(local_errors, dtype=dtype).T
                     error = error.ravel()
                     syndrome = matrix @ error
-                    yield (error.view(np.ndarray).astype(dtype), tuple(syndrome.view(np.ndarray)))
+                    if not np.any(syndrome[post_select]):
+                        yield (
+                            error.view(np.ndarray).astype(dtype),
+                            tuple(syndrome[keep].view(np.ndarray)),
+                        )
 
     def decode(self, syndrome: npt.NDArray[np.int_]) -> npt.NDArray[np.int_]:
         """Decode an error syndrome and return an inferred error.

--- a/src/qldpc/decoders/custom.py
+++ b/src/qldpc/decoders/custom.py
@@ -368,7 +368,7 @@ class LookupDecoder(Decoder):
         npt.NDArray[np.bool_] | None,
         npt.NDArray[np.int_],
     ]:
-        """Process and validate the inputs shared by LookupDecoder and WeightedLookupDecoder.
+        """Process and validate the inputs shared by LookupDecoder.
 
         Returns a parity check matrix, an observable-flip matrix (or None), a penalty function (or
         None), a boolean mask of syndrome bits to keep (or None if not post-selecting), and the

--- a/src/qldpc/decoders/custom.py
+++ b/src/qldpc/decoders/custom.py
@@ -215,47 +215,50 @@ class RelayBPDecoder(BatchDecoder):
 class LookupDecoder(Decoder):
     """Decoder based on a lookup table that maps syndromes to errors.
 
-    In addition to a parity check matrix, this decoder needs to be initialized with a max_weight.
-    The decoder then enumerates all errors with weight <= max_weight, in order of decreasing weight.
-    For each error ee, it computes the corresponding syndrome ss, and assigns syndrome ss the
-    "correction" ee, overriding any previously assigned correction if present.
+    Accepts a parity check matrix (PCM) or detector error model (DEM) for ``pcm_or_dem``.  If
+    provided a DEM, this decoder extracts a PCM, ``error_channel``, and ``observable_flip_matrix``
+    from the DEM, which are used as described below.
 
-    If provided an error_channel of independent probabilities for each "error mechanism" (associated
-    with one column of the parity check matrix), construct a penalty_func that penalizes unlikely
-    errors.
+    In addition to a PCM, this decoder needs to be initialized with some choice of ``max_weight``.
+    The decoder enumerates all errors with weight <= ``max_weight`` in order of decreasing weight.
+    For each ``error``, the decoder computes the corresponding ``syndrome``, and nominally adds an
+    ``syndrome -> error`` entry to the lookup table, overriding any past entry for ``syndrome``.
 
-    If provided a penalty_func that maps an error to a real number (i.e., a penalty), the decoder
-    only assigns correction ee to syndrome ss if (a) ss has no assigned correction, or (b) the
-    penalty of ee is <= the penalty of the correction currently assigned to ss.
+    If provided an ``error_channel`` of independent probabilities for each "primitive" error
+    mechanism (which associated with one column of a PCM, or one entry in a DEM), this method
+    constructs a penalty function, ``penalty_func``, that penalizes unlikely errors.  In this case,
+    a candidate ``syndrome -> new_error`` entry encountered during enumeration will only override a
+    past entry in the lookup table if ``penalty_func(new_error) < penalty_func(old_error)``.
+    Alternatively, this decoder supports the use of a user-provided ``penalty_func``, which must map
+    an error (represented as a binary vector of length ``num_primitive_error_mechanisms``) to a real
+    number (i.e., a penalty).
 
-    If provided an observable_flip_matrix (shape num_observables × num_errors), this decoder picks
-    an error that induces the most likely observable flip for each syndrome, rather than the single
-    most likely error.  Concretely: errors consistent with a given syndrome are grouped by their
-    observable flip value; the total probability of each group is (approximately) the sum of the
-    probabilities of its member errors.  This decoder returns the highest-probability individual
-    error from the group with the highest total probability.  When initialized from a
-    DetectorErrorModel that contains observables, the observable_flip_matrix is extracted
-    automatically.
+    If provided an ``observable_flip_matrix`` (shape ``num_observables × num_primitive_errors``),
+    this decoder maps each syndrome to an error that induces the most likely observable flip for
+    that syndrome, which may be different from the single most likely error.  Concretely: errors
+    consistent with a given syndrome are grouped by their observable flip value; the total
+    probability of each group is (approximately) the sum of the probabilities of its member errors.
+    This decoder then assings each ``syndrome`` the highest-probability individual ``error`` from
+    the group with the highest total probability.
 
-    If initialized with predict_observable_flips=True, this decoder maps each syndrome directly to
-    its most likely observable flip, rather than to an error.  In this case the decoded output is a
-    binary vector of length num_observables.  Predicting observable flips requires an
-    observable_flip_matrix (provided directly or extracted from a DetectorErrorModel).
+    If initialized with ``predict_observable_flips=True``, this decoder maps each syndrome directly
+    to its most likely observable flip, rather than to a representative ``error``.  In this case
+    the decoded output is a binary vector of length ``num_observables``.  Predicting observable
+    flips requires an ``observable_flip_matrix``.
 
-    If provided a post_select collection of syndrome-bit (i.e., detector) indices, this decoder
-    post-selects on those bits being trivial: when constructing the lookup table, it only considers
-    combinations of errors whose syndrome is zero on all post-selected bits, and it drops those bits
-    from the syndrome keys.  For consistency with the post-selection options in sinter, syndromes
-    passed to LookupDecoder.decode() should still contain all syndrome bits.
+    If provided a ``post_select`` collection of syndrome-bit (i.e., detector) indices, this decoder
+    post-selects on those bits being trivial: when constructing the lookup table, it ignores
+    syndromes that are nonzero on the post-selected bits. and it drops those bits from the syndrome
+    keys in the lookup table.  For consistency with the post-selection options in sinter, syndromes
+    passed to ``LookupDecoder.decode`` should still contain all syndrome bits.
 
-    If initialized with add_erasure_bit=True, this decoder appends a bit to all decoded errors.
+    If initialized with ``add_erasure_bit=True``, this decoder appends a bit to all decoded errors.
     If asked to decode a syndrome that was not observed when constructing the lookup table, the
     erasure bit is set to 1.  The erasure bit is set to 0 otherwise.
 
-    If initialized with symplectic=True, this decoder treats the provided parity check matrix as
-    that of a QuditCode, with the first and last half of the columns denoting, respectively, the X
-    and Z support of a stabilizer.  Decoded errors are likewise vectors that indicate their X and Z
-    support by the first and second half of their entries.
+    If initialized with ``symplectic=True``, this decoder treats the provided parity check matrix as
+    that of a ``QuditCode``, with the first and last half of the columns denoting, respectively, the
+    [X|Z] support of a stabilizer.  Decoded errors are likewise vectors that indicate [X|Z] support.
     """
 
     def __init__(
@@ -271,8 +274,8 @@ class LookupDecoder(Decoder):
         add_erasure_bit: bool = False,
         symplectic: bool = False,
     ) -> None:
-        pcm, observable_flip_matrix, penalty_func, keep, default_correction = (
-            self._process_lookup_data(
+        pcm, observable_flip_matrix, penalty_func, syndrome_mask, default_correction = (
+            self._organize_lookup_table_initialization_data(
                 pcm_or_dem,
                 error_channel,
                 penalty_func,
@@ -288,11 +291,11 @@ class LookupDecoder(Decoder):
                 " stim.DetectorErrorModel, error_channel, or penalty_func"
             )
 
-        # set some useful/necessary attributes
+        # save attributes
         self.post_select = tuple(post_select)
-        self.keep = keep
-        self.has_erasure_bit = add_erasure_bit
         self.predict_observable_flips = predict_observable_flips
+        self.syndrome_mask = syndrome_mask
+        self.has_erasure_bit = add_erasure_bit
         self.default_correction = default_correction
 
         # start working on the decoding map from syndrome -> error
@@ -302,7 +305,7 @@ class LookupDecoder(Decoder):
             # Loop over all errors in decreasing weight; assign each syndrome its likeliest error.
             error_penalty: dict[tuple[int, ...], float] = {}
             for error, syndrome in LookupDecoder._iter_errors_and_syndromes(
-                pcm, max_weight, symplectic, keep
+                pcm, max_weight, syndrome_mask, symplectic
             ):
                 if penalty_func is None:
                     self.syndrome_to_error[syndrome] = self._maybe_add_erasure_bit(error)
@@ -333,7 +336,7 @@ class LookupDecoder(Decoder):
         most_likely_errors: dict[tuple[Bitstring, Bitstring], npt.NDArray[np.int_]] = {}
         most_likely_error_probs: dict[tuple[Bitstring, Bitstring], float] = {}
         for error, syndrome in LookupDecoder._iter_errors_and_syndromes(
-            pcm, max_weight, symplectic, keep
+            pcm, max_weight, syndrome_mask, symplectic
         ):
             obs_flip = _get_obs_flip(error)
             prob = np.exp(-penalty_func(error))
@@ -353,7 +356,7 @@ class LookupDecoder(Decoder):
             self.syndrome_to_error[syndrome] = self._maybe_add_erasure_bit(prediction)
 
     @staticmethod
-    def _process_lookup_data(
+    def _organize_lookup_table_initialization_data(
         pcm_or_dem: IntegerArray | stim.DetectorErrorModel,
         error_channel: npt.NDArray[np.floating] | Sequence[float] | None,
         penalty_func: Callable[[npt.NDArray[np.int_] | Sequence[int]], float] | None,
@@ -368,17 +371,7 @@ class LookupDecoder(Decoder):
         npt.NDArray[np.bool_] | None,
         npt.NDArray[np.int_],
     ]:
-        """Process and validate the inputs shared by LookupDecoder.
-
-        Returns a parity check matrix, an observable-flip matrix (or None), a penalty function (or
-        None), a boolean mask of syndrome bits to keep (or None if not post-selecting), and the
-        default output to return for syndromes absent from the lookup table.  If pcm_or_dem is a
-        stim.DetectorErrorModel, its parity check matrix, error probabilities, and (if present)
-        observable-flip matrix are extracted from it, and passing an explicit error_channel,
-        penalty_func, or observable_flip_matrix is forbidden.  Otherwise pcm_or_dem is treated as a
-        parity check matrix.  The returned penalty function is built from the error channel when one
-        is available, unless a penalty_func is provided directly.
-        """
+        """Organize and validate the inputs to a LookupDecoder."""
         if isinstance(pcm_or_dem, stim.DetectorErrorModel):
             if (
                 error_channel is not None
@@ -401,26 +394,24 @@ class LookupDecoder(Decoder):
                     "Cannot specify both an error_channel and a penalty_func in a LookupDecoder"
                 )
 
-        if predict_observable_flips and observable_flip_matrix is None:  # pragma: no cover
-            raise ValueError(
-                "Predicting observable flips with a LookupDecoder requires providing a"
-                " stim.DetectorErrorModel with observables or an observable_flip_matrix"
-            )
-
-        # build a penalty function from the error channel, unless one was provided directly
+        # if an explicit penalty_func was not provided, build one from the error channel
         penalty_func = penalty_func or (
             LookupDecoder._build_penalty_func(error_channel) if error_channel is not None else None
         )
 
         # build the mask of syndrome bits to keep (None if not post-selecting)
-        keep: npt.NDArray[np.bool_] | None = None
+        syndrome_mask: npt.NDArray[np.bool_] | None = None
         if len(post_select):
-            keep = np.ones(pcm.shape[0], dtype=bool)
-            keep[list(post_select)] = False
+            syndrome_mask = np.ones(pcm.shape[0], dtype=bool)
+            syndrome_mask[list(post_select)] = False
 
         # build the default output returned for syndromes absent from the lookup table
         if predict_observable_flips:
-            assert observable_flip_matrix is not None  # guaranteed by the check above
+            if observable_flip_matrix is None:  # pragma: no cover
+                raise ValueError(
+                    "Predicting observable flips with a LookupDecoder requires providing a"
+                    " stim.DetectorErrorModel with observables or an observable_flip_matrix"
+                )
             output_length = observable_flip_matrix.shape[0]
         else:
             output_length = pcm.shape[1]
@@ -428,7 +419,7 @@ class LookupDecoder(Decoder):
         if add_erasure_bit:
             default_correction = np.hstack([default_correction, np.ones(1, dtype=pcm.dtype)])
 
-        return pcm, observable_flip_matrix, penalty_func, keep, default_correction
+        return pcm, observable_flip_matrix, penalty_func, syndrome_mask, default_correction
 
     @staticmethod
     def _build_penalty_func(
@@ -449,20 +440,25 @@ class LookupDecoder(Decoder):
 
     @staticmethod
     def _iter_errors_and_syndromes(
-        matrix: IntegerArray, max_weight: int, symplectic: bool, keep: npt.NDArray[np.bool_] | None
+        matrix: IntegerArray,
+        max_weight: int,
+        syndrome_mask: npt.NDArray[np.bool_] | None,
+        symplectic: bool,
     ) -> Iterator[tuple[npt.NDArray[np.int_], tuple[int, ...]]]:
         """Iterate over all errors that this decoder considers, and their associated syndromes.
 
-        Errors are sorted in decreasing weight (number of bits/qudits addressed nontrivially).
+        Errors are sorted in decreasing weight (number of bits or qudits addressed nontrivially).
 
-        The keep argument is a boolean mask of syndrome bits to retain, or None to keep all bits.
+        The syndrome_mask is a boolean mask of syndrome bits to retain, or None to keep all bits.
         When post-selecting (keep is not None), errors whose syndrome is nontrivial on any dropped
         bit are skipped, and dropped bits are omitted from the yielded syndrome.
         """
         dtype = matrix.dtype
         code = codes.ClassicalCode(matrix) if not symplectic else codes.QuditCode(matrix)
         matrix = code.matrix if not symplectic else -math.symplectic_conjugate(code.matrix)
-        drop = None if keep is None else ~keep  # post-selected bits, required to be trivial
+        syndrome_bits_to_drop = (
+            None if syndrome_mask is None else ~syndrome_mask
+        )  # post-selected bits, required to be trivial
 
         # identify the set of local errors that can occur
         repeat = 2 if symplectic else 1
@@ -477,10 +473,10 @@ class LookupDecoder(Decoder):
                     error[:, error_site_indices] = np.asarray(local_errors, dtype=dtype).T
                     error = error.ravel()
                     syndrome = matrix @ error
-                    if keep is not None:
-                        if np.any(syndrome[drop]):
+                    if syndrome_mask is not None:
+                        if np.any(syndrome[syndrome_bits_to_drop]):
                             continue
-                        syndrome = syndrome[keep]
+                        syndrome = syndrome[syndrome_mask]
                     yield (
                         error.view(np.ndarray).astype(dtype),
                         tuple(syndrome.view(np.ndarray)),
@@ -502,8 +498,8 @@ class LookupDecoder(Decoder):
         If initialized with predict_observable_flips=True, return the inferred observable flip.
         """
         syndrome = syndrome.view(np.ndarray)
-        if self.keep is not None:
-            syndrome = syndrome[self.keep]
+        if self.syndrome_mask is not None:
+            syndrome = syndrome[self.syndrome_mask]
         return self.syndrome_to_error.get(tuple(syndrome), self.default_correction).copy()
 
 
@@ -527,21 +523,23 @@ class WeightedLookupDecoder(LookupDecoder):
         add_erasure_bit: bool = False,
         symplectic: bool = False,
     ) -> None:
-        pcm, observable_flip_matrix, _, keep, default_correction = self._process_lookup_data(
-            pcm_or_dem,
-            None,
-            None,
-            observable_flip_matrix,
-            predict_observable_flips,
-            post_select,
-            add_erasure_bit,
+        pcm, observable_flip_matrix, _, syndrome_mask, default_correction = (
+            self._organize_lookup_table_initialization_data(
+                pcm_or_dem,
+                None,
+                None,
+                observable_flip_matrix,
+                predict_observable_flips,
+                post_select,
+                add_erasure_bit,
+            )
         )
 
-        # remember the post-selected syndrome (detector) bits and the mask of bits to keep
+        # save attributes
         self.post_select = tuple(post_select)
-        self.keep = keep
-        self.has_erasure_bit = add_erasure_bit
         self.predict_observable_flips = predict_observable_flips
+        self.syndrome_mask = syndrome_mask
+        self.has_erasure_bit = add_erasure_bit
         self.default_correction = default_correction
 
         # Record all errors consistent with each syndrome, together with the output to return if
@@ -552,7 +550,7 @@ class WeightedLookupDecoder(LookupDecoder):
             tuple[int, ...], list[tuple[npt.NDArray[np.int_], npt.NDArray[np.int_]]]
         ] = collections.defaultdict(list)
         for error, syndrome in LookupDecoder._iter_errors_and_syndromes(
-            pcm, max_weight, symplectic, keep
+            pcm, max_weight, syndrome_mask, symplectic
         ):
             if predict_observable_flips:
                 assert observable_flip_matrix is not None  # primarily for type-checking reasons
@@ -576,8 +574,8 @@ class WeightedLookupDecoder(LookupDecoder):
     ) -> npt.NDArray[np.int_]:
         """Decode an error syndrome and return an inferred error."""
         syndrome = syndrome.view(np.ndarray)
-        if self.keep is not None:
-            syndrome = syndrome[self.keep]
+        if self.syndrome_mask is not None:
+            syndrome = syndrome[self.syndrome_mask]
         key = tuple(syndrome)
         if key not in self.syndrome_to_candidates:
             return self.default_correction.copy()

--- a/src/qldpc/decoders/custom.py
+++ b/src/qldpc/decoders/custom.py
@@ -250,6 +250,14 @@ class LookupDecoder(Decoder):
     its most likely observable flip, rather than to an error.  In this case the decoded output is a
     binary vector of length num_observables.  Predicting observable flips requires an
     observable_flip_matrix (provided directly or extracted from a DetectorErrorModel).
+
+    If provided a post_select collection of syndrome-bit (i.e., detector) indices, this decoder
+    post-selects on those bits being trivial: when constructing the lookup table, it only considers
+    errors whose syndrome is zero on all post-selected bits, and it drops those bits from the
+    syndrome keys.  Syndromes passed to decode() should likewise omit the post-selected bits.  Any
+    error (or combination of errors) that would flip a post-selected bit is thus excluded from
+    consideration; the caller is responsible for discarding shots in which a post-selected bit is
+    observed to be nontrivial.
     """
 
     def __init__(

--- a/src/qldpc/decoders/custom.py
+++ b/src/qldpc/decoders/custom.py
@@ -271,71 +271,29 @@ class LookupDecoder(Decoder):
         predict_observable_flips: bool = False,
         post_select: Collection[int] = (),
     ) -> None:
-        if isinstance(pcm_or_dem, stim.DetectorErrorModel):
-            # Initialize from a stim.DetectorErrorModel:
-            # 1. Forbid conflicting arguments.
-            # 2. Extract parity check matrix, error probabilities, and observables (if applicable).
-            if (
-                error_channel is not None
-                or penalty_func is not None
-                or observable_flip_matrix is not None
-            ):  # pragma: no cover
-                raise ValueError(
-                    "Cannot specify an error_channel, penalty_func, or observable_flip_matrix when"
-                    " providing a stim.DetectorErrorModel to a LookupDecoder"
-                )
-            dem_arrays = DetectorErrorModelArrays(pcm_or_dem, simplify=False)
-            pcm = dem_arrays.detector_flip_matrix
-            error_channel = dem_arrays.error_probs
-            if dem_arrays.num_observables > 0:
-                observable_flip_matrix = dem_arrays.observable_flip_matrix
-
-        else:
-            # initialize from a parity check matrix and forbid conflicting arguments
-            pcm = pcm_or_dem
-            if error_channel is not None and penalty_func is not None:  # pragma: no cover
-                raise ValueError(
-                    "Cannot specify both an error_channel and a penalty_func in a LookupDecoder"
-                )
-            if (
-                observable_flip_matrix is not None
-                and penalty_func is None
-                and error_channel is None
-            ):  # pragma: no cover
-                raise ValueError(
-                    "Predicting observable flips with a LookupDecoder requires providing a"
-                    " stim.DetectorErrorModel, error_channel, or penalty_func"
-                )
-
-        # Construct the "penalty function" for each error.  If we have error probabilities, the
-        # penalty function is penalty_func(error) = -log(probability_of_error)
-        penalty_func = penalty_func or (
-            self.build_penalty_func(error_channel) if error_channel is not None else None
+        pcm, observable_flip_matrix, penalty_func, keep, default_correction = (
+            self._process_lookup_data(
+                pcm_or_dem,
+                error_channel,
+                penalty_func,
+                observable_flip_matrix,
+                add_erasure_bit,
+                predict_observable_flips,
+                post_select,
+            )
         )
-
-        # remember the post-selected syndrome (detector) bits and the mask of bits to keep
-        self.post_select = tuple(post_select)
-        keep = np.ones(pcm.shape[0], dtype=bool)
-        keep[list(self.post_select)] = False
-        self.keep: npt.NDArray[np.bool_] | None = keep if self.post_select else None
+        if observable_flip_matrix is not None and penalty_func is None:  # pragma: no cover
+            raise ValueError(
+                "Predicting observable flips with a LookupDecoder requires providing a"
+                " stim.DetectorErrorModel, error_channel, or penalty_func"
+            )
 
         # set some useful/necessary attributes
+        self.post_select = tuple(post_select)
+        self.keep = keep
         self.has_erasure_bit = add_erasure_bit
         self.predict_observable_flips = predict_observable_flips
-        if predict_observable_flips:
-            if observable_flip_matrix is None:  # pragma: no cover
-                raise ValueError(
-                    "Predicting observable flips with a LookupDecoder requires providing a"
-                    " stim.DetectorErrorModel with observables or an observable_flip_matrix"
-                )
-            output_length = observable_flip_matrix.shape[0]
-        else:
-            output_length = pcm.shape[1]
-        self.default_error_to_return = np.zeros(output_length, dtype=pcm.dtype)
-        if self.has_erasure_bit:
-            self.default_error_to_return = np.hstack(
-                [self.default_error_to_return, np.ones(1, dtype=pcm.dtype)]
-            )
+        self.default_correction = default_correction
 
         # start working on the decoding map from syndrome -> error
         self.syndrome_to_error: dict[tuple[int, ...], npt.NDArray[np.int_]] = {}
@@ -406,20 +364,20 @@ class LookupDecoder(Decoder):
 
     @staticmethod
     def iter_errors_and_syndromes(
-        matrix: IntegerArray, max_weight: int, symplectic: bool, keep: npt.NDArray[np.bool_]
+        matrix: IntegerArray, max_weight: int, symplectic: bool, keep: npt.NDArray[np.bool_] | None
     ) -> Iterator[tuple[npt.NDArray[np.int_], tuple[int, ...]]]:
         """Iterate over all errors that this decoder considers, and their associated syndromes.
 
         Errors are sorted in decreasing weight (number of bits/qudits addressed nontrivially).
 
-        The keep argument is a boolean mask of syndrome bits to retain: errors whose syndrome is
-        nontrivial on any dropped (post-selected) bit are skipped, and dropped bits are omitted from
-        the yielded syndrome.
+        The keep argument is a boolean mask of syndrome bits to retain, or None to keep all bits.
+        When post-selecting (keep is not None), errors whose syndrome is nontrivial on any dropped
+        bit are skipped, and dropped bits are omitted from the yielded syndrome.
         """
         dtype = matrix.dtype
         code = codes.ClassicalCode(matrix) if not symplectic else codes.QuditCode(matrix)
         matrix = code.matrix if not symplectic else -math.symplectic_conjugate(code.matrix)
-        drop = ~keep  # post-selected syndrome bits, which are required to be trivial
+        drop = None if keep is None else ~keep  # post-selected bits, required to be trivial
 
         # identify the set of local errors that can occur
         repeat = 2 if symplectic else 1
@@ -434,11 +392,14 @@ class LookupDecoder(Decoder):
                     error[:, error_site_indices] = np.asarray(local_errors, dtype=dtype).T
                     error = error.ravel()
                     syndrome = matrix @ error
-                    if not np.any(syndrome[drop]):
-                        yield (
-                            error.view(np.ndarray).astype(dtype),
-                            tuple(syndrome[keep].view(np.ndarray)),
-                        )
+                    if keep is not None:
+                        if np.any(syndrome[drop]):
+                            continue
+                        syndrome = syndrome[keep]
+                    yield (
+                        error.view(np.ndarray).astype(dtype),
+                        tuple(syndrome.view(np.ndarray)),
+                    )
 
     def decode(self, syndrome: npt.NDArray[np.int_]) -> npt.NDArray[np.int_]:
         """Decode an error syndrome and return an inferred error.
@@ -448,7 +409,7 @@ class LookupDecoder(Decoder):
         syndrome = syndrome.view(np.ndarray)
         if self.keep is not None:
             syndrome = syndrome[self.keep]
-        return self.syndrome_to_error.get(tuple(syndrome), self.default_error_to_return).copy()
+        return self.syndrome_to_error.get(tuple(syndrome), self.default_correction).copy()
 
     @staticmethod
     def build_penalty_func(
@@ -467,6 +428,84 @@ class LookupDecoder(Decoder):
 
         return penalty_func
 
+    @staticmethod
+    def _process_lookup_data(
+        pcm_or_dem: IntegerArray | stim.DetectorErrorModel,
+        error_channel: npt.NDArray[np.floating] | Sequence[float] | None,
+        penalty_func: Callable[[npt.NDArray[np.int_] | Sequence[int]], float] | None,
+        observable_flip_matrix: IntegerArray | None,
+        add_erasure_bit: bool,
+        predict_observable_flips: bool,
+        post_select: Collection[int],
+    ) -> tuple[
+        IntegerArray,
+        IntegerArray | None,
+        Callable[[npt.NDArray[np.int_] | Sequence[int]], float] | None,
+        npt.NDArray[np.bool_] | None,
+        npt.NDArray[np.int_],
+    ]:
+        """Process and validate the inputs shared by LookupDecoder and WeightedLookupDecoder.
+
+        Returns a parity check matrix, an observable-flip matrix (or None), a penalty function (or
+        None), a boolean mask of syndrome bits to keep (or None if not post-selecting), and the
+        default output to return for syndromes absent from the lookup table.  If pcm_or_dem is a
+        stim.DetectorErrorModel, its parity check matrix, error probabilities, and (if present)
+        observable-flip matrix are extracted from it, and passing an explicit error_channel,
+        penalty_func, or observable_flip_matrix is forbidden.  Otherwise pcm_or_dem is treated as a
+        parity check matrix.  The returned penalty function is built from the error channel when one
+        is available, unless a penalty_func is provided directly.
+        """
+        if isinstance(pcm_or_dem, stim.DetectorErrorModel):
+            if (
+                error_channel is not None
+                or penalty_func is not None
+                or observable_flip_matrix is not None
+            ):  # pragma: no cover
+                raise ValueError(
+                    "Cannot specify an error_channel, penalty_func, or observable_flip_matrix when"
+                    " providing a stim.DetectorErrorModel to a LookupDecoder"
+                )
+            dem_arrays = DetectorErrorModelArrays(pcm_or_dem, simplify=False)
+            pcm = dem_arrays.detector_flip_matrix
+            error_channel = dem_arrays.error_probs
+            if dem_arrays.num_observables > 0:
+                observable_flip_matrix = dem_arrays.observable_flip_matrix
+        else:
+            pcm = pcm_or_dem
+            if error_channel is not None and penalty_func is not None:  # pragma: no cover
+                raise ValueError(
+                    "Cannot specify both an error_channel and a penalty_func in a LookupDecoder"
+                )
+
+        if predict_observable_flips and observable_flip_matrix is None:  # pragma: no cover
+            raise ValueError(
+                "Predicting observable flips with a LookupDecoder requires providing a"
+                " stim.DetectorErrorModel with observables or an observable_flip_matrix"
+            )
+
+        # build a penalty function from the error channel, unless one was provided directly
+        penalty_func = penalty_func or (
+            LookupDecoder.build_penalty_func(error_channel) if error_channel is not None else None
+        )
+
+        # build the mask of syndrome bits to keep (None if not post-selecting)
+        keep: npt.NDArray[np.bool_] | None = None
+        if len(post_select):
+            keep = np.ones(pcm.shape[0], dtype=bool)
+            keep[list(post_select)] = False
+
+        # build the default output returned for syndromes absent from the lookup table
+        if predict_observable_flips:
+            assert observable_flip_matrix is not None  # guaranteed by the check above
+            output_length = observable_flip_matrix.shape[0]
+        else:
+            output_length = pcm.shape[1]
+        default_correction = np.zeros(output_length, dtype=pcm.dtype)
+        if add_erasure_bit:
+            default_correction = np.hstack([default_correction, np.ones(1, dtype=pcm.dtype)])
+
+        return pcm, observable_flip_matrix, penalty_func, keep, default_correction
+
 
 class WeightedLookupDecoder(LookupDecoder):
     """Decoder based on a lookup table that maps syndromes to errors.
@@ -484,37 +523,26 @@ class WeightedLookupDecoder(LookupDecoder):
         *,
         symplectic: bool = False,
         add_erasure_bit: bool = False,
+        observable_flip_matrix: IntegerArray | None = None,
         predict_observable_flips: bool = False,
         post_select: Collection[int] = (),
     ) -> None:
-        observable_flip_matrix: IntegerArray | None = None
-        if isinstance(pcm_or_dem, stim.DetectorErrorModel):
-            dem_arrays = DetectorErrorModelArrays(pcm_or_dem, simplify=False)
-            pcm = dem_arrays.detector_flip_matrix
-            if dem_arrays.num_observables > 0:
-                observable_flip_matrix = dem_arrays.observable_flip_matrix
-        else:
-            pcm = pcm_or_dem
-
-        if predict_observable_flips and observable_flip_matrix is None:  # pragma: no cover
-            raise ValueError(
-                "Predicting observable flips with a WeightedLookupDecoder requires providing a"
-                " stim.DetectorErrorModel with observables"
-            )
+        pcm, observable_flip_matrix, _, keep, default_correction = self._process_lookup_data(
+            pcm_or_dem,
+            None,
+            None,
+            observable_flip_matrix,
+            add_erasure_bit,
+            predict_observable_flips,
+            post_select,
+        )
 
         # remember the post-selected syndrome (detector) bits and the mask of bits to keep
         self.post_select = tuple(post_select)
-        keep = np.ones(pcm.shape[0], dtype=bool)
-        keep[list(self.post_select)] = False
-        self.keep: npt.NDArray[np.bool_] | None = keep if self.post_select else None
-
+        self.keep = keep
         self.has_erasure_bit = add_erasure_bit
         self.predict_observable_flips = predict_observable_flips
-        if predict_observable_flips:
-            assert observable_flip_matrix is not None  # primarily for type-checking reasons
-            output_length = observable_flip_matrix.shape[0]
-        else:
-            output_length = pcm.shape[1]
+        self.default_correction = default_correction
 
         # Record all errors consistent with each syndrome, together with the output to return if
         # that error is selected: an observable-flip prediction if requested (else the error
@@ -533,12 +561,6 @@ class WeightedLookupDecoder(LookupDecoder):
                 output = error
             self.syndrome_to_candidates[syndrome].append(
                 (error, self._maybe_add_erasure_bit(output))
-            )
-
-        self.default_correction = np.zeros(output_length, dtype=pcm.dtype)
-        if add_erasure_bit:
-            self.default_correction = np.hstack(
-                [self.default_correction, np.ones(1, dtype=pcm.dtype)]
             )
 
     def __len__(self) -> int:

--- a/src/qldpc/decoders/custom.py
+++ b/src/qldpc/decoders/custom.py
@@ -216,9 +216,9 @@ class LookupDecoder(Decoder):
     """Decoder based on a lookup table that maps syndromes to errors.
 
     In addition to a parity check matrix, this decoder needs to be initialized with a max_weight.
-    The decoder consider enumerates all errors with weight <= max_weight, in order of decreasing
-    weight.  For each error ee, it computes the corresponding syndrome ss, and assigns syndrome ss
-    the "correction" ee, overriding any previously assigned correction if present.
+    The decoder then enumerates all errors with weight <= max_weight, in order of decreasing weight.
+    For each error ee, it computes the corresponding syndrome ss, and assigns syndrome ss the
+    "correction" ee, overriding any previously assigned correction if present.
 
     If initialized with symplectic=True, this decoder treats the provided parity check matrix as
     that of a QuditCode, with the first and last half of the columns denoting, respectively, the X

--- a/src/qldpc/decoders/custom.py
+++ b/src/qldpc/decoders/custom.py
@@ -315,6 +315,12 @@ class LookupDecoder(Decoder):
             self.build_penalty_func(error_channel) if error_channel is not None else None
         )
 
+        # remember the post-selected syndrome (detector) bits and the mask of bits to keep
+        self.post_select = tuple(post_select)
+        keep = np.ones(pcm.shape[0], dtype=bool)
+        keep[list(self.post_select)] = False
+        self.keep: npt.NDArray[np.bool_] | None = keep if self.post_select else None
+
         # set some useful/necessary attributes
         self.has_erasure_bit = add_erasure_bit
         self.predict_observable_flips = predict_observable_flips
@@ -340,7 +346,7 @@ class LookupDecoder(Decoder):
             # Loop over all errors in decreasing weight; assign each syndrome its likeliest error.
             error_penalty: dict[tuple[int, ...], float] = {}
             for error, syndrome in LookupDecoder.iter_errors_and_syndromes(
-                pcm, max_weight, symplectic, np.array(post_select, dtype=np.intp)
+                pcm, max_weight, symplectic, keep
             ):
                 if penalty_func is None:
                     self.syndrome_to_error[syndrome] = self._maybe_add_erasure_bit(error)
@@ -371,7 +377,7 @@ class LookupDecoder(Decoder):
         most_likely_errors: dict[tuple[Bitstring, Bitstring], npt.NDArray[np.int_]] = {}
         most_likely_error_probs: dict[tuple[Bitstring, Bitstring], float] = {}
         for error, syndrome in LookupDecoder.iter_errors_and_syndromes(
-            pcm, max_weight, symplectic, np.array(post_select, dtype=np.intp)
+            pcm, max_weight, symplectic, keep
         ):
             obs_flip = _get_obs_flip(error)
             prob = np.exp(-penalty_func(error))
@@ -402,19 +408,20 @@ class LookupDecoder(Decoder):
 
     @staticmethod
     def iter_errors_and_syndromes(
-        matrix: IntegerArray, max_weight: int, symplectic: bool, post_select: npt.NDArray[np.intp]
+        matrix: IntegerArray, max_weight: int, symplectic: bool, keep: npt.NDArray[np.bool_]
     ) -> Iterator[tuple[npt.NDArray[np.int_], tuple[int, ...]]]:
         """Iterate over all errors that this decoder considers, and their associated syndromes.
 
         Errors are sorted in decreasing weight (number of bits/qudits addressed nontrivially).
+
+        The keep argument is a boolean mask of syndrome bits to retain: errors whose syndrome is
+        nontrivial on any dropped (post-selected) bit are skipped, and dropped bits are omitted from
+        the yielded syndrome.
         """
         dtype = matrix.dtype
         code = codes.ClassicalCode(matrix) if not symplectic else codes.QuditCode(matrix)
         matrix = code.matrix if not symplectic else -math.symplectic_conjugate(code.matrix)
-
-        # identify syndrome bits to keep
-        keep = np.ones(len(matrix), dtype=bool)
-        keep[post_select] = False
+        drop = ~keep  # post-selected syndrome bits, which are required to be trivial
 
         # identify the set of local errors that can occur
         repeat = 2 if symplectic else 1
@@ -429,7 +436,7 @@ class LookupDecoder(Decoder):
                     error[:, error_site_indices] = np.asarray(local_errors, dtype=dtype).T
                     error = error.ravel()
                     syndrome = matrix @ error
-                    if not np.any(syndrome[post_select]):
+                    if not np.any(syndrome[drop]):
                         yield (
                             error.view(np.ndarray).astype(dtype),
                             tuple(syndrome[keep].view(np.ndarray)),
@@ -440,9 +447,10 @@ class LookupDecoder(Decoder):
 
         If initialized with predict_observable_flips=True, return the inferred observable flip.
         """
-        return self.syndrome_to_error.get(
-            tuple(syndrome.view(np.ndarray)), self.default_error_to_return
-        ).copy()
+        syndrome = syndrome.view(np.ndarray)
+        if self.keep is not None:
+            syndrome = syndrome[self.keep]
+        return self.syndrome_to_error.get(tuple(syndrome), self.default_error_to_return).copy()
 
     @staticmethod
     def build_penalty_func(
@@ -496,6 +504,12 @@ class WeightedLookupDecoder(LookupDecoder):
                 " stim.DetectorErrorModel with observables"
             )
 
+        # remember the post-selected syndrome (detector) bits and the mask of bits to keep
+        self.post_select = tuple(post_select)
+        keep = np.ones(pcm.shape[0], dtype=bool)
+        keep[list(self.post_select)] = False
+        self.keep: npt.NDArray[np.bool_] | None = keep if self.post_select else None
+
         self.has_erasure_bit = add_erasure_bit
         self.predict_observable_flips = predict_observable_flips
         if predict_observable_flips:
@@ -512,7 +526,7 @@ class WeightedLookupDecoder(LookupDecoder):
             tuple[int, ...], list[tuple[npt.NDArray[np.int_], npt.NDArray[np.int_]]]
         ] = collections.defaultdict(list)
         for error, syndrome in LookupDecoder.iter_errors_and_syndromes(
-            pcm, max_weight, symplectic, np.array(post_select, dtype=np.intp)
+            pcm, max_weight, symplectic, keep
         ):
             if predict_observable_flips:
                 assert observable_flip_matrix is not None  # primarily for type-checking reasons
@@ -541,7 +555,10 @@ class WeightedLookupDecoder(LookupDecoder):
         ),
     ) -> npt.NDArray[np.int_]:
         """Decode an error syndrome and return an inferred error."""
-        key = tuple(syndrome.view(np.ndarray))
+        syndrome = syndrome.view(np.ndarray)
+        if self.keep is not None:
+            syndrome = syndrome[self.keep]
+        key = tuple(syndrome)
         if key not in self.syndrome_to_candidates:
             return self.default_correction.copy()
 

--- a/src/qldpc/decoders/custom.py
+++ b/src/qldpc/decoders/custom.py
@@ -220,15 +220,6 @@ class LookupDecoder(Decoder):
     For each error ee, it computes the corresponding syndrome ss, and assigns syndrome ss the
     "correction" ee, overriding any previously assigned correction if present.
 
-    If initialized with symplectic=True, this decoder treats the provided parity check matrix as
-    that of a QuditCode, with the first and last half of the columns denoting, respectively, the X
-    and Z support of a stabilizer.  Decoded errors are likewise vectors that indicate their X and Z
-    support by the first and second half of their entries.
-
-    If initialized with add_erasure_bit=True, this decoder appends a bit to all decoded errors.
-    If asked to decode a syndrome that was not observed when constructing the lookup table, the
-    erasure bit is set to 1.  The erasure bit is set to 0 otherwise.
-
     If provided an error_channel of independent probabilities for each "error mechanism" (associated
     with one column of the parity check matrix), construct a penalty_func that penalizes unlikely
     errors.
@@ -256,6 +247,15 @@ class LookupDecoder(Decoder):
     combinations of errors whose syndrome is zero on all post-selected bits, and it drops those bits
     from the syndrome keys.  For consistency with the post-selection options in sinter, syndromes
     passed to LookupDecoder.decode() should still contain all syndrome bits.
+
+    If initialized with add_erasure_bit=True, this decoder appends a bit to all decoded errors.
+    If asked to decode a syndrome that was not observed when constructing the lookup table, the
+    erasure bit is set to 1.  The erasure bit is set to 0 otherwise.
+
+    If initialized with symplectic=True, this decoder treats the provided parity check matrix as
+    that of a QuditCode, with the first and last half of the columns denoting, respectively, the X
+    and Z support of a stabilizer.  Decoded errors are likewise vectors that indicate their X and Z
+    support by the first and second half of their entries.
     """
 
     def __init__(
@@ -263,13 +263,13 @@ class LookupDecoder(Decoder):
         pcm_or_dem: IntegerArray | stim.DetectorErrorModel,
         max_weight: int,
         *,
-        symplectic: bool = False,
-        add_erasure_bit: bool = False,
         error_channel: npt.NDArray[np.floating] | Sequence[float] | None = None,
         penalty_func: Callable[[npt.NDArray[np.int_] | Sequence[int]], float] | None = None,
         observable_flip_matrix: IntegerArray | None = None,
         predict_observable_flips: bool = False,
         post_select: Collection[int] = (),
+        add_erasure_bit: bool = False,
+        symplectic: bool = False,
     ) -> None:
         pcm, observable_flip_matrix, penalty_func, keep, default_correction = (
             self._process_lookup_data(
@@ -277,9 +277,9 @@ class LookupDecoder(Decoder):
                 error_channel,
                 penalty_func,
                 observable_flip_matrix,
-                add_erasure_bit,
                 predict_observable_flips,
                 post_select,
+                add_erasure_bit,
             )
         )
         if observable_flip_matrix is not None and penalty_func is None:  # pragma: no cover
@@ -301,7 +301,7 @@ class LookupDecoder(Decoder):
         if observable_flip_matrix is None:
             # Loop over all errors in decreasing weight; assign each syndrome its likeliest error.
             error_penalty: dict[tuple[int, ...], float] = {}
-            for error, syndrome in LookupDecoder.iter_errors_and_syndromes(
+            for error, syndrome in LookupDecoder._iter_errors_and_syndromes(
                 pcm, max_weight, symplectic, keep
             ):
                 if penalty_func is None:
@@ -332,7 +332,7 @@ class LookupDecoder(Decoder):
         net_probs: dict[Bitstring, dict[Bitstring, float]] = collections.defaultdict(dict)
         most_likely_errors: dict[tuple[Bitstring, Bitstring], npt.NDArray[np.int_]] = {}
         most_likely_error_probs: dict[tuple[Bitstring, Bitstring], float] = {}
-        for error, syndrome in LookupDecoder.iter_errors_and_syndromes(
+        for error, syndrome in LookupDecoder._iter_errors_and_syndromes(
             pcm, max_weight, symplectic, keep
         ):
             obs_flip = _get_obs_flip(error)
@@ -352,91 +352,15 @@ class LookupDecoder(Decoder):
                 prediction = most_likely_errors[syndrome, most_likely_obs_flip]
             self.syndrome_to_error[syndrome] = self._maybe_add_erasure_bit(prediction)
 
-    def _maybe_add_erasure_bit(self, error: npt.NDArray[np.int_]) -> npt.NDArray[np.int_]:
-        """Append a trivial (zero) erasure bit to an error if this decoder tracks erasure bits."""
-        if not self.has_erasure_bit:
-            return error
-        return np.hstack([error, np.zeros(1, dtype=error.dtype)])
-
-    def __len__(self) -> int:
-        """The number of entries in this lookup table."""
-        return len(self.syndrome_to_error)
-
-    @staticmethod
-    def iter_errors_and_syndromes(
-        matrix: IntegerArray, max_weight: int, symplectic: bool, keep: npt.NDArray[np.bool_] | None
-    ) -> Iterator[tuple[npt.NDArray[np.int_], tuple[int, ...]]]:
-        """Iterate over all errors that this decoder considers, and their associated syndromes.
-
-        Errors are sorted in decreasing weight (number of bits/qudits addressed nontrivially).
-
-        The keep argument is a boolean mask of syndrome bits to retain, or None to keep all bits.
-        When post-selecting (keep is not None), errors whose syndrome is nontrivial on any dropped
-        bit are skipped, and dropped bits are omitted from the yielded syndrome.
-        """
-        dtype = matrix.dtype
-        code = codes.ClassicalCode(matrix) if not symplectic else codes.QuditCode(matrix)
-        matrix = code.matrix if not symplectic else -math.symplectic_conjugate(code.matrix)
-        drop = None if keep is None else ~keep  # post-selected bits, required to be trivial
-
-        # identify the set of local errors that can occur
-        repeat = 2 if symplectic else 1
-        error_ops = tuple(itertools.product(range(code.field.order), repeat=repeat))[1:]
-
-        block_length = matrix.shape[1] // repeat
-        for weight in range(max_weight, -1, -1):
-            for error_sites in itertools.combinations(range(block_length), weight):
-                error_site_indices = list(error_sites)
-                for local_errors in itertools.product(error_ops, repeat=weight):
-                    error = code.field.Zeros((repeat, block_length))
-                    error[:, error_site_indices] = np.asarray(local_errors, dtype=dtype).T
-                    error = error.ravel()
-                    syndrome = matrix @ error
-                    if keep is not None:
-                        if np.any(syndrome[drop]):
-                            continue
-                        syndrome = syndrome[keep]
-                    yield (
-                        error.view(np.ndarray).astype(dtype),
-                        tuple(syndrome.view(np.ndarray)),
-                    )
-
-    def decode(self, syndrome: npt.NDArray[np.int_]) -> npt.NDArray[np.int_]:
-        """Decode an error syndrome and return an inferred error.
-
-        If initialized with predict_observable_flips=True, return the inferred observable flip.
-        """
-        syndrome = syndrome.view(np.ndarray)
-        if self.keep is not None:
-            syndrome = syndrome[self.keep]
-        return self.syndrome_to_error.get(tuple(syndrome), self.default_correction).copy()
-
-    @staticmethod
-    def build_penalty_func(
-        error_channel: npt.NDArray[np.floating] | Sequence[float],
-    ) -> Callable[[npt.NDArray[np.int_] | Sequence[int]], float]:
-        """Construct a penalty function from independent probabilities of individual errors."""
-        error_channel = np.asarray(error_channel)
-        log_probs = np.log(error_channel)
-        log_non_probs = np.log(1 - error_channel)
-
-        def penalty_func(error: npt.NDArray[np.int_] | Sequence[int]) -> float:
-            """Penalize unlikely combinations of errors."""
-            events = np.asarray(error).astype(bool)
-            log_probability_of_error = np.sum(log_probs[events]) + np.sum(log_non_probs[~events])
-            return -float(log_probability_of_error)
-
-        return penalty_func
-
     @staticmethod
     def _process_lookup_data(
         pcm_or_dem: IntegerArray | stim.DetectorErrorModel,
         error_channel: npt.NDArray[np.floating] | Sequence[float] | None,
         penalty_func: Callable[[npt.NDArray[np.int_] | Sequence[int]], float] | None,
         observable_flip_matrix: IntegerArray | None,
-        add_erasure_bit: bool,
         predict_observable_flips: bool,
         post_select: Collection[int],
+        add_erasure_bit: bool,
     ) -> tuple[
         IntegerArray,
         IntegerArray | None,
@@ -485,7 +409,7 @@ class LookupDecoder(Decoder):
 
         # build a penalty function from the error channel, unless one was provided directly
         penalty_func = penalty_func or (
-            LookupDecoder.build_penalty_func(error_channel) if error_channel is not None else None
+            LookupDecoder._build_penalty_func(error_channel) if error_channel is not None else None
         )
 
         # build the mask of syndrome bits to keep (None if not post-selecting)
@@ -506,6 +430,82 @@ class LookupDecoder(Decoder):
 
         return pcm, observable_flip_matrix, penalty_func, keep, default_correction
 
+    @staticmethod
+    def _build_penalty_func(
+        error_channel: npt.NDArray[np.floating] | Sequence[float],
+    ) -> Callable[[npt.NDArray[np.int_] | Sequence[int]], float]:
+        """Construct a penalty function from independent probabilities of individual errors."""
+        error_channel = np.asarray(error_channel)
+        log_probs = np.log(error_channel)
+        log_non_probs = np.log(1 - error_channel)
+
+        def penalty_func(error: npt.NDArray[np.int_] | Sequence[int]) -> float:
+            """Penalize unlikely combinations of errors."""
+            events = np.asarray(error).astype(bool)
+            log_probability_of_error = np.sum(log_probs[events]) + np.sum(log_non_probs[~events])
+            return -float(log_probability_of_error)
+
+        return penalty_func
+
+    @staticmethod
+    def _iter_errors_and_syndromes(
+        matrix: IntegerArray, max_weight: int, symplectic: bool, keep: npt.NDArray[np.bool_] | None
+    ) -> Iterator[tuple[npt.NDArray[np.int_], tuple[int, ...]]]:
+        """Iterate over all errors that this decoder considers, and their associated syndromes.
+
+        Errors are sorted in decreasing weight (number of bits/qudits addressed nontrivially).
+
+        The keep argument is a boolean mask of syndrome bits to retain, or None to keep all bits.
+        When post-selecting (keep is not None), errors whose syndrome is nontrivial on any dropped
+        bit are skipped, and dropped bits are omitted from the yielded syndrome.
+        """
+        dtype = matrix.dtype
+        code = codes.ClassicalCode(matrix) if not symplectic else codes.QuditCode(matrix)
+        matrix = code.matrix if not symplectic else -math.symplectic_conjugate(code.matrix)
+        drop = None if keep is None else ~keep  # post-selected bits, required to be trivial
+
+        # identify the set of local errors that can occur
+        repeat = 2 if symplectic else 1
+        error_ops = tuple(itertools.product(range(code.field.order), repeat=repeat))[1:]
+
+        block_length = matrix.shape[1] // repeat
+        for weight in range(max_weight, -1, -1):
+            for error_sites in itertools.combinations(range(block_length), weight):
+                error_site_indices = list(error_sites)
+                for local_errors in itertools.product(error_ops, repeat=weight):
+                    error = code.field.Zeros((repeat, block_length))
+                    error[:, error_site_indices] = np.asarray(local_errors, dtype=dtype).T
+                    error = error.ravel()
+                    syndrome = matrix @ error
+                    if keep is not None:
+                        if np.any(syndrome[drop]):
+                            continue
+                        syndrome = syndrome[keep]
+                    yield (
+                        error.view(np.ndarray).astype(dtype),
+                        tuple(syndrome.view(np.ndarray)),
+                    )
+
+    def _maybe_add_erasure_bit(self, error: npt.NDArray[np.int_]) -> npt.NDArray[np.int_]:
+        """Append a trivial (zero) erasure bit to an error if this decoder tracks erasure bits."""
+        if not self.has_erasure_bit:
+            return error
+        return np.hstack([error, np.zeros(1, dtype=error.dtype)])
+
+    def __len__(self) -> int:
+        """The number of entries in this lookup table."""
+        return len(self.syndrome_to_error)
+
+    def decode(self, syndrome: npt.NDArray[np.int_]) -> npt.NDArray[np.int_]:
+        """Decode an error syndrome and return an inferred error.
+
+        If initialized with predict_observable_flips=True, return the inferred observable flip.
+        """
+        syndrome = syndrome.view(np.ndarray)
+        if self.keep is not None:
+            syndrome = syndrome[self.keep]
+        return self.syndrome_to_error.get(tuple(syndrome), self.default_correction).copy()
+
 
 class WeightedLookupDecoder(LookupDecoder):
     """Decoder based on a lookup table that maps syndromes to errors.
@@ -521,20 +521,20 @@ class WeightedLookupDecoder(LookupDecoder):
         pcm_or_dem: IntegerArray | stim.DetectorErrorModel,
         max_weight: int,
         *,
-        symplectic: bool = False,
-        add_erasure_bit: bool = False,
         observable_flip_matrix: IntegerArray | None = None,
         predict_observable_flips: bool = False,
         post_select: Collection[int] = (),
+        add_erasure_bit: bool = False,
+        symplectic: bool = False,
     ) -> None:
         pcm, observable_flip_matrix, _, keep, default_correction = self._process_lookup_data(
             pcm_or_dem,
             None,
             None,
             observable_flip_matrix,
-            add_erasure_bit,
             predict_observable_flips,
             post_select,
+            add_erasure_bit,
         )
 
         # remember the post-selected syndrome (detector) bits and the mask of bits to keep
@@ -551,7 +551,7 @@ class WeightedLookupDecoder(LookupDecoder):
         self.syndrome_to_candidates: dict[
             tuple[int, ...], list[tuple[npt.NDArray[np.int_], npt.NDArray[np.int_]]]
         ] = collections.defaultdict(list)
-        for error, syndrome in LookupDecoder.iter_errors_and_syndromes(
+        for error, syndrome in LookupDecoder._iter_errors_and_syndromes(
             pcm, max_weight, symplectic, keep
         ):
             if predict_observable_flips:

--- a/src/qldpc/decoders/custom.py
+++ b/src/qldpc/decoders/custom.py
@@ -216,9 +216,9 @@ class LookupDecoder(Decoder):
     """Decoder based on a lookup table that maps syndromes to errors.
 
     In addition to a parity check matrix, this decoder needs to be initialized with a max_weight.
-    The decoder consider then enumerates all errors with weight <= max_weight, in order of
-    decreasing weight.  For each error ee, it computes the corresponding syndrome ss, and assigns
-    syndrome ss the "correction" ee, overriding any previously assigned correction if present.
+    The decoder consider enumerates all errors with weight <= max_weight, in order of decreasing
+    weight.  For each error ee, it computes the corresponding syndrome ss, and assigns syndrome ss
+    the "correction" ee, overriding any previously assigned correction if present.
 
     If initialized with symplectic=True, this decoder treats the provided parity check matrix as
     that of a QuditCode, with the first and last half of the columns denoting, respectively, the X

--- a/src/qldpc/decoders/custom_test.py
+++ b/src/qldpc/decoders/custom_test.py
@@ -165,9 +165,12 @@ def test_observable_lookup_decoding() -> None:
     assert np.array_equal(weighted.decode(syndrome), [0])  # min-weight error E0 has obs_flip=0
     assert np.array_equal(weighted.decode(np.array([0, 1], dtype=int)), [0])
 
-    # post-selecting on a detector drops it from the syndrome keys
+    # post-selecting on a detector drops it from the syndrome keys; decode still takes the full
+    # syndrome and internally removes the post-selected bits before the lookup
+    decoder = decoders.LookupDecoder(dem, max_weight=2, post_select=[0])
+    assert np.array_equal(obs_matrix @ decoder.decode(np.array([0, 1], dtype=int)), [1])  # E4
     weighted = decoders.WeightedLookupDecoder(dem, max_weight=2, post_select=[0])
-    assert np.array_equal(obs_matrix @ weighted.decode(np.array([1], dtype=int)), [0])  # E2: D1
+    assert np.array_equal(obs_matrix @ weighted.decode(np.array([0, 1], dtype=int)), [0])  # E2: D1
 
 
 def test_ilp_decoder() -> None:

--- a/src/qldpc/decoders/custom_test.py
+++ b/src/qldpc/decoders/custom_test.py
@@ -160,6 +160,15 @@ def test_observable_lookup_decoding() -> None:
     decoder = decoders.LookupDecoder(dem, max_weight=2)
     assert np.array_equal(obs_matrix @ decoder.decode(syndrome), [1])
 
+    # a WeightedLookupDecoder can be built from a DEM and predict observable flips directly
+    weighted = decoders.WeightedLookupDecoder(dem, max_weight=2, predict_observable_flips=True)
+    assert np.array_equal(weighted.decode(syndrome), [0])  # min-weight error E0 has obs_flip=0
+    assert np.array_equal(weighted.decode(np.array([0, 1], dtype=int)), [0])
+
+    # post-selecting on a detector drops it from the syndrome keys
+    weighted = decoders.WeightedLookupDecoder(dem, max_weight=2, post_select=[0])
+    assert np.array_equal(obs_matrix @ weighted.decode(np.array([1], dtype=int)), [0])  # E2: D1
+
 
 def test_ilp_decoder() -> None:
     """Decode using an integer linear program."""

--- a/src/qldpc/decoders/custom_test.py
+++ b/src/qldpc/decoders/custom_test.py
@@ -290,6 +290,10 @@ def test_quantum_decoding(pytestconfig: pytest.Config) -> None:
     assert np.array_equal(syndrome, code.matrix @ math.symplectic_conjugate(decoded_error[:-1]))
     assert decoder.decode(np.ones_like(syndrome))[-1] == 1
 
+    # passing penalty_func=None returns the last-recorded (lowest-weight) consistent candidate
+    decoded_error = decoder.decode(syndrome, penalty_func=None).view(code.field)
+    assert np.array_equal(syndrome, code.matrix @ math.symplectic_conjugate(decoded_error[:-1]))
+
 
 def test_penalty_func() -> None:
     """Lookup tables can build penalty functions that penalize unlikely errors."""

--- a/src/qldpc/decoders/custom_test.py
+++ b/src/qldpc/decoders/custom_test.py
@@ -165,6 +165,12 @@ def test_observable_lookup_decoding() -> None:
     assert np.array_equal(weighted.decode(syndrome), [0])  # min-weight error E0 has obs_flip=0
     assert np.array_equal(weighted.decode(np.array([0, 1], dtype=int)), [0])
 
+    # ... or from a parity check matrix and an explicit observable_flip_matrix
+    weighted = decoders.WeightedLookupDecoder(
+        pcm, max_weight=2, observable_flip_matrix=obs_matrix, predict_observable_flips=True
+    )
+    assert np.array_equal(weighted.decode(syndrome), [0])  # min-weight error E0 has obs_flip=0
+
     # post-selecting on a detector drops it from the syndrome keys; decode still takes the full
     # syndrome and internally removes the post-selected bits before the lookup
     decoder = decoders.LookupDecoder(dem, max_weight=2, post_select=[0])

--- a/src/qldpc/decoders/custom_test.py
+++ b/src/qldpc/decoders/custom_test.py
@@ -294,5 +294,5 @@ def test_quantum_decoding(pytestconfig: pytest.Config) -> None:
 def test_penalty_func() -> None:
     """Lookup tables can build penalty functions that penalize unlikely errors."""
     error_channel = [0.2, 0.1]
-    penalty_func = decoders.LookupDecoder.build_penalty_func(error_channel)
+    penalty_func = decoders.LookupDecoder._build_penalty_func(error_channel)
     assert penalty_func([0, 0]) < penalty_func([1, 0]) < penalty_func([0, 1]) < penalty_func([1, 1])


### PR DESCRIPTION
For example, to build a lookup table of for an experiment that post-selects on detectors 0 and 6 in a DEM:

```python
decoder = qldpc.decoders.LookupTable(dem, max_weight=..., post_select=[0, 6])
```

Also rewrite and reorganize the `LookupTable` while we're at it.