### PR TITLE
Add `QuditCode.get_destabilizer_ops`

### DIFF
--- a/src/qldpc/circuits/encoding.py
+++ b/src/qldpc/circuits/encoding.py
@@ -57,9 +57,12 @@ def get_encoding_tableau(code: codes.QuditCode, *, only_zero: bool = False) -> s
     logical_ops = code.get_logical_ops()
     gauge_ops = code.get_gauge_ops()
 
-    # identify a minimal generating set of stabilizers, and dual destabilizers
+    # identify a minimal generating set of stabilizers and the dual destabilizers.  Evaluate the
+    # stabilizer count (which may canonicalize the cached stabilizers) before grabbing the
+    # stabilizers, so that stab_ops matches the stabilizers used by code.get_destabilizer_ops.
+    num_stabilizers = len(code) - code.dimension - code.gauge_dimension
     stab_ops = code.get_stabilizer_ops()
-    if len(logical_ops) + len(gauge_ops) + len(stab_ops) != len(code):
+    if len(stab_ops) != num_stabilizers:
         stab_ops = code.get_stabilizer_ops(canonicalized=True)
     destab_ops = code.get_destabilizer_ops()
 

--- a/src/qldpc/circuits/encoding.py
+++ b/src/qldpc/circuits/encoding.py
@@ -53,16 +53,13 @@ def get_encoding_tableau(code: codes.QuditCode, *, only_zero: bool = False) -> s
             allow_underconstrained=True,
         )
 
-    # identify logical and gauge operators operators
+    # identify logical and gauge operators
     logical_ops = code.get_logical_ops()
     gauge_ops = code.get_gauge_ops()
 
-    # identify a minimal generating set of stabilizers and the dual destabilizers.  Evaluate the
-    # stabilizer count (which may canonicalize the cached stabilizers) before grabbing the
-    # stabilizers, so that stab_ops matches the stabilizers used by code.get_destabilizer_ops.
-    num_stabilizers = len(code) - code.dimension - code.gauge_dimension
+    # identify a minimal generating set of stabilizers and the dual destabilizers
     stab_ops = code.get_stabilizer_ops()
-    if len(stab_ops) != num_stabilizers:
+    if len(stab_ops) != len(code) - code.dimension - code.gauge_dimension:
         stab_ops = code.get_stabilizer_ops(canonicalized=True)
     destab_ops = code.get_destabilizer_ops()
 

--- a/src/qldpc/circuits/encoding.py
+++ b/src/qldpc/circuits/encoding.py
@@ -57,26 +57,11 @@ def get_encoding_tableau(code: codes.QuditCode, *, only_zero: bool = False) -> s
     logical_ops = code.get_logical_ops()
     gauge_ops = code.get_gauge_ops()
 
-    # Identify:
-    # (1) A minimal generating set of stabilizers.
-    # (2) "Candidate" destabilizers that have correct pair-wise (anti-)commutation relations
-    #     with the stabilizers, but may contain extra stabilizer, logical, or gauge factors.
+    # identify a minimal generating set of stabilizers, and dual destabilizers
     stab_ops = code.get_stabilizer_ops()
-    if len(stab_ops) != len(code) - code.dimension - code.gauge_dimension:  # pragma: no cover
+    if len(logical_ops) + len(gauge_ops) + len(stab_ops) != len(code):
         stab_ops = code.get_stabilizer_ops(canonicalized=True)
-    destab_ops = math.get_dual_basis(math.symplectic_conjugate(stab_ops))
-
-    # remove logical and gauge operator components
-    dual_logical_ops = logical_ops.reshape(2, -1)[::-1, :].reshape(logical_ops.shape)
-    dual_gauge_ops = gauge_ops.reshape(2, -1)[::-1, :].reshape(gauge_ops.shape)
-    destab_ops -= destab_ops @ math.symplectic_conjugate(dual_logical_ops).T @ logical_ops
-    destab_ops -= destab_ops @ math.symplectic_conjugate(dual_gauge_ops).T @ gauge_ops
-
-    # enforce that destabilizers commute with each other by removing stabilizer factors
-    for dd in range(len(destab_ops)):
-        for ss in range(dd, len(destab_ops)):
-            if destab_ops[dd] @ math.symplectic_conjugate(destab_ops[ss]):  # pragma: no cover
-                destab_ops[dd] -= stab_ops[ss]
+    destab_ops = code.get_destabilizer_ops()
 
     # construct Pauli strings to hand over to Stim
     matrices_x = [logical_ops[: code.dimension], gauge_ops[: code.gauge_dimension], destab_ops]

