### PR TITLE
Add `confidence_ratio` option to LookupDecoder

### DIFF
--- a/src/qldpc/decoders/custom.py
+++ b/src/qldpc/decoders/custom.py
@@ -288,7 +288,7 @@ class LookupDecoder:
         observable_flip_matrix: IntegerArray | None = None,
         predict_observable_flips: bool = False,
         post_select: Collection[int] = (),
-        add_erasure_bit: bool | None = None,
+        add_erasure_bit: bool | None = None,  # falsy by default
         confidence_ratio: float | None = None,
         symplectic: bool = False,
     ) -> None:

--- a/src/qldpc/decoders/custom.py
+++ b/src/qldpc/decoders/custom.py
@@ -268,7 +268,9 @@ class LookupDecoder:
     ``confidence_ratio`` times as likely as the rest, i.e. ``prob_top >= confidence_ratio *
     prob_rest``.  Otherwise, the syndrome is omitted from the lookup table, so that it decodes to
     erasure, identically to a syndrome that was never enumerated.  A positive ``confidence_ratio``
-    therefore auto-enables the erasure bit, setting ``add_erasure_bit=True``.
+    therefore auto-enables the erasure bit, setting ``add_erasure_bit=True``.  At the extreme,
+    ``confidence_ratio=np.inf`` keeps only syndromes with a single consistent observable flip,
+    erasing every syndrome that has any competing flip.
 
     If initialized with ``symplectic=True``, this decoder treats the provided parity check matrix as
     that of a ``QuditCode``, with the first and last half of the columns denoting, respectively, the

--- a/src/qldpc/decoders/custom.py
+++ b/src/qldpc/decoders/custom.py
@@ -268,10 +268,7 @@ class LookupDecoder:
     ``confidence_ratio`` times as likely as the rest, i.e. ``prob_top >= confidence_ratio *
     prob_rest``.  Otherwise, the syndrome is omitted from the lookup table, so that it decodes to
     erasure, identically to a syndrome that was never enumerated.  A positive ``confidence_ratio``
-    therefore auto-enables the erasure bit (see ``add_erasure_bit``).  ``confidence_ratio=0`` (or
-    its default ``None``) is a requirement-free no-op; larger values demand a wider margin before
-    committing -- e.g. ``confidence_ratio=10`` erases unless the top flip is at least 10 times as
-    likely as all others combined.
+    therefore auto-enables the erasure bit, setting ``add_erasure_bit=True``.
 
     If initialized with ``symplectic=True``, this decoder treats the provided parity check matrix as
     that of a ``QuditCode``, with the first and last half of the columns denoting, respectively, the

--- a/src/qldpc/decoders/custom.py
+++ b/src/qldpc/decoders/custom.py
@@ -260,16 +260,18 @@ class LookupDecoder:
     erasure bit is set to 1.  The erasure bit is set to 0 otherwise.
 
     If initialized with a positive ``confidence_ratio`` (which then requires an
-    ``observable_flip_matrix`` and ``add_erasure_bit=True``), this decoder declares erasure for any
-    syndrome whose most likely observable flip is not sufficiently more likely than the rest.
+    ``observable_flip_matrix``), this decoder handles ambiguous syndromes -- those consistent with
+    more than one observable flip -- by declining to guess unless one flip is clearly dominant.
     Letting ``prob_top`` and ``prob_rest`` be the net probabilities of the most likely observable
     flip and of all other flips combined (summed over the enumerated weight <= ``max_weight``
-    errors, grouped as above), erasure is declared -- by setting the erasure bit to 1 -- whenever
-    ``prob_top < confidence_ratio * prob_rest``.  The decoded output still carries the most likely
-    flip (or its representative error) as a best guess, so ignoring the erasure bit recovers the
-    default behavior.  ``confidence_ratio=0`` (or its default ``None``) is a requirement-free no-op;
-    larger values erase more aggressively -- e.g. ``confidence_ratio=10`` erases unless the top flip
-    is at least 10 times as likely as all others combined.
+    errors, grouped as above), the decoder assigns the most likely flip iff it is at least
+    ``confidence_ratio`` times as likely as the rest, i.e. ``prob_top >= confidence_ratio *
+    prob_rest``.  Otherwise, the syndrome is omitted from the lookup table, so that it decodes to
+    erasure, identically to a syndrome that was never enumerated.  A positive ``confidence_ratio``
+    therefore auto-enables the erasure bit (see ``add_erasure_bit``).  ``confidence_ratio=0`` (or
+    its default ``None``) is a requirement-free no-op; larger values demand a wider margin before
+    committing -- e.g. ``confidence_ratio=10`` erases unless the top flip is at least 10 times as
+    likely as all others combined.
 
     If initialized with ``symplectic=True``, this decoder treats the provided parity check matrix as
     that of a ``QuditCode``, with the first and last half of the columns denoting, respectively, the
@@ -286,10 +288,21 @@ class LookupDecoder:
         observable_flip_matrix: IntegerArray | None = None,
         predict_observable_flips: bool = False,
         post_select: Collection[int] = (),
