### PR TITLE
Cheaper tests

### DIFF
--- a/checks/coverage_.py
+++ b/checks/coverage_.py
@@ -5,8 +5,12 @@ import checks_superstaq
 import pytest_
 
 if __name__ == "__main__":
+    # The coverage check only runs *.py tests, never notebooks, so the nbmake plugin is pure
+    # overhead here; disabling it saves ~0.7s of pytest startup in each modular-coverage subprocess.
+    # "-pno:nbmake" is the attached spelling of "-p no:nbmake"; the separate "no:nbmake" token would
+    # otherwise be parsed as a positional filename by checks_superstaq's argument parser.
     sys.exit(
         checks_superstaq.coverage_.run(
-            *sys.argv[1:], "--modular", "--sysmon", exclude=pytest_.EXCLUDE
+            *sys.argv[1:], "--modular", "--sysmon", "-pno:nbmake", exclude=pytest_.EXCLUDE
         )
     )

--- a/src/qldpc/circuits/memory/alpha_syndrome_test.py
+++ b/src/qldpc/circuits/memory/alpha_syndrome_test.py
@@ -31,6 +31,7 @@ DEFAULT_STRATEGY = circuits.AlphaSyndrome(
     circuits.DepolarizingNoiseModel(0.001),
     iters_per_step=3,
     shots_per_iter=1,
+    verbose=False,
 )
 
 
@@ -43,7 +44,7 @@ def test_alpha_syndrome(pytestconfig: pytest.Config) -> None:
     assert alpha_syndrome_is_valid(codes.ToricCode(2, rotated=True))
     assert alpha_syndrome_is_valid(codes.SurfaceCode(2, rotated=True))
 
-    code_a = codes.ClassicalCode.random(5, 3, seed=seed)
+    code_a = codes.ClassicalCode.random(3, 2, seed=seed)
     code_b = codes.ClassicalCode.random(3, 2, seed=seed + 1)
     assert alpha_syndrome_is_valid(codes.HGPCode(code_a, code_b))
 


### PR DESCRIPTION
Passing `"-pno:nbmake"` to `checks_superstaq.coverage_.run` seems to cut down the coverage test time on github from ~7m to ~2m30s.  Amazing.