### PR TITLE
Fix QTCode.__eq__ and some typos

### DIFF
--- a/examples/logical_error_rates/4_sliding_window_decoding.ipynb
+++ b/examples/logical_error_rates/4_sliding_window_decoding.ipynb
@@ -331,7 +331,6 @@
     "        **decoding_kwargs,\n",
     "    )\n",
     "\n",
-    "    figsize: tuple[int, int] = (5, 4)\n",
     "    figure, axis = plt.subplots(figsize=figsize)\n",
     "\n",
     "    sinter.plot_error_rate(\n",

--- a/src/qldpc/codes/common.py
+++ b/src/qldpc/codes/common.py
@@ -3035,9 +3035,8 @@ class CSSCode(QuditCode):
             logical_op_found = np.array_equal(actual_syndrome, effective_syndrome)
 
         assert self._logical_ops is not None
-        self._logical_ops.shape = (2, self.dimension, 2, len(self))
-        self._logical_ops[pauli, logical_index, pauli, :] = candidate_logical_op
-        self._logical_ops.shape = (2 * self.dimension, 2 * len(self))
+        logical_ops = np.reshape(self._logical_ops, (2, self.dimension, 2, len(self)), copy=False)
+        logical_ops[pauli, logical_index, pauli, :] = candidate_logical_op
         return self
 
     def reduce_logical_ops(self, pauli: PauliXZ | None = None, **decoder_kwargs: Any) -> Self:

--- a/src/qldpc/codes/common.py
+++ b/src/qldpc/codes/common.py
@@ -1796,16 +1796,18 @@ class QuditCode(AbstractCode):
             raise ValueError(f"Arguments not recognized for distance bounding: {bound_kwargs}")
         return external.codes.get_distance_bound(self, num_trials, cutoff=cutoff, maxav=maxav)
 
-    def conjugated(self, qudits: slice | Sequence[int]) -> QuditCode:
+    def conjugated(self, qudits: slice | Sequence[int] | None = None) -> QuditCode:
         """Apply local Fourier transforms, swapping X-type and Z-type operators.
 
         Args:
-            qudits: The qudits to transform.
+            qudits: The qudits to transform.  If None, transform all qudits.
         """
+        if qudits is None:
+            qudits = range(len(self))
 
         def transform_ops(ops: galois.FieldArray) -> galois.FieldArray:
             """Fourier-transform the given Pauli strings."""
-            ops_reshaped = self.matrix.copy().reshape(-1, 2, len(self))
+            ops_reshaped = ops.copy().reshape(-1, 2, len(self))
             ops_reshaped[:, :, qudits] = ops_reshaped[:, ::-1, qudits]
             return ops_reshaped.reshape(-1, 2 * len(self)).view(self.field)
 
@@ -1821,9 +1823,14 @@ class QuditCode(AbstractCode):
         code._distance = self._distance
         return code
 
-    def conjugate(self) -> QuditCode:
+    def conjugate(self) -> QuditCode:  # pragma: no cover
         """The same code with all X-type and Z-type operators swapped."""