-        add_erasure_bit: bool = False,
+        add_erasure_bit: bool | None = None,
         confidence_ratio: float | None = None,
         symplectic: bool = False,
     ) -> None:
+        if confidence_ratio is not None and not confidence_ratio >= 0:  # also rejects NaN
+            raise ValueError("A LookupDecoder confidence_ratio must be a non-negative number")
+        if confidence_ratio:  # a positive confidence_ratio signals erasure via the erasure bit
+            if add_erasure_bit is False:
+                raise ValueError(
+                    "A positive confidence_ratio signals erasure with the erasure bit, so it cannot"
+                    " be combined with add_erasure_bit=False"
+                )
+            add_erasure_bit = True  # auto-enable the erasure bit used to signal erasure
+        add_erasure_bit = bool(add_erasure_bit)  # a default of None is treated as False
+
         pcm, observable_flip_matrix, penalty_func, syndrome_mask, default_correction = (
             self._organize_lookup_table_initialization_data(
                 pcm_or_dem,
@@ -306,20 +319,12 @@ class LookupDecoder:
                 "Grouping errors by observable flip with a LookupDecoder requires providing a"
                 " stim.DetectorErrorModel, error_channel, or penalty_func"
             )
-        if confidence_ratio is not None and not confidence_ratio >= 0:  # also rejects NaN
-            raise ValueError("A LookupDecoder confidence_ratio must be a non-negative number")
-        if confidence_ratio:  # a positive confidence_ratio can actually declare erasure
-            if not add_erasure_bit:
-                raise ValueError(
-                    "Using a positive confidence_ratio with a LookupDecoder requires"
-                    " add_erasure_bit=True, which provides the erasure bit used to declare erasure"
-                )
-            if observable_flip_matrix is None:
-                raise ValueError(
-                    "Using a positive confidence_ratio with a LookupDecoder requires grouping"
-                    " errors by observable flip, which requires a stim.DetectorErrorModel with"
-                    " observables or an observable_flip_matrix"
-                )
+        if confidence_ratio and observable_flip_matrix is None:
+            raise ValueError(
+                "Using a positive confidence_ratio with a LookupDecoder requires grouping errors by"
+                " observable flip, which requires a stim.DetectorErrorModel with observables or an"
+                " observable_flip_matrix"
+            )
 
         # save attributes
         self.predict_observable_flips = predict_observable_flips
@@ -423,17 +428,12 @@ class LookupDecoder:
 
         # Identify the most likely observable_flip for each syndrome, and map the syndrome to the
         # most likely error with that (syndrome, observable_flip) combination.  If a
-        # confidence_ratio is set, we instead declare erasure (flip the erasure bit) for any
-        # syndrome whose most likely observable flip is not confidence_ratio times as likely as the
-        # rest.
+        # confidence_ratio is set, we instead omit any syndrome whose most likely observable flip is
+        # not confidence_ratio times as likely as the rest, so that it decodes to erasure (via
+        # default_correction) just like a syndrome that was never enumerated.
         log_confidence_ratio = float(np.log(confidence_ratio)) if confidence_ratio else -np.inf
         for syndrome, obs_flip_to_log_prob in net_log_probs.items():
             most_likely_obs_flip = max(obs_flip_to_log_prob, key=obs_flip_to_log_prob.__getitem__)
-            if predict_observable_flips:
-                prediction = np.asarray(most_likely_obs_flip, dtype=pcm.dtype)
-            else:
-                prediction = most_likely_errors[syndrome, most_likely_obs_flip]
-            correction = self._maybe_add_erasure_bit(prediction)
             if confidence_ratio:
                 log_prob_top = obs_flip_to_log_prob[most_likely_obs_flip]
                 other_log_probs = [
@@ -446,8 +446,12 @@ class LookupDecoder:
                 )
                 # confident iff prob_top >= confidence_ratio * prob_rest (compared in log-space)
                 if log_prob_top < log_confidence_ratio + log_prob_rest:
-                    correction[-1] = 1  # declare erasure
-            self.syndrome_to_error[syndrome] = correction
+                    continue  # omit the ambiguous syndrome, leaving it to decode as erasure
+            if predict_observable_flips:
+                prediction = np.asarray(most_likely_obs_flip, dtype=pcm.dtype)
+            else:
+                prediction = most_likely_errors[syndrome, most_likely_obs_flip]
+            self.syndrome_to_error[syndrome] = self._maybe_add_erasure_bit(prediction)
 
     @staticmethod
     def _organize_lookup_table_initialization_data(

--- a/src/qldpc/decoders/custom.py
+++ b/src/qldpc/decoders/custom.py
@@ -259,20 +259,17 @@ class LookupDecoder:
     If asked to decode a syndrome that was not observed when constructing the lookup table, the
     erasure bit is set to 1.  The erasure bit is set to 0 otherwise.
 
-    If initialized with a ``confidence_ratio`` (which requires both an ``observable_flip_matrix``
-    and ``add_erasure_bit=True``), this decoder declares erasure for any syndrome whose most likely
-    observable flip is not "sufficiently more likely" than the alternatives.  Concretely, let
-    ``prob_top`` be the net probability of the most likely observable flip for a syndrome, and let
-    ``prob_rest`` be the net probability of all other observable flips combined -- with both
-    probabilities computed from the enumerated errors of weight <= ``max_weight``, grouped by
-    observable flip as described above.  This decoder declares erasure -- by setting the erasure bit
-    of the decoded output to 1 -- whenever ``prob_top < confidence_ratio * prob_rest``.  The decoded
-    output otherwise retains the most likely observable flip (or its representative error) as a best
-    guess, so a downstream consumer that ignores the erasure bit recovers the default behavior.
-    Setting ``confidence_ratio=0`` (or leaving it as its default of ``None``) recovers the default
-    behavior of always assigning the most likely observable flip; larger values declare erasure more
-    aggressively.  For example, ``confidence_ratio=10`` declares erasure unless the most likely
-    observable flip is at least 10 times as likely as all others combined.
+    If initialized with a positive ``confidence_ratio`` (which then requires an
+    ``observable_flip_matrix`` and ``add_erasure_bit=True``), this decoder declares erasure for any
+    syndrome whose most likely observable flip is not sufficiently more likely than the rest.
+    Letting ``prob_top`` and ``prob_rest`` be the net probabilities of the most likely observable
+    flip and of all other flips combined (summed over the enumerated weight <= ``max_weight``
+    errors, grouped as above), erasure is declared -- by setting the erasure bit to 1 -- whenever
+    ``prob_top < confidence_ratio * prob_rest``.  The decoded output still carries the most likely
+    flip (or its representative error) as a best guess, so ignoring the erasure bit recovers the
+    default behavior.  ``confidence_ratio=0`` (or its default ``None``) is a requirement-free no-op;
+    larger values erase more aggressively -- e.g. ``confidence_ratio=10`` erases unless the top flip
+    is at least 10 times as likely as all others combined.
 
     If initialized with ``symplectic=True``, this decoder treats the provided parity check matrix as
     that of a ``QuditCode``, with the first and last half of the columns denoting, respectively, the
@@ -304,24 +301,24 @@ class LookupDecoder:
                 add_erasure_bit,
             )
         )