--- a/src/qldpc/circuits/encoding_test.py
+++ b/src/qldpc/circuits/encoding_test.py
@@ -91,6 +91,19 @@ def _get_logical_pauli_string(  # pragma: no cover
     return 1j * string_x * string_z
 
 
+def test_encoding_overcomplete_stabilizers() -> None:
+    """Build an encoding circuit for a code with an overcomplete stabilizer matrix."""
+    code = codes.ToricCode(4)  # has more stabilizer generators than len(code) - dimension
+    assert len(code.get_stabilizer_ops()) != len(code) - code.dimension - code.gauge_dimension
+
+    simulator = stim.TableauSimulator()
+    simulator.do(circuits.get_encoding_circuit(code))
+
+    # all stabilizers have expectation value +1
+    for op in code.get_stabilizer_ops():
+        assert simulator.peek_observable_expectation(math.op_to_string(op)) == 1
+
+
 def test_logical_tableau() -> None:
     """Reconstruct a logical tableau."""
     code = codes.FiveQubitCode()

--- a/src/qldpc/codes/common.py
+++ b/src/qldpc/codes/common.py
@@ -1580,14 +1580,14 @@ class QuditCode(AbstractCode):
         destab_ops = math.get_dual_basis(math.symplectic_conjugate(stab_ops))
 
         # Remove logical and gauge operator components.  The logical (gauge) operators are in
-        # standard symplectic form, so symplectic_conjugate(ops.T).T is a dual basis satisfying
-        # ops @ symplectic_conjugate(dual_ops).T = identity.  Subtracting destab_ops's projection
-        # onto ops along this dual removes the logical/gauge component while preserving the
-        # (anti-)commutation with the stabilizers, which commute with the logical/gauge operators.
+        # standard symplectic form, so symplectic_conjugate(ops.T).T is their symplectic dual basis:
+        # projecting destab_ops's overlaps with the operators back onto this dual removes the
+        # logical/gauge component, while preserving the (anti-)commutation with the stabilizers,
+        # which commute with the logical/gauge operators.
         for ops in [logical_ops, gauge_ops]:
             if len(ops):
-                dual_ops = math.symplectic_conjugate(ops.T).T
-                destab_ops -= destab_ops @ math.symplectic_conjugate(dual_ops).T @ ops
+                overlaps = destab_ops @ math.symplectic_conjugate(ops).T
+                destab_ops += overlaps @ math.symplectic_conjugate(ops.T).T
 
         # enforce that destabilizers commute with each other by removing stabilizer factors
         for dd in range(len(destab_ops)):

--- a/src/qldpc/codes/common.py
+++ b/src/qldpc/codes/common.py
@@ -1580,14 +1580,13 @@ class QuditCode(AbstractCode):
         destab_ops = math.get_dual_basis(math.symplectic_conjugate(stab_ops))
 
         # Remove logical and gauge operator components.  The logical (gauge) operators are in
-        # standard symplectic form, so their symplectic dual basis -- the rows D that satisfy
-        # D @ symplectic_conjugate(ops).T = identity -- is just the operators reindexed as [Z; -X].
-        # Subtracting destab_ops's overlap with the operators along this dual removes the component
-        # while preserving the (anti-)commutation relations with the stabilizers, which commute with
-        # the logical and gauge operators.
+        # standard symplectic form, so symplectic_conjugate(ops.T).T is a dual basis satisfying
+        # ops @ symplectic_conjugate(dual_ops).T = identity.  Subtracting destab_ops's projection
+        # onto ops along this dual removes the logical/gauge component while preserving the
+        # (anti-)commutation with the stabilizers, which commute with the logical/gauge operators.
         for ops in [logical_ops, gauge_ops]:
             if len(ops):
-                dual_ops = np.vstack([ops[len(ops) // 2 :], -ops[: len(ops) // 2]])
+                dual_ops = math.symplectic_conjugate(ops.T).T
                 destab_ops -= destab_ops @ math.symplectic_conjugate(dual_ops).T @ ops
 
         # enforce that destabilizers commute with each other by removing stabilizer factors

--- a/src/qldpc/codes/common.py
+++ b/src/qldpc/codes/common.py
@@ -1570,14 +1570,9 @@ class QuditCode(AbstractCode):
         logical_ops = self.get_logical_ops()
         gauge_ops = self.get_gauge_ops()
 
-        # Identify a minimal generating set of stabilizers.  Evaluating self.dimension and
-        # self.gauge_dimension may canonicalize (and thereby rebind) the cached stabilizer
-        # operators, so compute the expected number of stabilizers before retrieving them, and
-        # grab the stabilizers only afterwards to ensure the returned destabilizers are dual to the
-        # same stabilizer matrix that self.get_stabilizer_ops() reports.
-        num_stabilizers = len(self) - self.dimension - self.gauge_dimension
+        # identify a minimal generating set of stabilizers
         stab_ops = self.get_stabilizer_ops()
-        if len(stab_ops) != num_stabilizers:
+        if len(stab_ops) != len(self) - self.dimension - self.gauge_dimension:
             stab_ops = self.get_stabilizer_ops(canonicalized=True)
 
         # Build "candidate" destabilizers that have correct pair-wise (anti-)commutation relations
@@ -1652,7 +1647,9 @@ class QuditCode(AbstractCode):
             return len(self._logical_ops) // 2
         if not self.is_subsystem_code:
             return len(self) - self.rank
-        num_stabs = len(self.get_stabilizer_ops(canonicalized=True))
+        # Count independent stabilizer generators without the canonicalized=True call, which would
+        # otherwise rebind the cached stabilizer operators.
+        num_stabs = len(self.get_stabilizer_ops().row_space())
         return len(self) - (self.rank + num_stabs) // 2
 
     @functools.cached_property
@@ -1660,7 +1657,7 @@ class QuditCode(AbstractCode):
         """The number of gauge qudits in this code."""
         if not self.is_subsystem_code:
             return 0
-        num_stabs = len(self.get_stabilizer_ops(canonicalized=True))
+        num_stabs = len(self.get_stabilizer_ops().row_space())
         return (self.rank - num_stabs) // 2
 
     def get_code_params(

--- a/src/qldpc/codes/common.py
+++ b/src/qldpc/codes/common.py
@@ -1647,8 +1647,6 @@ class QuditCode(AbstractCode):
             return len(self._logical_ops) // 2
         if not self.is_subsystem_code:
             return len(self) - self.rank
-        # Count independent stabilizer generators without the canonicalized=True call, which would
-        # otherwise rebind the cached stabilizer operators.
         num_stabs = len(self.get_stabilizer_ops().row_space())
         return len(self) - (self.rank + num_stabs) // 2
 

--- a/src/qldpc/codes/common.py
+++ b/src/qldpc/codes/common.py
@@ -1579,16 +1579,16 @@ class QuditCode(AbstractCode):
         # with the stabilizers, but may contain extra stabilizer, logical, or gauge factors.
         destab_ops = math.get_dual_basis(math.symplectic_conjugate(stab_ops))
 
-        # Remove logical and gauge operator components.  Logical (gauge) operators satisfy
-        # logical_ops @ symplectic_conjugate(logical_ops).T = Ω, the symplectic form, so subtracting
-        # (destab_ops @ symplectic_conjugate(logical_ops).T) @ Ω⁻¹ @ logical_ops projects out the
-        # logical component.  This preserves the (anti-)commutation relations with the stabilizers
-        # because logical and gauge operators commute with the stabilizers.
+        # Remove logical and gauge operator components.  The logical (gauge) operators are in
+        # standard symplectic form, so their symplectic dual basis -- the rows D that satisfy
+        # D @ symplectic_conjugate(ops).T = identity -- is just the operators reindexed as [Z; -X].
+        # Subtracting destab_ops's overlap with the operators along this dual removes the component
+        # while preserving the (anti-)commutation relations with the stabilizers, which commute with
+        # the logical and gauge operators.
         for ops in [logical_ops, gauge_ops]:
             if len(ops):
-                overlaps = destab_ops @ math.symplectic_conjugate(ops).T
-                symplectic_form = ops @ math.symplectic_conjugate(ops).T
-                destab_ops -= overlaps @ np.linalg.inv(symplectic_form) @ ops
+                dual_ops = np.vstack([ops[len(ops) // 2 :], -ops[: len(ops) // 2]])
+                destab_ops -= destab_ops @ math.symplectic_conjugate(dual_ops).T @ ops
 
         # enforce that destabilizers commute with each other by removing stabilizer factors
         for dd in range(len(destab_ops)):

--- a/src/qldpc/codes/common.py
+++ b/src/qldpc/codes/common.py
@@ -1566,30 +1566,40 @@ class QuditCode(AbstractCode):
         This method first considers the stabilizer matrix built by self.get_stabilizer_ops().  If
         that choice is overcomplete, this method uses self.get_stabilizer_ops(canonicalized=True).
         """
-        # identify logical and gauge operators operators
+        # identify logical and gauge operators
         logical_ops = self.get_logical_ops()
         gauge_ops = self.get_gauge_ops()
 
-        # identify a minimal generating set of stabilizers
+        # Identify a minimal generating set of stabilizers.  Evaluating self.dimension and
+        # self.gauge_dimension may canonicalize (and thereby rebind) the cached stabilizer
+        # operators, so compute the expected number of stabilizers before retrieving them, and
+        # grab the stabilizers only afterwards to ensure the returned destabilizers are dual to the
+        # same stabilizer matrix that self.get_stabilizer_ops() reports.
+        num_stabilizers = len(self) - self.dimension - self.gauge_dimension
         stab_ops = self.get_stabilizer_ops()
-        if len(logical_ops) + len(gauge_ops) + len(stab_ops) != len(self):
+        if len(stab_ops) != num_stabilizers:
             stab_ops = self.get_stabilizer_ops(canonicalized=True)
 
         # Build "candidate" destabilizers that have correct pair-wise (anti-)commutation relations
         # with the stabilizers, but may contain extra stabilizer, logical, or gauge factors.
         destab_ops = math.get_dual_basis(math.symplectic_conjugate(stab_ops))
 
-        # remove logical and gauge operator components
-        dual_logical_ops = logical_ops.reshape(2, -1)[::-1, :].reshape(logical_ops.shape)
-        dual_gauge_ops = gauge_ops.reshape(2, -1)[::-1, :].reshape(gauge_ops.shape)
-        destab_ops -= destab_ops @ math.symplectic_conjugate(dual_logical_ops).T @ logical_ops
-        destab_ops -= destab_ops @ math.symplectic_conjugate(dual_gauge_ops).T @ gauge_ops
+        # Remove logical and gauge operator components.  Logical (gauge) operators satisfy
+        # logical_ops @ symplectic_conjugate(logical_ops).T = Ω, the symplectic form, so subtracting
+        # (destab_ops @ symplectic_conjugate(logical_ops).T) @ Ω⁻¹ @ logical_ops projects out the
+        # logical component.  This preserves the (anti-)commutation relations with the stabilizers
+        # because logical and gauge operators commute with the stabilizers.
+        for ops in [logical_ops, gauge_ops]:
+            if len(ops):
+                overlaps = destab_ops @ math.symplectic_conjugate(ops).T
+                symplectic_form = ops @ math.symplectic_conjugate(ops).T
+                destab_ops -= overlaps @ np.linalg.inv(symplectic_form) @ ops
 
         # enforce that destabilizers commute with each other by removing stabilizer factors
         for dd in range(len(destab_ops)):
             for ss in range(dd, len(destab_ops)):
-                if destab_ops[dd] @ math.symplectic_conjugate(destab_ops[ss]):
-                    destab_ops[dd] -= stab_ops[ss]
+                if overlap := destab_ops[dd] @ math.symplectic_conjugate(destab_ops[ss]):
+                    destab_ops[dd] += overlap * stab_ops[ss]
         return destab_ops
 
     def dual(self) -> QuditCode:

--- a/src/qldpc/codes/common.py
+++ b/src/qldpc/codes/common.py
@@ -1559,6 +1559,39 @@ class QuditCode(AbstractCode):
         self._gauge_ops = self.dual().get_logical_ops()
         return self._gauge_ops
 
+    def get_destabilizer_ops(self) -> galois.FieldArray:
+        """The destabilizers of this code.
+
+        Destabilizers are defined relative to a specific minimal choice of stabilizer generators.
+        This method first considers the stabilizer matrix built by self.get_stabilizer_ops().  If
+        that choice is overcomplete, this method uses self.get_stabilizer_ops(canonicalized=True).
+        """
+        # identify logical and gauge operators operators
+        logical_ops = self.get_logical_ops()
+        gauge_ops = self.get_gauge_ops()
+
+        # identify a minimal generating set of stabilizers
+        stab_ops = self.get_stabilizer_ops()
+        if len(logical_ops) + len(gauge_ops) + len(stab_ops) != len(self):
+            stab_ops = self.get_stabilizer_ops(canonicalized=True)
+
+        # Build "candidate" destabilizers that have correct pair-wise (anti-)commutation relations
+        # with the stabilizers, but may contain extra stabilizer, logical, or gauge factors.
+        destab_ops = math.get_dual_basis(math.symplectic_conjugate(stab_ops))
+
+        # remove logical and gauge operator components
+        dual_logical_ops = logical_ops.reshape(2, -1)[::-1, :].reshape(logical_ops.shape)
+        dual_gauge_ops = gauge_ops.reshape(2, -1)[::-1, :].reshape(gauge_ops.shape)
+        destab_ops -= destab_ops @ math.symplectic_conjugate(dual_logical_ops).T @ logical_ops
+        destab_ops -= destab_ops @ math.symplectic_conjugate(dual_gauge_ops).T @ gauge_ops
+
+        # enforce that destabilizers commute with each other by removing stabilizer factors
+        for dd in range(len(destab_ops)):
+            for ss in range(dd, len(destab_ops)):
+                if destab_ops[dd] @ math.symplectic_conjugate(destab_ops[ss]):
+                    destab_ops[dd] -= stab_ops[ss]
+        return destab_ops
+
     def dual(self) -> QuditCode:
         """Dual to this code, which swaps the roles of logical and gauge operators.
 

--- a/src/qldpc/codes/common_test.py
+++ b/src/qldpc/codes/common_test.py
@@ -473,6 +473,19 @@ def test_qudit_ops(pytestconfig: pytest.Config) -> None:
         logical_ops = code.get_logical_ops()
         gauge_ops = code.get_gauge_ops()
         assert not np.any(stabilizer_ops @ math.symplectic_conjugate(stabilizer_ops).T)
+
+        # destabilizers anticommute with their paired stabilizer, commute with everything else
+        destabilizer_ops = code.get_destabilizer_ops()
+        minimal_stabilizer_ops = code.get_stabilizer_ops()
+        if len(minimal_stabilizer_ops) != len(code) - code.dimension - code.gauge_dimension:
+            minimal_stabilizer_ops = code.get_stabilizer_ops(canonicalized=True)
+        assert np.array_equal(
+            destabilizer_ops @ math.symplectic_conjugate(minimal_stabilizer_ops).T,
+            code.field.Identity(len(minimal_stabilizer_ops)),
+        )
+        assert not np.any(destabilizer_ops @ math.symplectic_conjugate(destabilizer_ops).T)
+        assert not np.any(destabilizer_ops @ math.symplectic_conjugate(logical_ops).T)
+        assert not np.any(destabilizer_ops @ math.symplectic_conjugate(gauge_ops).T)
         assert np.array_equal(
             gauge_ops @ math.symplectic_conjugate(gauge_ops).T,
             get_symplectic_form(code.gauge_dimension, code.field),


### PR DESCRIPTION
Example usage: I have a syndrome vector `syndrome_bits = (s_0, s_1, ...)` from stabilizer measurements.  I want the destabilizer that zeros out that syndrome and commutes with all logical operators.  Say the code is self-dual and defined by a minimal set of stabilizer generators.  I can construct the desired stabilizer with some thing like:
```python
from qldpc import codes

code = codes.SteaneCode()
syndrome_bits = (0, 1, 0)

# X-type stabilizers and their Z-type duals
stabs = code.matrix_x
destab_ops = code.get_destabilizer_ops()[: len(stabs), len(code):]

syndrome_vec = code.field(syndrome_bits)  # convert to a galois.FieldArray
print(syndrome_vec)

net_destabilizer = syndrome_vec @ destab_ops
print(net_destabilizer)
```