### PR TITLE
Add `CSS.get_destabilizer_ops`

### DIFF
--- a/src/qldpc/codes/common.py
+++ b/src/qldpc/codes/common.py
@@ -1559,13 +1559,27 @@ class QuditCode(AbstractCode):
         self._gauge_ops = self.dual().get_logical_ops()
         return self._gauge_ops
 
-    def get_destabilizer_ops(self) -> galois.FieldArray:
+    def get_destabilizer_ops(
+        self, pauli: PauliXZ | None = None, *, symplectic: bool = True
+    ) -> galois.FieldArray:
         """The destabilizers of this code.
 
         Destabilizers are defined relative to a specific minimal choice of stabilizer generators.
         This method first considers the stabilizer matrix built by self.get_stabilizer_ops().  If
         that choice is overcomplete, this method uses self.get_stabilizer_ops(canonicalized=True).
+
+        The symplectic argument is provided for compatibility with CSSCode.get_destabilizer_ops, and
+        must always be True for a non-CSS code.
         """
+        assert symplectic is True
+        assert pauli is None or pauli in PAULIS_XZ
+
+        # if requested, retrieve destabilizer operators of one type only
+        if pauli is not None:
+            destabilizer_ops = self.get_destabilizer_ops()
+            pivots_x = math.first_nonzero_cols(destabilizer_ops) < len(self)
+            return destabilizer_ops[pivots_x if pauli is Pauli.X else ~pivots_x]
+
         # identify logical and gauge operators
         logical_ops = self.get_logical_ops()
         gauge_ops = self.get_gauge_ops()
@@ -2654,9 +2668,10 @@ class CSSCode(QuditCode):
     ) -> galois.FieldArray:
         """Basis of stabilizer group generators for this code.
 
-        If canonicalized is True, guarantee that the stabilizer matrix is canonicalized (i.e., row
-        reduced) such that its rows are a minimal generating set for the stabilizer group.
+        If canonicalized is True, guarantee that the stabilizer matrix is canonicalized (i.e.,
+        row-reduced) such that its rows are a minimal generating set for the stabilizer group.
         """
+        assert pauli is None or pauli in PAULIS_XZ
         if self._stabilizer_ops is None and self.is_subsystem_code:
             stabs_and_gauges_x = self.canonicalized.get_matrix(Pauli.X)
             stabs_and_gauges_z = self.canonicalized.get_matrix(Pauli.Z)
@@ -2686,10 +2701,24 @@ class CSSCode(QuditCode):
         Nontrivial logical Pauli operators for the gauge qudits are organized similarly to the
         logical Pauli operators computed by CSSCode.get_logical_ops.
         """
+        assert pauli is None or pauli in PAULIS_XZ
         gauge_ops = QuditCode.get_gauge_ops(self, pauli)
         if symplectic or pauli is None:
             return gauge_ops
         return gauge_ops.reshape(-1, 2, len(self))[:, pauli, :].view(self.field)
+
+    def get_destabilizer_ops(
+        self, pauli: PauliXZ | None = None, *, symplectic: bool = False
+    ) -> galois.FieldArray:
+        """The destabilizers of this code.
+
+        See help(qldpc.codes.QuditCode.get_destabilizer_ops) for an explanation of destabilizers.
+        """
+        assert pauli is None or pauli in PAULIS_XZ
+        destabilizer_ops = QuditCode.get_destabilizer_ops(self, pauli)
+        if symplectic or pauli is None:
+            return destabilizer_ops
+        return destabilizer_ops.reshape(-1, 2, len(self))[:, pauli, :].view(self.field)
 
     def dual(self) -> CSSCode:
         """The dual of this code, which swaps the roles of logical and gauge operators.

--- a/src/qldpc/codes/common_test.py
+++ b/src/qldpc/codes/common_test.py
@@ -28,7 +28,7 @@ import numpy as np
 import pytest
 
 from qldpc import abstract, codes, external, math
-from qldpc.objects import Pauli
+from qldpc.objects import PAULIS_XZ, Pauli
 
 ####################################################################################################
 # classical code tests
@@ -693,20 +693,12 @@ def test_css_ops(pytestconfig: pytest.Config) -> None:
     )
     assert not np.any(code.get_stabilizer_ops() @ math.symplectic_conjugate(code.get_gauge_ops()).T)
 
-    # CSS destabilizers can be retrieved by Pauli type, consistently with the symplectic form
+    # destabilizers of one Pauli type are dual to the stabilizers of the opposite type
     for code in get_codes_for_testing_ops():