-        if observable_flip_matrix is not None and penalty_func is None:  # pragma: no cover
+        if observable_flip_matrix is not None and penalty_func is None:
             raise ValueError(
-                "Predicting observable flips with a LookupDecoder requires providing a"
+                "Grouping errors by observable flip with a LookupDecoder requires providing a"
                 " stim.DetectorErrorModel, error_channel, or penalty_func"
             )
-        if confidence_ratio is not None:
-            if confidence_ratio < 0:
-                raise ValueError("A LookupDecoder confidence_ratio must be non-negative")
+        if confidence_ratio is not None and not confidence_ratio >= 0:  # also rejects NaN
+            raise ValueError("A LookupDecoder confidence_ratio must be a non-negative number")
+        if confidence_ratio:  # a positive confidence_ratio can actually declare erasure
             if not add_erasure_bit:
                 raise ValueError(
-                    "Using a confidence_ratio with a LookupDecoder requires add_erasure_bit=True,"
-                    " which provides the erasure bit used to declare erasure"
+                    "Using a positive confidence_ratio with a LookupDecoder requires"
+                    " add_erasure_bit=True, which provides the erasure bit used to declare erasure"
                 )
             if observable_flip_matrix is None:
                 raise ValueError(
-                    "Using a confidence_ratio with a LookupDecoder requires grouping errors by"
-                    " observable flip, which requires a stim.DetectorErrorModel with observables or"
-                    " an observable_flip_matrix"
+                    "Using a positive confidence_ratio with a LookupDecoder requires grouping"
+                    " errors by observable flip, which requires a stim.DetectorErrorModel with"
+                    " observables or an observable_flip_matrix"
                 )
 
         # save attributes
