### PR TITLE
Consolidate SymPy polynomial handling into a single helper

### DIFF
--- a/src/qldpc/abstract/__init__.py
+++ b/src/qldpc/abstract/__init__.py
@@ -14,6 +14,7 @@ from .groups import (
     SymmetricGroup,
     TrivialGroup,
     get_coefficient_and_exponents,
+    iter_monomial_terms,
     resolve_field,
 )
 from .linalg import (
@@ -60,6 +61,7 @@ __all__ = [
     "block_diag",
     "get_coefficient_and_exponents",
     "get_howell_dual",
+    "iter_monomial_terms",
     "kron",
     "matmul",
     "resolve_field",

--- a/src/qldpc/abstract/groups.py
+++ b/src/qldpc/abstract/groups.py
@@ -965,6 +965,19 @@ PSL = ProjectiveSpecialLinearGroup
 # miscellaneous helper methods that don't quite belong in qldpc.math
 
 
+def iter_monomial_terms(polynomial: sympy.Basic | int | np.int_) -> tuple[sympy.Expr, ...]:
+    """Split a SymPy polynomial into its monomial terms, distributing any products of sums.
+
+    Accepts a sympy.Expr, a sympy.Poly, or a (Python or NumPy) integer, and always returns a tuple
+    of single-term monomials.  For example, (1 + x) * (1 + y) becomes (1, x, y, x*y), while a lone
+    monomial or constant such as 2 * x or 5 becomes a one-element tuple.
+    """
+    if isinstance(polynomial, sympy.Poly):
+        polynomial = polynomial.as_expr()
+    # sympify integers into SymPy objects, then expand so that make_args sees a sum of monomials
+    return sympy.Add.make_args(sympy.sympify(polynomial).expand())
+
+
 def get_coefficient_and_exponents(
     monomial: sympy.Integer | sympy.Symbol | sympy.Pow | sympy.Mul | int | np.int_,
 ) -> tuple[int, list[tuple[sympy.Symbol, int]]]:

--- a/src/qldpc/abstract/groups_test.py
+++ b/src/qldpc/abstract/groups_test.py
@@ -296,3 +296,19 @@ def test_sympy_parsing() -> None:
     assert abstract.get_coefficient_and_exponents(x) == (1, [(x, 1)])
     assert abstract.get_coefficient_and_exponents(x**2) == (1, [(x, 2)])
     assert abstract.get_coefficient_and_exponents(3 * x * y**2) == (3, [(x, 1), (y, 2)])
+
+
+def test_iter_monomial_terms() -> None:
+    """Split SymPy polynomials into their monomial terms, distributing products of sums."""
+    x = sympy.abc.x
+    y = sympy.abc.y
+
+    # a sum, a product of sums, a lone monomial, a bare integer, and zero
+    assert set(abstract.iter_monomial_terms(x**2 + y)) == {x**2, y}
+    assert set(abstract.iter_monomial_terms((1 + x) * (1 + y))) == {sympy.Integer(1), x, y, x * y}
+    assert abstract.iter_monomial_terms(2 * x * y) == (2 * x * y,)
+    assert abstract.iter_monomial_terms(5) == (sympy.Integer(5),)
+    assert abstract.iter_monomial_terms(0) == (sympy.Integer(0),)
+
+    # a sympy.Poly is accepted and treated the same as its expression
+    assert set(abstract.iter_monomial_terms(sympy.Poly(x**2 + y, x, y))) == {x**2, y}

--- a/src/qldpc/abstract/rings.py
+++ b/src/qldpc/abstract/rings.py
@@ -42,7 +42,15 @@ from typing_extensions import Self
 import qldpc
 from qldpc import external
 
-from .groups import AbelianGroup, CyclicGroup, Group, GroupMember, TrivialGroup, resolve_field
+from .groups import (
+    AbelianGroup,
+    CyclicGroup,
+    Group,
+    GroupMember,
+    TrivialGroup,
+    iter_monomial_terms,
+    resolve_field,
+)
 
 if TYPE_CHECKING:
     from .wedderburn_artin import WedderburnArtinTransformer
@@ -200,36 +208,22 @@ class GroupRing:
         self, expression: sympy.Basic | int | np.int_, symbols: dict[sympy.Symbol, GroupMember]
     ) -> RingMember:
         """Convert a SymPy expression (such as a polynomial) into a member of this ring."""
-        if isinstance(expression, sympy.Expr):
-            # distribute products of sums, such as (1 + x) * (1 + y), into a sum of monomials
-            expression = expression.expand()
-
-        if isinstance(expression, (sympy.Poly, sympy.Add)):
-            # evaluate the (now-expanded) polynomial one monomial term at a time
-            terms = sympy.Add.make_args(expression.as_expr())
-            evaluated_terms = (self._eval_monomial(term, symbols) for term in terms)
-            return functools.reduce(operator.add, evaluated_terms)
-
-        return self._eval_monomial(expression, symbols)
-
-    def _eval_monomial(
-        self, expression: sympy.Basic | int | np.int_, symbols: dict[sympy.Symbol, GroupMember]
-    ) -> RingMember:
-        """Convert a single SymPy monomial into a member of this ring."""
         # helpful error message for invalid symbols
         if any(not isinstance(value, GroupMember) for value in symbols.values()):
             raise ValueError("The symbols passed to Ring.eval must be GroupMember-valued")
 
-        # if applicable, convert python integers into SymPy integers
-        if isinstance(expression, (int, np.int_)):
-            expression = sympy.Integer(expression)
+        # sum the ring members obtained by evaluating each monomial term of the polynomial
+        terms = (self._eval_monomial(term, symbols) for term in iter_monomial_terms(expression))
+        return functools.reduce(operator.add, terms, self.zero)
 
-        # factor this term into its coefficient and variable content
-        _coeff, monomial = expression.as_coeff_Mul()
+    def _eval_monomial(
+        self, monomial: sympy.Expr, symbols: dict[sympy.Symbol, GroupMember]
+    ) -> RingMember:
+        """Convert a single SymPy monomial into a member of this ring."""
+        # split the monomial into its integer coefficient and its group-element content
+        _coeff, group_content = monomial.as_coeff_Mul()
         coeff = self._eval_int(int(_coeff))
-
-        # construct and return a member of this ring
-        group_member = self.group.eval(monomial, symbols)
+        group_member = self.group.eval(group_content, symbols)
         return RingMember(self, (coeff, group_member))
 
     def _eval_int(self, value: int) -> galois.FieldArray:

--- a/src/qldpc/codes/quantum.py
+++ b/src/qldpc/codes/quantum.py
@@ -506,24 +506,24 @@ class QCCode(TBCode):
         )
 
     def get_canonical_form(
-        self, poly: sympy.Poly, orders: tuple[int, ...] | None = None
-    ) -> tuple[sympy.Poly, sympy.Poly]:
+        self, poly: sympy.Basic, orders: tuple[int, ...] | None = None
+    ) -> sympy.Expr:
         """Canonicalize the given polynomial, shifting exponents to (-order/2, order/2]."""
         orders = orders or self.orders
         assert len(orders) == len(self.symbols)
 