-        destabilizer_ops = code.get_destabilizer_ops()
-        assert np.array_equal(code.get_destabilizer_ops(None), destabilizer_ops)
-
-        # X-type destabilizers only address qudits with physical X-type operators, and likewise for
-        # Z; taken together they partition the full (symplectic) destabilizer matrix
-        pivots_x = math.first_nonzero_cols(destabilizer_ops) < len(code)
-        for pauli, pivots in [(Pauli.X, pivots_x), (Pauli.Z, ~pivots_x)]:
-            destabs = code.get_destabilizer_ops(pauli, symplectic=True)
-            assert np.array_equal(destabs, destabilizer_ops[pivots])
-            assert np.array_equal(
-                code.get_destabilizer_ops(pauli), destabs.reshape(-1, 2, len(code))[:, pauli, :]
-            )
+        for pauli in PAULIS_XZ:
+            destabs = code.get_destabilizer_ops(pauli)
+            stabs = code.get_stabilizer_ops(pauli.swap_xz())
+            assert np.linalg.matrix_rank(destabs @ stabs.T) == len(destabs)
 
     # successfully construct and reduce logical operators in a code with "over-complete" checks
     dist = 4

--- a/src/qldpc/codes/common_test.py
+++ b/src/qldpc/codes/common_test.py
@@ -486,6 +486,11 @@ def test_qudit_ops(pytestconfig: pytest.Config) -> None:
         assert not np.any(destabilizer_ops @ math.symplectic_conjugate(destabilizer_ops).T)
         assert not np.any(destabilizer_ops @ math.symplectic_conjugate(logical_ops).T)
         assert not np.any(destabilizer_ops @ math.symplectic_conjugate(gauge_ops).T)
+
+        # destabilizers can be retrieved by Pauli type, partitioning the full destabilizer matrix
+        pivots_x = math.first_nonzero_cols(destabilizer_ops) < len(code)
+        assert np.array_equal(code.get_destabilizer_ops(Pauli.X), destabilizer_ops[pivots_x])
+        assert np.array_equal(code.get_destabilizer_ops(Pauli.Z), destabilizer_ops[~pivots_x])
         assert np.array_equal(
             gauge_ops @ math.symplectic_conjugate(gauge_ops).T,
             get_symplectic_form(code.gauge_dimension, code.field),
@@ -687,6 +692,21 @@ def test_css_ops(pytestconfig: pytest.Config) -> None:
         code.get_stabilizer_ops() @ math.symplectic_conjugate(code.get_logical_ops()).T
     )
     assert not np.any(code.get_stabilizer_ops() @ math.symplectic_conjugate(code.get_gauge_ops()).T)
+
+    # CSS destabilizers can be retrieved by Pauli type, consistently with the symplectic form
+    for code in get_codes_for_testing_ops():
+        destabilizer_ops = code.get_destabilizer_ops()
+        assert np.array_equal(code.get_destabilizer_ops(None), destabilizer_ops)
+
+        # X-type destabilizers only address qudits with physical X-type operators, and likewise for
+        # Z; taken together they partition the full (symplectic) destabilizer matrix
+        pivots_x = math.first_nonzero_cols(destabilizer_ops) < len(code)
+        for pauli, pivots in [(Pauli.X, pivots_x), (Pauli.Z, ~pivots_x)]:
+            destabs = code.get_destabilizer_ops(pauli, symplectic=True)
+            assert np.array_equal(destabs, destabilizer_ops[pivots])
+            assert np.array_equal(
+                code.get_destabilizer_ops(pauli), destabs.reshape(-1, 2, len(code))[:, pauli, :]
+            )
 
     # successfully construct and reduce logical operators in a code with "over-complete" checks
     dist = 4


### PR DESCRIPTION
Cleanup of #543.  The example (copy-pasted and modified) is now:

Example usage: I have a syndrome vector `syndrome_bits = (s_0, s_1, ...)` from stabilizer measurements.  I want the destabilizer that zeros out that syndrome and commutes with all logical operators.  Say the code is self-dual and defined by a minimal set of stabilizer generators.  I can construct the desired stabilizer with some thing like:
```python
from qldpc import codes
from qldpc.objects import Pauli

code = codes.SteaneCode()
syndrome_bits = (0, 1, 0)

# X-type stabilizers and their Z-type duals
stabs = code.get_stabilizer_ops(Pauli.X)
destab_ops = code.get_destabilizer_ops(Pauli.Z)

syndrome_vec = code.field(syndrome_bits)  # convert to a galois.FieldArray
print(syndrome_vec)

net_destabilizer = syndrome_vec @ destab_ops
print(net_destabilizer)
```