@@ -360,7 +357,8 @@ class LookupDecoder:
     ) -> None:
         """Populate syndrome_to_error, mapping each syndrome to its likeliest error.
 
-        Loops over all errors in decreasing weight, assigning each syndrome its likeliest error.
+        Errors are enumerated in decreasing weight, so ties in penalty (or, with no penalty
+        function, all errors) resolve in favor of the lowest-weight error for each syndrome.
         """
         error_penalty: dict[tuple[int, ...], float] = {}
         for error, syndrome in LookupDecoder._iter_errors_and_syndromes(
@@ -416,9 +414,12 @@ class LookupDecoder:
             net_log_probs[syndrome][obs_flip] = float(
                 np.logaddexp(net_log_probs[syndrome].get(obs_flip, -np.inf), log_prob)
             )
-            if log_prob > most_likely_error_log_probs.get((syndrome, obs_flip), -np.inf):
-                most_likely_error_log_probs[syndrome, obs_flip] = log_prob
-                most_likely_errors[syndrome, obs_flip] = error
+            # Record the first error for each key (so it always has a representative, even when all
+            # of its errors have zero probability), then keep the most likely one thereafter.
+            key = (syndrome, obs_flip)
+            if key not in most_likely_errors or log_prob > most_likely_error_log_probs[key]:
+                most_likely_error_log_probs[key] = log_prob
+                most_likely_errors[key] = error
 
         # Identify the most likely observable_flip for each syndrome, and map the syndrome to the
         # most likely error with that (syndrome, observable_flip) combination.  If a
@@ -433,7 +434,7 @@ class LookupDecoder:
             else:
                 prediction = most_likely_errors[syndrome, most_likely_obs_flip]
             correction = self._maybe_add_erasure_bit(prediction)
-            if confidence_ratio is not None:
+            if confidence_ratio:
                 log_prob_top = obs_flip_to_log_prob[most_likely_obs_flip]
                 other_log_probs = [
                     log_prob
@@ -520,8 +521,9 @@ class LookupDecoder:
     ) -> Callable[[npt.NDArray[np.int_] | Sequence[int]], float]:
         """Construct a penalty function from independent probabilities of individual errors."""
         error_channel = np.asarray(error_channel)
-        log_probs = np.log(error_channel)
-        log_non_probs = np.log(1 - error_channel)
+        with np.errstate(divide="ignore"):  # a probability of 0 or 1 yields a -inf log, which is ok
+            log_probs = np.log(error_channel)
+            log_non_probs = np.log(1 - error_channel)
 
         def penalty_func(error: npt.NDArray[np.int_] | Sequence[int]) -> float:
             """Penalize unlikely combinations of errors."""

--- a/src/qldpc/decoders/custom.py
+++ b/src/qldpc/decoders/custom.py
@@ -239,9 +239,10 @@ class LookupDecoder:
     this decoder maps each syndrome to an error that induces the most likely observable flip for
     that syndrome, which may be different from the single most likely error.  Concretely: errors
     consistent with a given syndrome are grouped by their observable flip value; the total
-    probability of each group is (approximately) the sum of the probabilities of its member errors.
-    This decoder then assings each ``syndrome`` the highest-probability individual ``error`` from
-    the group with the highest total probability.
+    probability of each group is the sum of the probabilities of its member errors, restricted to
+    the errors of weight <= ``max_weight`` that this decoder enumerates.  This decoder then assigns
+    each ``syndrome`` the highest-probability individual ``error`` from the group with the highest
+    total probability.
 
     If initialized with ``predict_observable_flips=True``, this decoder maps each syndrome directly
     to its most likely observable flip, rather than to a representative ``error``.  In this case
@@ -257,6 +258,21 @@ class LookupDecoder:
     If initialized with ``add_erasure_bit=True``, this decoder appends a bit to all decoded errors.
     If asked to decode a syndrome that was not observed when constructing the lookup table, the
     erasure bit is set to 1.  The erasure bit is set to 0 otherwise.
+
+    If initialized with a ``confidence_ratio`` (which requires both an ``observable_flip_matrix``
+    and ``add_erasure_bit=True``), this decoder declares erasure for any syndrome whose most likely
+    observable flip is not "sufficiently more likely" than the alternatives.  Concretely, let
+    ``prob_top`` be the net probability of the most likely observable flip for a syndrome, and let
+    ``prob_rest`` be the net probability of all other observable flips combined -- with both
+    probabilities computed from the enumerated errors of weight <= ``max_weight``, grouped by
+    observable flip as described above.  This decoder declares erasure -- by setting the erasure bit
+    of the decoded output to 1 -- whenever ``prob_top < confidence_ratio * prob_rest``.  The decoded
+    output otherwise retains the most likely observable flip (or its representative error) as a best
+    guess, so a downstream consumer that ignores the erasure bit recovers the default behavior.
+    Setting ``confidence_ratio=0`` (or leaving it as its default of ``None``) recovers the default
+    behavior of always assigning the most likely observable flip; larger values declare erasure more
+    aggressively.  For example, ``confidence_ratio=10`` declares erasure unless the most likely
+    observable flip is at least 10 times as likely as all others combined.
 
     If initialized with ``symplectic=True``, this decoder treats the provided parity check matrix as
     that of a ``QuditCode``, with the first and last half of the columns denoting, respectively, the
@@ -274,6 +290,7 @@ class LookupDecoder:
         predict_observable_flips: bool = False,
         post_select: Collection[int] = (),
         add_erasure_bit: bool = False,
+        confidence_ratio: float | None = None,
         symplectic: bool = False,
     ) -> None:
         pcm, observable_flip_matrix, penalty_func, syndrome_mask, default_correction = (
@@ -292,6 +309,20 @@ class LookupDecoder:
                 "Predicting observable flips with a LookupDecoder requires providing a"
                 " stim.DetectorErrorModel, error_channel, or penalty_func"
             )
+        if confidence_ratio is not None:
+            if confidence_ratio < 0:
+                raise ValueError("A LookupDecoder confidence_ratio must be non-negative")
+            if not add_erasure_bit:
+                raise ValueError(
+                    "Using a confidence_ratio with a LookupDecoder requires add_erasure_bit=True,"
+                    " which provides the erasure bit used to declare erasure"
+                )
+            if observable_flip_matrix is None:
+                raise ValueError(
+                    "Using a confidence_ratio with a LookupDecoder requires grouping errors by"
+                    " observable flip, which requires a stim.DetectorErrorModel with observables or"
+                    " an observable_flip_matrix"
+                )
 
         # save attributes
         self.predict_observable_flips = predict_observable_flips