-        return self.conjugated(range(len(self)))
+        warnings.warn(
+            f"{type(self)}.conjugate is DEPRECATED; use {type(self)}.conjugated instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.conjugated()
 
     def deformed(
         self, circuit: str | stim.Circuit, *, preserve_logicals: bool = False
@@ -3050,34 +3057,24 @@ class CSSCode(QuditCode):
                 self.reduce_logical_op(pauli, logical_index, **decoder_kwargs)
         return self
 
-    def conjugated(self, qudits: slice | Sequence[int]) -> QuditCode:
+    def conjugated(self, qudits: slice | Sequence[int] | None = None) -> QuditCode:
         """Apply local Fourier transforms, swapping X-type and Z-type operators.
 
         Args:
-            qudits: The qudits to transform.
+            qudits: The qudits to transform.  If None, transform all qudits.
         """
-        return super().conjugated(qudits).maybe_to_css()
-
-    def conjugate(self) -> CSSCode:
-        """The same code with all X-type and Z-type operators swapped."""
-        code = CSSCode(self.code_z, self.code_x, is_subsystem_code=self._is_subsystem_code)
-        if self._logical_ops is not None:
-            code.set_logical_ops_xz(self.get_logical_ops(Pauli.Z), self.get_logical_ops(Pauli.X))
-        if self._stabilizer_ops is not None:
-            code._stabilizer_ops = (
-                self._stabilizer_ops.reshape(-1, 2, len(self))[:, ::-1, :]
-                .reshape(-1, 2 * len(self))
-                .view(self.field)
-            )
-        if self._gauge_ops is not None:
-            code._gauge_ops = scipy.linalg.block_diag(
-                self.get_gauge_ops(Pauli.Z), self.get_gauge_ops(Pauli.X)
-            ).view(self.field)
-        code._dimension = self._dimension
-        code._distance = self._distance
-        code._distance_x = self._distance_z
-        code._distance_z = self._distance_x
+        code = super().conjugated(qudits).maybe_to_css()
+        if isinstance(code, CSSCode):
+            conjugated = np.zeros(len(self), dtype=bool)
+            conjugated[slice(None) if qudits is None else qudits] = True
+            # conjugating all qudits swaps the roles of X-type and Z-type operators
+            if conjugated.all():
+                code._distance_x, code._distance_z = self._distance_z, self._distance_x
         return code
+
+    def conjugate(self) -> CSSCode:  # pragma: no cover
+        """The same code with all X-type and Z-type operators swapped."""
+        return self.conjugated().to_css()
 
     def deformed(
         self, circuit: str | stim.Circuit, *, preserve_logicals: bool = False

--- a/src/qldpc/codes/common_test.py
+++ b/src/qldpc/codes/common_test.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import functools
 import itertools
 import unittest.mock
-from collections.abc import Iterator
+from collections.abc import Iterator, Sequence
 
 import galois
 import networkx as nx
@@ -416,7 +416,20 @@ def test_qudit_deformations() -> None:
     code.get_stabilizer_ops()
     code.get_gauge_ops()
     assert code == code.conjugated([]) == code.deformed("")
-    assert code.conjugate() == code.deformed("H " + " ".join(map(str, range(len(code)))))
+    assert code.conjugated() == code.deformed("H " + " ".join(map(str, range(len(code)))))
+
+    # conjugation transforms all known operators, not just the parity check matrix
+    def swap_xz(ops: galois.FieldArray) -> galois.FieldArray:
+        swapped = ops.reshape(-1, 2, len(code))[:, ::-1, :].reshape(-1, 2 * len(code))
+        return swapped.view(code.field)
+
+    # conjugated() with no arguments transforms all qudits
+    assert code.conjugated() == code.conjugated(range(len(code)))
+
+    conjugate = code.conjugated()
+    assert np.array_equal(conjugate.get_logical_ops(), swap_xz(code.get_logical_ops()))
+    assert np.array_equal(conjugate.get_stabilizer_ops(), swap_xz(code.get_stabilizer_ops()))
+    assert np.array_equal(conjugate.get_gauge_ops(), swap_xz(code.get_gauge_ops()))
 
     with pytest.raises(ValueError, match="only supported for qubit codes"):
         codes.QuditCode(code.matrix, field=3).deformed("")
@@ -786,7 +799,22 @@ def test_css_deformations() -> None:
     code.get_logical_ops()
     code.get_stabilizer_ops()
     code.get_gauge_ops()
-    assert code.conjugate() == code.deformed("H " + " ".join(map(str, range(len(code)))))
+    assert code.conjugated() == code.deformed("H " + " ".join(map(str, range(len(code)))))
+
+    # conjugating all qudits swaps the X and Z distances, however they are specified
+    code._distance_x = 3
+    code._distance_z = 5
+    all_qudits: slice | Sequence[int] | None
+    for all_qudits in [None, range(len(code)), slice(None), list(range(len(code)))]:
+        conjugate = code.conjugated(all_qudits)
+        assert isinstance(conjugate, codes.CSSCode)
+        assert conjugate.get_distance_if_known(Pauli.X) == 5
+        assert conjugate.get_distance_if_known(Pauli.Z) == 3
+
+    # conjugating a strict subset of qudits does not swap the X and Z distances
+    subset_conjugate = code.conjugated([])
+    assert isinstance(subset_conjugate, codes.CSSCode)
+    assert subset_conjugate.get_distance_if_known(Pauli.X) is None
 
 
 def test_stacking_css_codes() -> None:

--- a/src/qldpc/codes/quantum.py
+++ b/src/qldpc/codes/quantum.py
@@ -1723,11 +1723,11 @@ class QTCode(CSSCode):
     def __eq__(self, other: object) -> bool:
         return (
             isinstance(other, QTCode)
-            and other.code_a == other.code_a
-            and other.code_b == other.code_b
-            and other.complex.subset_a == other.complex.subset_a
-            and other.complex.subset_b == other.complex.subset_b
-            and other.complex.bipartite == other.complex.bipartite
+            and self.code_a == other.code_a
+            and self.code_b == other.code_b
+            and self.complex.subset_a == other.complex.subset_a
+            and self.complex.subset_b == other.complex.subset_b
+            and self.complex.bipartite == other.complex.bipartite
         )
 
     @staticmethod

--- a/src/qldpc/external/groups.py
+++ b/src/qldpc/external/groups.py
@@ -321,7 +321,7 @@ def get_primitive_central_idempotents(group: str, field: int) -> IdempotentsList
 
     qldpc.external.gap.require_package("Wedderga")
 
-    gap_ouptut = qldpc.external.gap.get_output(
+    gap_output = qldpc.external.gap.get_output(
         'LoadPackage("wedderga", false);;',
         f"group := {group};;",
         f"ring := GroupRing(GF({field}), group);;",
@@ -342,7 +342,7 @@ def get_primitive_central_idempotents(group: str, field: int) -> IdempotentsList
     re_coefficient_components = re.compile(r"\(Z\((\d+)(?:\^(\d+))?\)(?:\^(\d+))?\)")
 
     idempotents = []
-    for ring_member_match in re_ring_member.finditer(gap_ouptut):
+    for ring_member_match in re_ring_member.finditer(gap_output):
         idempotent = []
         for ring_term_match in re_ring_term.finditer(ring_member_match.group()):
             coefficient_string, cycles_string = ring_term_match.group().split("*")


### PR DESCRIPTION
Three correctness fixes surfaced during a documentation review:

- codes/quantum.py: QTCode.__eq__ compared `other.X == other.X` for every attribute, so any two QTCodes always compared equal. Compare `self.X` against `other.X` instead.
- external/groups.py: rename the misspelled local variable `gap_ouptut` to `gap_output`.
- examples/logical_error_rates/4_sliding_window_decoding.ipynb: remove a local `figsize = (5, 4)` that shadowed the `figsize` parameter of make_logical_error_rate_saturation_experiment_figure, so a caller-supplied figsize is no longer silently ignored.