-        # canonialize and add one term ata time
-        new_poly = sympy.core.numbers.Zero()
-        for term in poly.args:
+        # canonicalize and add one monomial term at a time
+        new_poly: sympy.Expr = sympy.Integer(0)
+        for term in abstract.iter_monomial_terms(poly):
             coeff, _exponents = abstract.get_coefficient_and_exponents(term)
             exponents = dict(_exponents)  # convert into a dictionary, {symbol: exponent}
 
-            new_term = sympy.core.numbers.One()
+            new_term = sympy.Integer(coeff)
             for symbol, order in zip(self.symbols, orders):
                 new_exponent = exponents.get(symbol, 0) % order
                 if new_exponent > order / 2:
                     new_exponent -= order
-                new_term *= coeff * symbol**new_exponent
+                new_term *= symbol**new_exponent
 
             new_poly += new_term
 
@@ -561,8 +561,8 @@ class QCCode(TBCode):
         )
 
         # build matrices for each term in A and B
-        terms_a = sympy.Add.make_args(self.poly_a.as_expr())
-        terms_b = sympy.Add.make_args(self.poly_b.as_expr())
+        terms_a = abstract.iter_monomial_terms(self.poly_a)
+        terms_b = abstract.iter_monomial_terms(self.poly_b)
         matrices_a = [self.ring.eval(term, self.symbol_gens).lift().T for term in terms_a]
         matrices_b = [self.ring.eval(term, self.symbol_gens).lift().T for term in terms_b]
 
@@ -773,8 +773,8 @@ class BBCode(QCCode):
             return []
 
         # identify individual monomials (terms without their coefficients) in the polynomials
-        monomials_a = [term.as_coeff_Mul()[1] for term in self.poly_a.as_expr().args]
-        monomials_b = [term.as_coeff_Mul()[1] for term in self.poly_b.as_expr().args]
+        monomials_a = [term.as_coeff_Mul()[1] for term in abstract.iter_monomial_terms(self.poly_a)]
+        monomials_b = [term.as_coeff_Mul()[1] for term in abstract.iter_monomial_terms(self.poly_b)]
 
         # identify collections of monomials that can be combined to obtain a toric layout
         toric_params = []


### PR DESCRIPTION
Several places independently split a SymPy polynomial into its monomial terms, and most did so incorrectly: they iterated `.args` / `make_args` without expanding, so products of sums, single-term polynomials, and raw `Poly` objects (whose `.args` also include the generators) were mishandled.

This PR adds `abstract.iter_monomial_terms`, which expands products of sums and returns the monomials of any Expr / Poly / integer uniformly, and route all call sites through it: `GroupRing.eval`, `BBCode.get_canonical_form`, `get_syndrome_subgraphs`, and `get_equivalent_toric_layout_code_data`.

This GR also fixes bugs in `get_canonical_form`: the coefficient was multiplied once per symbol (coeff**num_symbols, wrong for non-binary fields), a `Poly` argument leaked its generators as spurious terms, and the return annotation claimed a tuple while a single expression was returned.