@@ -303,21 +334,60 @@ class LookupDecoder:
         self.syndrome_to_error: dict[tuple[int, ...], npt.NDArray[np.int_]] = {}
 
         if observable_flip_matrix is None:
-            # Loop over all errors in decreasing weight; assign each syndrome its likeliest error.
-            error_penalty: dict[tuple[int, ...], float] = {}
-            for error, syndrome in LookupDecoder._iter_errors_and_syndromes(
-                pcm, max_weight, syndrome_mask, symplectic
-            ):
-                if penalty_func is None:
-                    self.syndrome_to_error[syndrome] = self._maybe_add_erasure_bit(error)
-                elif (error_weight := penalty_func(error)) <= error_penalty.get(syndrome, np.inf):
-                    error_penalty[syndrome] = error_weight
-                    self.syndrome_to_error[syndrome] = self._maybe_add_erasure_bit(error)
-            return  # we have built the syndrome_to_error map, so we have no more to do!
+            self._build_syndrome_map_from_errors(
+                pcm, max_weight, penalty_func, syndrome_mask, symplectic
+            )
+        else:
+            assert penalty_func is not None  # primarily for type-checking reasons
+            self._build_syndrome_map_from_observable_flips(
+                pcm,
+                max_weight,
+                penalty_func,
+                observable_flip_matrix,
+                predict_observable_flips,
+                syndrome_mask,
+                confidence_ratio,
+                symplectic,
+            )
 
-        # If we got here, we are building a lookup table that maps each syndrome to an error that
-        # induces the most likely observable flips.
-        assert penalty_func is not None  # primarily for type-checking reasons
+    def _build_syndrome_map_from_errors(
+        self,
+        pcm: IntegerArray,
+        max_weight: int,
+        penalty_func: Callable[[npt.NDArray[np.int_] | Sequence[int]], float] | None,
+        syndrome_mask: npt.NDArray[np.bool_] | None,
+        symplectic: bool,
+    ) -> None:
+        """Populate syndrome_to_error, mapping each syndrome to its likeliest error.
+
+        Loops over all errors in decreasing weight, assigning each syndrome its likeliest error.
+        """
+        error_penalty: dict[tuple[int, ...], float] = {}
+        for error, syndrome in LookupDecoder._iter_errors_and_syndromes(
+            pcm, max_weight, syndrome_mask, symplectic
+        ):
+            if penalty_func is None:
+                self.syndrome_to_error[syndrome] = self._maybe_add_erasure_bit(error)
+            elif (error_weight := penalty_func(error)) <= error_penalty.get(syndrome, np.inf):
+                error_penalty[syndrome] = error_weight
+                self.syndrome_to_error[syndrome] = self._maybe_add_erasure_bit(error)
+
+    def _build_syndrome_map_from_observable_flips(
+        self,
+        pcm: IntegerArray,
+        max_weight: int,
+        penalty_func: Callable[[npt.NDArray[np.int_] | Sequence[int]], float],
+        observable_flip_matrix: IntegerArray,
+        predict_observable_flips: bool,
+        syndrome_mask: npt.NDArray[np.bool_] | None,
+        confidence_ratio: float | None,
+        symplectic: bool,
+    ) -> None:
+        """Populate syndrome_to_error, mapping each syndrome to its most likely observable flip.
+
+        Builds a lookup table that maps each syndrome to an error that induces the most likely
+        observable flips (or, if predict_observable_flips, to the observable flips themselves).
+        """
 
         def _get_obs_flip(error: npt.NDArray[np.int_]) -> tuple[int, ...]:
             """Map an error to its induced observable flips."""
@@ -329,32 +399,54 @@ class LookupDecoder:
             return tuple(obs_flip.tolist())
 
         # For each "key" = (syndrome, observable_flip) combination, identify:
-        # 1. The net probability of each key.
+        # 1. The net log-probability of each key.
         # 2. The most likely error for each key.
-        # 3. The probability of the most likely error for each key.
+        # 3. The log-probability of the most likely error for each key.
+        # Probabilities are accumulated in log-space (via logaddexp) to avoid the underflow that
+        # would otherwise arise from summing the tiny probabilities of individual errors.
         Bitstring = tuple[int, ...]
-        net_probs: dict[Bitstring, dict[Bitstring, float]] = collections.defaultdict(dict)
+        net_log_probs: dict[Bitstring, dict[Bitstring, float]] = collections.defaultdict(dict)
         most_likely_errors: dict[tuple[Bitstring, Bitstring], npt.NDArray[np.int_]] = {}
-        most_likely_error_probs: dict[tuple[Bitstring, Bitstring], float] = {}
+        most_likely_error_log_probs: dict[tuple[Bitstring, Bitstring], float] = {}
         for error, syndrome in LookupDecoder._iter_errors_and_syndromes(
             pcm, max_weight, syndrome_mask, symplectic
         ):
             obs_flip = _get_obs_flip(error)
-            prob = np.exp(-penalty_func(error))
-            net_probs[syndrome][obs_flip] = net_probs[syndrome].get(obs_flip, 0.0) + prob
-            if prob > most_likely_error_probs.get((syndrome, obs_flip), 0.0):
-                most_likely_error_probs[syndrome, obs_flip] = prob
+            log_prob = -penalty_func(error)
+            net_log_probs[syndrome][obs_flip] = float(
+                np.logaddexp(net_log_probs[syndrome].get(obs_flip, -np.inf), log_prob)
+            )
+            if log_prob > most_likely_error_log_probs.get((syndrome, obs_flip), -np.inf):
+                most_likely_error_log_probs[syndrome, obs_flip] = log_prob
                 most_likely_errors[syndrome, obs_flip] = error
 
         # Identify the most likely observable_flip for each syndrome, and map the syndrome to the
-        # most likely error with that (syndrome, observable_flip) combination.
-        for syndrome, obs_flip_to_net_prob in net_probs.items():
-            most_likely_obs_flip = max(obs_flip_to_net_prob, key=obs_flip_to_net_prob.__getitem__)
+        # most likely error with that (syndrome, observable_flip) combination.  If a
+        # confidence_ratio is set, we instead declare erasure (flip the erasure bit) for any
+        # syndrome whose most likely observable flip is not confidence_ratio times as likely as the
+        # rest.
+        log_confidence_ratio = float(np.log(confidence_ratio)) if confidence_ratio else -np.inf
+        for syndrome, obs_flip_to_log_prob in net_log_probs.items():
+            most_likely_obs_flip = max(obs_flip_to_log_prob, key=obs_flip_to_log_prob.__getitem__)
             if predict_observable_flips:
                 prediction = np.asarray(most_likely_obs_flip, dtype=pcm.dtype)
             else:
                 prediction = most_likely_errors[syndrome, most_likely_obs_flip]
-            self.syndrome_to_error[syndrome] = self._maybe_add_erasure_bit(prediction)
+            correction = self._maybe_add_erasure_bit(prediction)
+            if confidence_ratio is not None:
+                log_prob_top = obs_flip_to_log_prob[most_likely_obs_flip]
+                other_log_probs = [
+                    log_prob
+                    for obs_flip, log_prob in obs_flip_to_log_prob.items()
+                    if obs_flip != most_likely_obs_flip
+                ]
+                log_prob_rest = (
+                    float(np.logaddexp.reduce(other_log_probs)) if other_log_probs else -np.inf
+                )
+                # confident iff prob_top >= confidence_ratio * prob_rest (compared in log-space)
+                if log_prob_top < log_confidence_ratio + log_prob_rest:
+                    correction[-1] = 1  # declare erasure
+            self.syndrome_to_error[syndrome] = correction
 
     @staticmethod
     def _organize_lookup_table_initialization_data(

--- a/src/qldpc/decoders/custom_test.py
+++ b/src/qldpc/decoders/custom_test.py
@@ -24,7 +24,6 @@ import unittest.mock
 
 import galois
 import numpy as np
-import numpy.typing as npt
 import pytest
 import scipy.sparse
 import stim
@@ -185,24 +184,26 @@ def test_observable_lookup_decoding() -> None:
 
 
 def test_confidence_ratio() -> None:
-    """A confidence_ratio declares erasure when no observable flip is clearly most likely."""
-    # a positive confidence_ratio must be a non-negative number, with an erasure bit and obs flips
+    """A confidence_ratio omits ambiguous syndromes so they decode to erasure."""
     pcm = np.eye(1, dtype=int)
+
+    # a confidence_ratio must be a non-negative number
     with pytest.raises(ValueError, match="non-negative"):
-        decoders.LookupDecoder(
-            pcm, 1, error_channel=[0.1], add_erasure_bit=True, confidence_ratio=-1
-        )
+        decoders.LookupDecoder(pcm, 1, error_channel=[0.1], confidence_ratio=-1)
     with pytest.raises(ValueError, match="non-negative"):
         decoders.LookupDecoder(pcm, 1, error_channel=[0.1], confidence_ratio=float("nan"))
-    with pytest.raises(ValueError, match="requires add_erasure_bit"):
-        decoders.LookupDecoder(pcm, 1, error_channel=[0.1], confidence_ratio=2)
-    with pytest.raises(ValueError, match="observable flip"):
+    # a positive confidence_ratio signals erasure, so it conflicts with add_erasure_bit=False
+    with pytest.raises(ValueError, match="add_erasure_bit=False"):
         decoders.LookupDecoder(
-            pcm, 1, error_channel=[0.1], add_erasure_bit=True, confidence_ratio=2
+            pcm, 1, error_channel=[0.1], add_erasure_bit=False, confidence_ratio=2
         )
+    # ... and it requires grouping errors by observable flip
+    with pytest.raises(ValueError, match="observable flip"):
+        decoders.LookupDecoder(pcm, 1, error_channel=[0.1], confidence_ratio=2)
 
     # confidence_ratio=0 is a requirement-free no-op: it needs neither an erasure bit nor obs flips
     decoder = decoders.LookupDecoder(pcm, 1, error_channel=[0.1], confidence_ratio=0)
+    assert not decoder.has_erasure_bit
     assert np.array_equal(decoder.decode(np.array([1], dtype=int)), [1])
 
     # a zero-probability error mechanism does not crash a syndrome that only it can explain: here
@@ -225,26 +226,27 @@ def test_confidence_ratio() -> None:
         error(0.10) D0 L0
         error(0.25) D1 L0
     """)
+    syndrome = np.array([1, 1], dtype=int)
 
-    def decode(confidence_ratio: float) -> npt.NDArray[np.int_]:
-        decoder = decoders.LookupDecoder(
-            dem,
-            max_weight=2,
-            predict_observable_flips=True,
-            add_erasure_bit=True,
-            confidence_ratio=confidence_ratio,
-        )
-        return decoder.decode(np.array([1, 1], dtype=int))
+    # confidence_ratio=0 assigns the most likely flip (obs_flip=1) and adds no erasure bit
+    decoder = decoders.LookupDecoder(
+        dem, max_weight=2, predict_observable_flips=True, confidence_ratio=0
+    )
+    assert np.array_equal(decoder.decode(syndrome), [1])
 
-    # confidence_ratio=0 (the graceful limit) assigns the most likely flip with no erasure; a ratio
-    # above the ~1.067 threshold instead declares erasure, keeping the most likely flip as a guess
-    assert np.array_equal(decode(0), [1, 0])
-    assert np.array_equal(decode(1.5), [1, 1])
+    # a confidence_ratio above the ~1.067 threshold omits the syndrome and auto-enables the erasure
+    # bit, so the syndrome decodes to erasure: an all-zero flip with the erasure bit set
+    decoder = decoders.LookupDecoder(
+        dem, max_weight=2, predict_observable_flips=True, confidence_ratio=1.5
+    )
+    assert decoder.has_erasure_bit
+    assert np.array_equal(decoder.decode(syndrome), [0, 1])
 
-    # a syndrome with a single consistent observable flip is always confident, never erased
+    # a syndrome with a single consistent observable flip is always confident, so it is kept and
+    # decodes to that flip with the auto-enabled erasure bit left clear
     dem = stim.DetectorErrorModel("error(0.1) D0 L0")
     decoder = decoders.LookupDecoder(
-        dem, max_weight=1, predict_observable_flips=True, add_erasure_bit=True, confidence_ratio=1e6
+        dem, max_weight=1, predict_observable_flips=True, confidence_ratio=1e6
     )
     assert np.array_equal(decoder.decode(np.array([1], dtype=int)), [1, 0])
 

--- a/src/qldpc/decoders/custom_test.py
+++ b/src/qldpc/decoders/custom_test.py
@@ -179,21 +179,42 @@ def test_observable_lookup_decoding() -> None:
     weighted = decoders.WeightedLookupDecoder(dem, max_weight=2, post_select=[0])
     assert np.array_equal(obs_matrix @ weighted.decode(np.array([0, 1], dtype=int)), [0])  # E2: D1
 
+    # grouping errors by observable flip requires a way to weigh errors against each other
+    with pytest.raises(ValueError, match="error_channel, or penalty_func"):
+        decoders.LookupDecoder(pcm, max_weight=2, observable_flip_matrix=obs_matrix)
+
 
 def test_confidence_ratio() -> None:
     """A confidence_ratio declares erasure when no observable flip is clearly most likely."""
-    # a confidence_ratio requires a non-negative value, an erasure bit, and observable flips
+    # a positive confidence_ratio must be a non-negative number, with an erasure bit and obs flips
     pcm = np.eye(1, dtype=int)
     with pytest.raises(ValueError, match="non-negative"):
         decoders.LookupDecoder(
             pcm, 1, error_channel=[0.1], add_erasure_bit=True, confidence_ratio=-1
         )
+    with pytest.raises(ValueError, match="non-negative"):
+        decoders.LookupDecoder(pcm, 1, error_channel=[0.1], confidence_ratio=float("nan"))
     with pytest.raises(ValueError, match="requires add_erasure_bit"):
         decoders.LookupDecoder(pcm, 1, error_channel=[0.1], confidence_ratio=2)
     with pytest.raises(ValueError, match="observable flip"):
         decoders.LookupDecoder(
             pcm, 1, error_channel=[0.1], add_erasure_bit=True, confidence_ratio=2
         )
+
+    # confidence_ratio=0 is a requirement-free no-op: it needs neither an erasure bit nor obs flips
+    decoder = decoders.LookupDecoder(pcm, 1, error_channel=[0.1], confidence_ratio=0)
+    assert np.array_equal(decoder.decode(np.array([1], dtype=int)), [1])
+
+    # a zero-probability error mechanism does not crash a syndrome that only it can explain: here
+    # syndrome (1, 0) is reachable only via the probability-0 mechanism, so its group has no
+    # finite-probability representative, but the decoder still returns that mechanism's error
+    decoder = decoders.LookupDecoder(
+        np.array([[1, 0], [0, 1]], dtype=int),
+        max_weight=1,
+        error_channel=[0.0, 0.1],
+        observable_flip_matrix=np.array([[1, 0]], dtype=int),
+    )
+    assert np.array_equal(decoder.decode(np.array([1, 0], dtype=int)), [1, 0])
 
     # In this DEM, syndrome (1, 1)'s most likely observable flip (obs_flip=1) is only ~1.067 times
     # as likely as the alternative; see test_observable_lookup_decoding for the enumeration.

--- a/src/qldpc/decoders/custom_test.py
+++ b/src/qldpc/decoders/custom_test.py
@@ -24,6 +24,7 @@ import unittest.mock
 
 import galois
 import numpy as np
+import numpy.typing as npt
 import pytest
 import scipy.sparse
 import stim
@@ -177,6 +178,54 @@ def test_observable_lookup_decoding() -> None:
     assert np.array_equal(obs_matrix @ decoder.decode(np.array([0, 1], dtype=int)), [1])  # E4
     weighted = decoders.WeightedLookupDecoder(dem, max_weight=2, post_select=[0])
     assert np.array_equal(obs_matrix @ weighted.decode(np.array([0, 1], dtype=int)), [0])  # E2: D1
+
+
+def test_confidence_ratio() -> None:
+    """A confidence_ratio declares erasure when no observable flip is clearly most likely."""
+    # a confidence_ratio requires a non-negative value, an erasure bit, and observable flips
+    pcm = np.eye(1, dtype=int)
+    with pytest.raises(ValueError, match="non-negative"):
+        decoders.LookupDecoder(
+            pcm, 1, error_channel=[0.1], add_erasure_bit=True, confidence_ratio=-1
+        )
+    with pytest.raises(ValueError, match="requires add_erasure_bit"):
+        decoders.LookupDecoder(pcm, 1, error_channel=[0.1], confidence_ratio=2)
+    with pytest.raises(ValueError, match="observable flip"):
+        decoders.LookupDecoder(
+            pcm, 1, error_channel=[0.1], add_erasure_bit=True, confidence_ratio=2
+        )
+
+    # In this DEM, syndrome (1, 1)'s most likely observable flip (obs_flip=1) is only ~1.067 times
+    # as likely as the alternative; see test_observable_lookup_decoding for the enumeration.
+    dem = stim.DetectorErrorModel("""
+        error(0.04) D0 D1
+        error(0.25) D0
+        error(0.10) D1
+        error(0.10) D0 L0
+        error(0.25) D1 L0
+    """)
+
+    def decode(confidence_ratio: float) -> npt.NDArray[np.int_]:
+        decoder = decoders.LookupDecoder(
+            dem,
+            max_weight=2,
+            predict_observable_flips=True,
+            add_erasure_bit=True,
+            confidence_ratio=confidence_ratio,
+        )
+        return decoder.decode(np.array([1, 1], dtype=int))
+
+    # confidence_ratio=0 (the graceful limit) assigns the most likely flip with no erasure; a ratio
+    # above the ~1.067 threshold instead declares erasure, keeping the most likely flip as a guess
+    assert np.array_equal(decode(0), [1, 0])
+    assert np.array_equal(decode(1.5), [1, 1])
+
+    # a syndrome with a single consistent observable flip is always confident, never erased
+    dem = stim.DetectorErrorModel("error(0.1) D0 L0")
+    decoder = decoders.LookupDecoder(
+        dem, max_weight=1, predict_observable_flips=True, add_erasure_bit=True, confidence_ratio=1e6
+    )
+    assert np.array_equal(decoder.decode(np.array([1], dtype=int)), [1, 0])
 
 
 def test_ilp_decoder() -> None:


### PR DESCRIPTION
## AI-assisted summary

This PR lets `LookupDecoder` decline to commit to a logical prediction when a syndrome is ambiguous, rather than always guessing the single most likely observable flip.

**Behavior.** When a syndrome is consistent with more than one observable flip, the decoder groups the candidate errors (of weight ≤ `max_weight`) by the observable flip they induce and gives each group a net probability. With a positive `confidence_ratio`, the decoder assigns an ambiguous syndrome the most likely flip **iff** that flip is at least `confidence_ratio` times as likely as all the other flips combined — i.e. `prob_top >= confidence_ratio * prob_rest`. Otherwise, the syndrome is omitted from the lookup table, so it decodes to erasure.

A positive ``confidence_ratio`` therefore auto-enables the erasure bit, setting ``add_erasure_bit=True``.  At the extreme, ``confidence_ratio=np.inf`` keeps only syndromes with a single consistent observable flip, erasing every syndrome that has any competing flip.

**Implementation notes.**
- Group probabilities are now accumulated in log-space (`logaddexp`) to avoid underflow when summing the tiny probabilities of individual errors.
- Lookup-table construction was factored into two helper methods (`_build_syndrome_map_from_errors` / `_build_syndrome_map_from_observable_flips`).
- Fixes a latent `KeyError` for syndromes whose only consistent errors have zero probability, and rejects negative/`NaN` ratios.